### PR TITLE
CM2DM robustness

### DIFF
--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -142,7 +142,7 @@ static bool process_reset_req(struct bh_chip *chip, uint8_t msg_id, uint32_t msg
 	switch (msg_data) {
 	case 0x0:
 		chip->data.last_cm2dm_seq_num_valid = false;
-		jtag_bootrom_reset_sequence(chip, true);
+		bh_chip_reset_chip(chip, true);
 		break;
 
 	case 0x3:

--- a/include/tenstorrent/bh_chip.h
+++ b/include/tenstorrent/bh_chip.h
@@ -86,6 +86,8 @@ struct bh_chip_data {
 
 	uint8_t last_cm2dm_seq_num;
 	bool last_cm2dm_seq_num_valid;
+
+	uint32_t cm2dm_suspicion;
 };
 
 struct bh_chip {

--- a/include/tenstorrent/bh_chip.h
+++ b/include/tenstorrent/bh_chip.h
@@ -83,6 +83,9 @@ struct bh_chip_data {
 	uint8_t fan_speed;
 	/* Is that a forced or automatic fan speed? */
 	bool fan_speed_forced;
+
+	uint8_t last_cm2dm_seq_num;
+	bool last_cm2dm_seq_num_valid;
 };
 
 struct bh_chip {

--- a/lib/tenstorrent/bh_chip/bh_chip.c
+++ b/lib/tenstorrent/bh_chip/bh_chip.c
@@ -51,6 +51,11 @@ cm2dmMessageRet bh_chip_get_cm2dm_message(struct bh_chip *chip)
 							     CMFW_SMBUS_ACK, wire_ack.val);
 	}
 
+	if (output.ret != 0 || (output.msg.msg_id != kCm2DmMsgIdNull && output.ack_ret != 0)) {
+		LOG_WRN("CM2DM SMBus communication failed. req: %d ack: %d", output.ret,
+			output.ack_ret);
+	}
+
 	return output;
 }
 


### PR DESCRIPTION
- DMC should detect back-to-back same sequence ID, not process repeat messages (must attempt to ack though)
- DMC should process all outstanding messages (up to message ID count)
- DMC should detect request failures
- DMC should detect ACK failures
