### PR TITLE
scripts: add galaxy recovery scripting

### DIFF
--- a/scripts/galaxy_flash.py
+++ b/scripts/galaxy_flash.py
@@ -1,0 +1,414 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+from intelhex import IntelHex
+from pathlib import Path
+import subprocess
+import sys
+import re
+
+# Command code constants
+NETFN = 0x32  # OEM NetFn 2 (used for flash operations)
+CMD_READ_FLASH = 0x77
+CMD_WRITE_FLASH = 0x78
+CMD_ERASE_FLASH = 0x79
+
+SPI_BLOCK_SIZE = 4096
+
+
+def send_raw_ipmi_command(
+    netfn, cmd, data=None, host=None, username=None, password=None, timeout=30
+):
+    """
+    Send raw IPMI command using ipmitool subprocess and return bytes
+
+    @param netfn (int): Network Function
+    @param cmd (int): Command
+    @param data (list/int/bytes, optional): Command data payload
+    @param host (str, optional): Remote BMC IP
+    @param username (str, optional): Username for remote connection
+    @param password (str, optional): Password for remote connection
+    @param timeout (int): Command timeout in seconds
+
+    @return dict: {
+            'success': bool,
+            'completion_code': int,
+            'data': bytes,
+            'error': str (if any)
+        }
+    """
+    try:
+        # Build command
+        cmd_list = ["ipmitool"]
+
+        # Add remote connection parameters
+        if host and username and password:
+            cmd_list.extend(
+                ["-I", "lanplus", "-H", host, "-U", username, "-P", password]
+            )
+
+        # Add raw command
+        cmd_list.extend(["raw", f"0x{netfn:02x}", f"0x{cmd:02x}"])
+
+        # Add data payload
+        if data is not None:
+            if isinstance(data, (list, tuple)):
+                cmd_list.extend([f"0x{x:02x}" for x in data])
+            elif isinstance(data, int):
+                cmd_list.append(f"0x{data:02x}")
+            elif isinstance(data, (bytes, bytearray)):
+                cmd_list.extend([f"0x{x:02x}" for x in data])
+
+        # Execute command
+        result = subprocess.run(
+            cmd_list, capture_output=True, text=True, timeout=timeout
+        )
+
+        if result.returncode == 0:
+            # Parse hex output to bytes
+            hex_output = result.stdout.strip()
+            if hex_output:
+                # Remove any whitespace and split hex values
+                hex_values = re.findall(r"[0-9a-fA-F]{2}", hex_output)
+                data_bytes = bytes([int(x, 16) for x in hex_values])
+            else:
+                data_bytes = b""
+
+            return {
+                "success": True,
+                "completion_code": 0,  # Successful ipmitool execution
+                "data": data_bytes,
+                "error": None,
+            }
+        else:
+            return {
+                "success": False,
+                "completion_code": result.returncode,
+                "data": b"",
+                "error": result.stderr.strip(),
+            }
+
+    except subprocess.TimeoutExpired:
+        return {
+            "success": False,
+            "completion_code": None,
+            "data": b"",
+            "error": "Command timed out",
+        }
+    except Exception as e:
+        return {"success": False, "completion_code": None, "data": b"", "error": str(e)}
+
+
+def report_progress(operation, addr, bytes_done, bytes_total):
+    print(
+        f"{operation} at 0x{addr:x} ({bytes_done}/{bytes_total} bytes, {bytes_done * 100 / bytes_total:.1f}%)\r",
+        end="",
+    )
+    sys.stdout.flush()
+
+
+def read_flash(ubb_idx, asic_idx, address, length, progress_print=False):
+    """
+    Read data from flash memory at specified address
+    @ param ubb_idx (int): UBB index
+    @ param asic_idx (int): ASIC index
+    @ param address (int): Flash memory address to read from
+    @ param length (int): Number of bytes to read
+    @ return bytes read from flash memory, or raise exception on failure
+    """
+    read_data = bytearray()
+    read_addr = address
+    read_len = length
+
+    if read_addr % 256 != 0:
+        raise ValueError("Read address must be aligned to 256 bytes")
+
+    while read_len > 0:
+        if read_addr % SPI_BLOCK_SIZE == 0:
+            # Report progress every 4K block
+            if progress_print:
+                report_progress("Reading", read_addr, len(read_data), length)
+        result = send_raw_ipmi_command(
+            NETFN,
+            CMD_READ_FLASH,
+            data=[
+                ubb_idx,  # arg0: UBB index
+                asic_idx,  # arg1: ASIC index
+                (read_addr & 0xFF),  # arg2: Address low byte
+                ((read_addr >> 8) & 0xFF),  # arg3: Address mid byte
+                ((read_addr >> 16) & 0xFF),  # arg4: Address high byte
+                0x0,  # arg5: bytes to read (1-256, 0 means 256 bytes)
+            ],
+        )
+        if not result["success"]:
+            raise RuntimeError(
+                f"Failed to read flash block at 0x{read_addr:x}: {result['error']}"
+            )
+
+        read_data.extend(result["data"])
+        read_addr += 256
+        read_len -= 256
+
+    if progress_print:
+        report_progress("Reading", read_addr, len(read_data), length)
+        print("\nRead complete")
+    return bytes(read_data[:length])
+
+
+def program_flash_block(ubb_idx, asic_idx, write_addr, data):
+    """
+    Program flash block (4K length) to given address
+    @ param ubb_idx (int): UBB index
+    @ param asic_idx (int): ASIC index
+    @ param write_addr (int): Address to write to
+    @ param data (bytes): Bytes to program to address
+    """
+
+    write_offset = 0
+    if len(data) != SPI_BLOCK_SIZE:
+        raise ValueError("Flash block can only be 4K bytes")
+
+    # Erase 4K block, then program in 128 byte chunks
+    ipmi_data = [
+        ubb_idx,  # arg0: UBB index
+        asic_idx,  # arg1: ASIC index
+        (write_addr & 0xFF),  # arg2: Address low byte
+        ((write_addr >> 8) & 0xFF),  # arg3: Address mid byte
+        ((write_addr >> 16) & 0xFF),  # arg4: Address high byte
+    ]
+    result = send_raw_ipmi_command(NETFN, CMD_ERASE_FLASH, data=ipmi_data)
+    if not result["success"]:
+        raise RuntimeError(
+            f"Failed to erase flash block at 0x{write_addr:x}: {result['error']}"
+        )
+
+    # Write 32 chunks of 128 bytes (total 4K block)
+    for _ in range(32):
+        ipmi_data = (
+            [
+                ubb_idx,  # arg0: UBB index
+                asic_idx,  # arg1: ASIC index
+                (write_addr & 0xFF),  # arg2: Address low byte
+                ((write_addr >> 8) & 0xFF),  # arg3: Address mid byte
+                ((write_addr >> 16) & 0xFF),  # arg4: Address high byte
+            ]
+            + list(data[write_offset : write_offset + 128])
+        )  # arg5+: Data payload
+
+        result = send_raw_ipmi_command(NETFN, CMD_WRITE_FLASH, data=ipmi_data)
+        if not result["success"]:
+            raise RuntimeError(
+                f"Failed to write flash block at 0x{write_addr:x}: {result['error']}"
+            )
+        write_addr += 128
+        write_offset += 128
+
+
+def write_flash(ubb_idx, asic_idx, ih):
+    """
+    Write data to flash memory at specified address
+    @ param ubb_idx (int): UBB index
+    @ param asic_idx (int): ASIC index
+    @ param ih: Intel Hex object with data to program
+    @ return None, or raise exception on failure
+    """
+    total_len = sum(segment[1] - segment[0] for segment in ih.segments())
+    total_written = 0
+
+    for segment in ih.segments():
+        write_len = segment[1] - segment[0]
+        write_addr = segment[0]
+
+        # Program segment in 3 phases:
+        # 1. Unaligned section before first 4K boundary (if needed)
+        # 2. Aligned 4K blocks
+        # 3. Unaligned section after last 4K boundary (if needed)
+
+        # Phase 1: Handle unaligned start address by programming up to next 4K block boundary
+        if write_addr % SPI_BLOCK_SIZE != 0:
+            # Program up to 4K block boundary
+            block_boundary = (write_addr + 4095) // SPI_BLOCK_SIZE * SPI_BLOCK_SIZE
+            phase1_len = min(write_len, block_boundary - write_addr)
+            flash_data = read_flash(
+                ubb_idx, asic_idx, block_boundary - SPI_BLOCK_SIZE, SPI_BLOCK_SIZE
+            )
+            flash_data = bytes(
+                flash_data[0 : write_addr - block_boundary + SPI_BLOCK_SIZE]
+            ) + ih.tobinarray(start=write_addr, size=phase1_len)
+            program_flash_block(
+                ubb_idx, asic_idx, block_boundary - SPI_BLOCK_SIZE, flash_data
+            )
+            write_addr = block_boundary
+            write_len -= phase1_len
+            total_written += phase1_len
+
+        # Phase 2: Aligned 4K blocks
+        while (
+            write_addr < ((segment[1] // SPI_BLOCK_SIZE) * SPI_BLOCK_SIZE)
+            and write_len >= SPI_BLOCK_SIZE
+        ):
+            # Program 4K blocks
+            # Report progress every 4K block
+            report_progress("Writing", write_addr, total_written, total_len)
+            flash_data = ih.tobinarray(write_addr, size=SPI_BLOCK_SIZE)
+            program_flash_block(ubb_idx, asic_idx, write_addr, flash_data)
+            write_addr += SPI_BLOCK_SIZE
+            write_len -= SPI_BLOCK_SIZE
+            total_written += SPI_BLOCK_SIZE
+
+        # Phase 3: Handle unaligned programming after 4K boundary
+        if write_len > 0:
+            flash_data = read_flash(ubb_idx, asic_idx, write_addr, SPI_BLOCK_SIZE)
+            flash_data = (
+                bytes(ih.tobinarray(start=write_addr, size=write_len))
+                + flash_data[write_len:SPI_BLOCK_SIZE]
+            )
+            program_flash_block(ubb_idx, asic_idx, write_addr, flash_data)
+            total_written += write_len
+
+        report_progress("Writing", write_addr, total_written, total_len)
+    print("\nWrite complete")
+
+
+def check_bmc_version():
+    """
+    Check BMC version to ensure compatibility with flash operations
+    @ return dict: {
+            'success': bool,
+            'version': str (if success),
+            'error': str (if failure)
+        }
+    """
+    try:
+        result = subprocess.run(
+            ["ipmitool", "mc", "info"], capture_output=True, text=True, timeout=10
+        )
+        if result.returncode != 0:
+            return {"success": False, "version": None, "error": result.stderr.strip()}
+
+        match = re.search(r"Firmware Revision\s*:\s*(\d+)\.(\d+)", result.stdout)
+        if not match:
+            return {
+                "success": False,
+                "version": None,
+                "error": "Version not found in output",
+            }
+        major = int(match.group(1))
+        minor = int(match.group(2))
+
+        # Find minor version
+        # match = re.search(r"Aux Firmware Rev Info\s+:\n\s+0x(\d+)", result.stdout)
+        match = re.search(r"Aux Firmware Rev Info\s+:\s+\n\s+0x(\d+)", result.stdout)
+        if not match:
+            return {
+                "success": False,
+                "version": None,
+                "error": "Aux version not found in output",
+            }
+        aux = int(match.group(1))
+        return {"success": True, "version": (major, minor, aux), "error": None}
+    except subprocess.TimeoutExpired:
+        return {"success": False, "version": None, "error": "Command timed out"}
+    except Exception as e:
+        return {"success": False, "version": None, "error": str(e)}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Galaxy Flash Utility", allow_abbrev=False
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Parser for integer that handles hex or dec
+    def auto_int(x):
+        return int(x, 0)
+
+    # Write command
+    write_parser = subparsers.add_parser("write", help="Write data to flash memory")
+    write_parser.add_argument("ubb_id", type=int, help="UBB index (0-3)")
+    write_parser.add_argument("asic_num", type=int, help="ASIC index (0-8)")
+    write_parser.add_argument(
+        "address", type=auto_int, help="Flash memory address to write to (e.g. 0x10000)"
+    )
+    write_parser.add_argument(
+        "file", type=Path, help="Path to file to write (intel hex or binary supported)"
+    )
+
+    # Read command
+    read_parser = subparsers.add_parser("read", help="Read data from flash memory")
+    read_parser.add_argument("ubb_id", type=int, help="UBB index (0-3)")
+    read_parser.add_argument("asic_num", type=int, help="ASIC index (0-8)")
+    read_parser.add_argument(
+        "address",
+        type=auto_int,
+        help="Flash memory address to read from (e.g. 0x10000)",
+    )
+    read_parser.add_argument(
+        "length", type=auto_int, help="Number of bytes to read (e.g. 0x1000)"
+    )
+    read_parser.add_argument("file", type=Path, help="Path to output binary file")
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    # Validate UBB and ASIC indices
+    if not 0 <= args.ubb_id <= 3:
+        print("Error: UBB index must be between 0 and 3")
+        return
+    if not 0 <= args.asic_num <= 8:
+        print("Error: ASIC index must be between 0 and 8")
+        return
+
+    version = check_bmc_version()
+    if not version["success"]:
+        print(f"Error checking BMC version: {version['error']}")
+        return
+    if version["version"] < (0, 5, 14):
+        print(f"Error, unsupported BMC version: {version['version']}")
+        return
+
+    if args.command == "write":
+        if not args.file.is_file():
+            print(f"Error: File {args.file} does not exist")
+            return
+        try:
+            if (
+                args.file.suffix.lower() == ".hex"
+                or args.file.suffix.lower() == ".ihex"
+            ):
+                print(f"Programming from Intel Hex file: {args.file}")
+                ih = IntelHex(str(args.file))
+                write_flash(args.ubb_id, args.asic_num, ih)
+            else:
+                print(f"Programming binary file: {args.file}")
+                ih = IntelHex()
+                # Load binary at offset
+                ih.loadbin(args.file, offset=args.address)
+                write_flash(args.ubb_id, args.asic_num, ih)
+        except RuntimeError as e:
+            print(f"Error: {e}")
+        except ValueError as e:
+            print(f"Input error: {e}")
+    elif args.command == "read":
+        try:
+            data = read_flash(
+                args.ubb_id,
+                args.asic_num,
+                args.address,
+                args.length,
+                progress_print=True,
+            )
+            with open(args.file, "wb") as f:
+                f.write(data)
+        except RuntimeError as e:
+            print(f"Error: {e}")
+        except ValueError as e:
+            print(f"Input error: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/recover_galaxy.py
+++ b/scripts/recover_galaxy.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pyluwen
+from galaxy_flash import write_flash
+import subprocess
+import sys
+import signal
+import time
+from intelhex import IntelHex
+
+COORD_TO_I2C = {
+    (0, 0): (0, 0),
+    (3, 0): (1, 0),
+    (0, 7): (2, 0),
+    (3, 7): (3, 0),
+    (0, 1): (0, 1),
+    (3, 1): (1, 1),
+    (0, 6): (2, 1),
+    (3, 6): (3, 1),
+    (0, 2): (0, 2),
+    (3, 2): (1, 2),
+    (0, 5): (2, 2),
+    (3, 5): (3, 2),
+    (0, 3): (0, 3),
+    (3, 3): (1, 3),
+    (0, 4): (2, 3),
+    (3, 4): (3, 3),
+    (1, 0): (0, 4),
+    (2, 0): (1, 4),
+    (1, 7): (2, 4),
+    (2, 7): (3, 4),
+    (1, 1): (0, 5),
+    (2, 1): (1, 5),
+    (1, 6): (2, 5),
+    (2, 6): (3, 5),
+    (1, 2): (0, 6),
+    (2, 2): (1, 6),
+    (1, 5): (2, 6),
+    (2, 5): (3, 6),
+    (1, 3): (0, 7),
+    (2, 3): (1, 7),
+    (1, 4): (2, 7),
+    (2, 4): (3, 7),
+}
+
+UBB_MAP = {
+    # UBB 1                         # UBB 2
+    0xC1: (0, 7),
+    0xC5: (1, 7),
+    0x85: (2, 7),
+    0x81: (3, 7),
+    0xC2: (0, 6),
+    0xC6: (1, 6),
+    0x86: (2, 6),
+    0x82: (3, 6),
+    0xC3: (0, 5),
+    0xC7: (1, 5),
+    0x87: (2, 5),
+    0x83: (3, 5),
+    0xC4: (0, 4),
+    0xC8: (1, 4),
+    0x88: (2, 4),
+    0x84: (3, 4),
+    # UBB 3                         # UBB 4
+    0x04: (0, 3),
+    0x08: (1, 3),
+    0x48: (2, 3),
+    0x44: (3, 3),
+    0x03: (0, 2),
+    0x07: (1, 2),
+    0x47: (2, 2),
+    0x43: (3, 2),
+    0x02: (0, 1),
+    0x06: (1, 1),
+    0x46: (2, 1),
+    0x42: (3, 1),
+    0x01: (0, 0),
+    0x05: (1, 0),
+    0x45: (2, 0),
+    0x41: (3, 0),
+}
+
+TT_SMC_MSG_TEST = 0x90
+
+
+def list_missing_asics():
+    """
+    Finds the I2C programming coordinates of all missing ASICs on the system.
+    an ASIC is defined as "missing" if it fails to respond to a test ARC message, or
+    is not present on the PCIe bus.
+    """
+
+    seen_coords = []
+    missing_coords = []
+
+    for i in range(32):
+        try:
+            chip = pyluwen.PciChip(i)
+            response = chip.arc_msg(TT_SMC_MSG_TEST, True, False, 20, 0, 1000)
+            if response[0] != 21:
+                print(f"Chip {i} had unexpected response to test message")
+        except Exception as e:
+            print(f"Could not find chip {i}: {e}")
+            continue
+        pcie_bus = int(chip.get_pci_bdf()[5:7], 16)
+        coords = UBB_MAP[pcie_bus]
+        seen_coords.append(coords)
+    for coord in UBB_MAP.values():
+        if coord not in seen_coords:
+            i2c_coord = COORD_TO_I2C[coord]
+            missing_coords.append(i2c_coord)
+    return missing_coords
+
+
+def sigint_handler(sig, frame):
+    print("Caught SIGINT, clearing IPMI reset")
+    subprocess.run("ipmitool raw 0x30 0x8b 0xf 0xff 0x2 0xf".split(), check=True)
+    subprocess.run("ipmitool raw 0x30 0x8b 0xf 0xff 0x0 0xf".split(), check=True)
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: recover_galaxy.py <firmware.hex>")
+        sys.exit(1)
+    ih = IntelHex()
+    ih.loadhex(sys.argv[1])
+    missing = list_missing_asics()
+    print(f"{len(missing)} ASIC(s) not alive")
+    # Hold ASICs in reset while we program
+    signal.signal(signal.SIGINT, sigint_handler)  # In case we are interrupted
+    subprocess.run("ipmitool raw 0x30 0x8b 0xf 0xff 0x1 0xf".split(), check=True)
+    for coord in missing:
+        print(f"Missing coordinate {coord}")
+        print("Programming Flash...")
+        write_flash(coord[0], coord[1], ih)
+    # Release reset
+    subprocess.run("ipmitool raw 0x30 0x8b 0xf 0xff 0x2 0xf".split(), check=True)
+    subprocess.run("ipmitool raw 0x30 0x8b 0xf 0xff 0x0 0xf".split(), check=True)
+    time.sleep(5)
+    missing = list_missing_asics()
+    if len(missing) > 0:
+        print(f"Error, {len(missing)} asics still offline. Try a reboot?")
+        sys.exit(1)
+
+    # Check and set ASIC locations
+    chips = pyluwen.detect_chips()
+    for chip in chips:
+        pcie_bus = int(chip.get_pci_bdf()[5:7], 16)
+        expected = pcie_bus & 0xF
+        table = chip.as_bh().decode_boot_fs_table("boardcfg")
+        real = table["asic_location"]
+        if expected != real:
+            print(f"Chip location should be {expected}, it is {real}")
+            table["asic_location"] = expected
+            chip.as_bh().encode_and_write_boot_fs_table(table, "boardcfg")
+
+    subprocess.run("ipmitool raw 0x30 0x8b 0xf 0xff 0x0 0xf".split(), check=True)
+    time.sleep(5)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add initial galaxy recovery scripting. This tooling will program a hex file to all ASICs that do not enumerate or respond to a test ARC message, and will then set ASIC locations correctly based on PCIe bus numbers.

This recovery scripting requires an updated BMC firmware be deployed to the galaxy system, so that it can accept flash read,write and erase commands over IPMI