### PR TITLE
.github: workflows: hardware-long: add manufacturing test

### DIFF
--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -325,6 +325,9 @@ jobs:
 
   build-preflash:
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        board_rev: [p150a, p300a]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -336,12 +339,12 @@ jobs:
       - name: Build preflash firmware
         shell: bash
         run: |
-          ./tt-system-firmware/scripts/build-preflash.sh
+          ./tt-system-firmware/scripts/build-preflash.sh ${{ matrix.board_rev }}
 
       - name: Upload preflash
         uses: actions/upload-artifact@v4
         with:
-          name: preflash-fw
+          name: preflash-fw-${{ matrix.board_rev }}
           path: |
             preflash*.ihex
             preflash*.bin
@@ -394,6 +397,11 @@ jobs:
         shell: bash
         run: |
           ./build-flm.sh
+      - name: Upload Flash Loader Module
+        uses: actions/upload-artifact@v4
+        with:
+          name: bh-flm
+          path: tt-system-firmware/scripts/tooling/blackhole_recovery/data/bh_flm/build/*.flm
 
   discover-smc-tests:
     runs-on: ubuntu-24.04

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -35,11 +35,15 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       matrix-config: ${{ steps.gen.outputs.matrix-config }}
+      mfg-matrix-config: ${{ steps.gen.outputs.mfg-matrix-config }}
     steps:
       - uses: actions/checkout@v4
       - id: gen
         run: |
           echo "matrix-config=$(jq -c '.bh' .github/ci_boards.json)" | tee -a $GITHUB_OUTPUT
+          # Manufacturing test only runs on the standalone PCIe cards (p100a, p150a, p300a)
+          MFG_MATRIX_CONFIG="$(jq -c '[.bh[] | select(.board == "p100a" or .board == "p150a" or .board == "p300a")]' .github/ci_boards.json)"
+          echo "mfg-matrix-config=$MFG_MATRIX_CONFIG" | tee -a $GITHUB_OUTPUT
 
   e2e-stress-test:
     name: BH E2E Stress Test on ${{ matrix.config.board }}
@@ -171,3 +175,100 @@ jobs:
             exit 1
           fi
           echo "Successfully verified that tensix-enabled column count is correct: $TENSIX_COUNT"
+
+  manufacturing-test:
+    needs: [build-fw-artifact, gen-config]
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.gen-config.outputs.mfg-matrix-config) }}
+    runs-on: ${{ matrix.config.board }}
+    container:
+      image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
+      volumes:
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/
+      options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
+    steps:
+      - name: Cleanup State
+        if: ${{ always() }}
+        run: |
+          ls -la
+          rm -rf *
+
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          path: tt-system-firmware
+
+      - name: Prepare Container
+        uses: ./tt-system-firmware/.github/workflows/prepare-container
+        with:
+          app-path: tt-system-firmware
+          kmd-version: ${{ matrix.config.kmd_build }}
+
+      - name: Derive board properties
+        id: board-map
+        shell: bash
+        working-directory: tt-system-firmware
+        run: |
+          BOARD="${{ matrix.config.board }}"
+          source scripts/ci/board-map.sh
+          echo "assembly_board=$ASSEMBLY_BOARD" | tee -a $GITHUB_OUTPUT
+          echo "num_asics=$NUM_ASICS" | tee -a $GITHUB_OUTPUT
+          echo "preflash_rev=$PREFLASH_REV" | tee -a $GITHUB_OUTPUT
+
+      - name: Download preflash firmware
+        uses: actions/download-artifact@v4
+        with:
+          name: preflash-fw-${{ steps.board-map.outputs.preflash_rev }}
+          path: artifacts/preflash
+
+      - name: Download assembly test firmware
+        uses: actions/download-artifact@v4
+        with:
+          name: assembly-fw-${{ steps.board-map.outputs.assembly_board }}
+          path: artifacts/assembly-fw
+
+      - name: Download assembly MCUBoot
+        uses: actions/download-artifact@v4
+        with:
+          name: assembly-mcuboot-${{ steps.board-map.outputs.assembly_board }}
+          path: artifacts/assembly-mcuboot
+
+      - name: Download combined firmware bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: combined-fwbundle
+          path: artifacts/fwbundle
+
+      - name: Download Flash Loader Module
+        uses: actions/download-artifact@v4
+        with:
+          name: bh-flm
+          path: tt-system-firmware/scripts/tooling/blackhole_recovery/data/bh_flm/build
+
+      - name: Run manufacturing test
+        shell: bash
+        run: |
+          tt-system-firmware/scripts/ci/run-manufacturing-test.sh \
+            -p artifacts/preflash \
+            -m artifacts/assembly-mcuboot \
+            -a artifacts/assembly-fw \
+            -f artifacts/fwbundle \
+            ${{ matrix.config.board }}
+
+      # ---- Debug info on failure ----
+      - name: Print RTT logs
+        if: ${{ failure() }}
+        working-directory: tt-system-firmware
+        run: |
+          echo "DMC RTT logs:"
+          python3 ./scripts/dmc_rtt.py -n
+          echo "SMC RTT logs:"
+          python3 ./scripts/smc_console.py --rtt -n
+          NUM_ASICS=${{ steps.board-map.outputs.num_asics }}
+          for ((i=0; i<NUM_ASICS; i++)); do
+            echo "SMC state dump for ASIC $i:"
+            python3 ./scripts/dump_smc_state.py --asic-id $i
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,11 +209,17 @@ jobs:
         with:
           pattern: assembly-test-*
 
-      - name: Download preflash firmware
+      - name: Download preflash firmware (p300a)
         uses: actions/download-artifact@v4
         with:
-          name: preflash-fw
-          path: preflash-fw
+          name: preflash-fw-p300a
+          path: preflash-fw/p300a
+
+      - name: Download preflash firmware (p150a)
+        uses: actions/download-artifact@v4
+        with:
+          name: preflash-fw-p150a
+          path: preflash-fw/p150a
 
       - name: Download Debian Package
         uses: actions/download-artifact@v4

--- a/scripts/build-preflash.sh
+++ b/scripts/build-preflash.sh
@@ -34,8 +34,13 @@ trap cleanup EXIT
 SCRIPT_DIR="$(dirname "$0")"
 TTZP_BASE="$(dirname "$SCRIPT_DIR")"
 
-# use p300a for pre-flash.
-BOARD_REV="p300a"
+# board rev to build pre-flash for (p300a or p150a)
+BOARD_REV="${1:-p300a}"
+if [[ "$BOARD_REV" != "p300a" && "$BOARD_REV" != "p150a" ]]; then
+  echo "ERROR: unsupported board rev '$BOARD_REV' (expected p300a or p150a)"
+  echo "Usage: $0 [p300a|p150a]"
+  exit 1
+fi
 BUILD_DIR="$TEMP_DIR"
 
 # firmware version info

--- a/scripts/check_card.py
+++ b/scripts/check_card.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import logging
+import sys
+
+from pathlib import Path
+
+import pcie_utils
+
+logger = logging.getLogger(Path(__file__).stem)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Wait for a Tenstorrent card to enumerate and respond to ARC/DMC pings",
+        allow_abbrev=False,
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    parser.add_argument(
+        "--asic-id", type=int, default=0, help="ASIC index (default: 0)"
+    )
+    parser.add_argument(
+        "--timeout", type=int, default=60, help="Timeout in seconds (default: 60)"
+    )
+
+    args = parser.parse_args()
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(name)s: %(levelname)s: %(message)s")
+
+    ok = pcie_utils.wait_for_enum(asic_id=args.asic_id, timeout=args.timeout)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/board-map.sh
+++ b/scripts/ci/board-map.sh
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Tenstorrent AI ULC
+
+# Derive Blackhole board-family properties from a runner board name.
+#
+# Source this file with $BOARD set (e.g. p100a, p150a, p300a) to populate:
+#   ASSEMBLY_BOARD  - board family used to select assembly test FW artifacts
+#                      (p100 and p150 share the same assembly FW)
+#   NUM_ASICS       - number of ASICs on the board (2 for p300 variants, else 1)
+#   PREFLASH_REV    - preflash image revision to use (p150a or p300a)
+#   PYOCD_CONFIGS   - bash array with one pyocd FLM user-script per ASIC (in ASIC
+#                      order), taken from board_metadata.yaml. Used to program the
+#                      external SPI EEPROM over JTAG/SWD with `pyocd`.
+
+# Strip the trailing revision letter, e.g. p150a -> p150.
+ASSEMBLY_BOARD=$(echo "$BOARD" | sed 's/[a-z]$//')
+
+# p100 uses the same assembly test firmware as p150.
+if [[ "$ASSEMBLY_BOARD" == "p100" ]]; then
+	ASSEMBLY_BOARD="p150"
+fi
+
+# p300 variants have 2 ASICs, all others have 1.
+if [[ "$ASSEMBLY_BOARD" == "p300" ]]; then
+	NUM_ASICS=2
+else
+	NUM_ASICS=1
+fi
+
+# p100 and p150 variants use the p150a preflash, all others use p300a.
+case "$ASSEMBLY_BOARD" in
+	p100 | p150) PREFLASH_REV="p150a" ;;
+	*) PREFLASH_REV="p300a" ;;
+esac
+
+# Per-ASIC pyocd FLM user-script names, read from board_metadata.yaml. bash has
+# no YAML parser, so shell out to python3 (available in the CI container). The
+# order matches the ASIC order in the metadata, which is the order the rest of
+# the manufacturing test iterates over.
+_BOARD_MAP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+mapfile -t PYOCD_CONFIGS < <(
+	python3 -c '
+import sys, yaml
+board, meta_path = sys.argv[1], sys.argv[2]
+with open(meta_path) as f:
+    meta = yaml.safe_load(f)
+if board not in meta:
+    sys.exit(f"Unknown board {board!r} in {meta_path}")
+for asic in meta[board]:
+    print(asic["pyocd-config"])
+' "$BOARD" "$_BOARD_MAP_DIR/../board_metadata.yaml"
+)

--- a/scripts/ci/run-manufacturing-test.sh
+++ b/scripts/ci/run-manufacturing-test.sh
@@ -1,0 +1,175 @@
+#!/bin/env bash
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Tenstorrent AI ULC
+
+# This script runs the manufacturing test sequence for Blackhole boards.
+# It assumes the following:
+# - pyocd is installed (with the STM32G0B1CEUx CMSIS pack) for early SPI preflash
+#   (step 1) and assembly DMC flash (step 2)
+# - The DUT is reachable via JTAG for pyocd steps and enumerated on PCIe for step 5
+# - All required firmware artifacts are available in the specified directories
+
+set -e
+
+TT_Z_P_ROOT=$(realpath "$(dirname "$(realpath "$0")")"/../..)
+
+# STM32 DMC target used by pyocd for both the SPI EEPROM (via the FLM user-script)
+# and the DMC internal flash. Keep in sync with PYOCD_TARGET_BH in pyocd_utils.py.
+PYOCD_TARGET="STM32G0B1CEUx"
+
+function print_help {
+	echo "Usage: $(basename "$0") [options] <board_name>"
+	echo ""
+	echo "Run the manufacturing test sequence for a Blackhole board."
+	echo ""
+	echo "Options:"
+	echo "  -p <dir>   Directory containing the preflash ihex (default: artifacts/preflash)"
+	echo "  -m <dir>   Directory containing assembly MCUBoot ELF"
+	echo "             (default: artifacts/assembly-mcuboot)"
+	echo "  -a <dir>   Directory containing assembly app hex (default: artifacts/assembly-fw)"
+	echo "  -f <dir>   Directory containing production fwbundle (default: artifacts/fwbundle)"
+	echo "  -h         Show this help"
+}
+
+if [ $# -lt 1 ]; then
+	print_help
+	exit 1
+fi
+
+PREFLASH_DIR="artifacts/preflash"
+MCUBOOT_DIR="artifacts/assembly-mcuboot"
+ASSEMBLY_FW_DIR="artifacts/assembly-fw"
+FWBUNDLE_DIR="artifacts/fwbundle"
+
+while getopts "p:m:a:f:h" opt; do
+	case "$opt" in
+		p) PREFLASH_DIR=$OPTARG ;;
+		m) MCUBOOT_DIR=$OPTARG ;;
+		a) ASSEMBLY_FW_DIR=$OPTARG ;;
+		f) FWBUNDLE_DIR=$OPTARG ;;
+		h) print_help; exit 0 ;;
+		\?) print_help; exit 1 ;;
+	esac
+done
+shift $((OPTIND-1))
+
+BOARD=$1
+
+if [ -z "$BOARD" ]; then
+	echo "ERROR: Board name is required"
+	print_help
+	exit 1
+fi
+
+# Derive board properties (ASSEMBLY_BOARD, NUM_ASICS, PREFLASH_REV)
+source "$TT_Z_P_ROOT/scripts/ci/board-map.sh"
+
+echo "Board: $BOARD, Assembly board: $ASSEMBLY_BOARD, Num ASICs: $NUM_ASICS"
+echo "Preflash rev: $PREFLASH_REV"
+echo "Preflash dir: $PREFLASH_DIR"
+echo "MCUBoot dir: $MCUBOOT_DIR"
+echo "Assembly FW dir: $ASSEMBLY_FW_DIR"
+echo "FW bundle dir: $FWBUNDLE_DIR"
+
+function verify_pcie_enumeration {
+	local DESCRIPTION=$1
+	echo "Verifying PCIe enumeration ($DESCRIPTION)..."
+	local TIMEOUT=60
+	local ELAPSED=0
+	while true; do
+		echo "Rescanning PCIe bus..."
+		"$TT_Z_P_ROOT"/scripts/rescan-pcie.sh
+		local COUNT=0
+		for dev in /sys/bus/pci/devices/*/vendor; do
+			if [ -f "$dev" ] && [ "$(cat "$dev")" = "0x1e52" ]; then
+				COUNT=$((COUNT + 1))
+			fi
+		done
+		echo "Detected $COUNT Tenstorrent PCIe endpoint(s), expected $NUM_ASICS"
+		if [ "$COUNT" -ge "$NUM_ASICS" ]; then
+			echo "PASS: All $NUM_ASICS endpoint(s) enumerated"
+			return 0
+		fi
+		if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+			echo "FAIL: Only $COUNT of $NUM_ASICS endpoint(s)" \
+				"enumerated after ${TIMEOUT}s"
+			return 1
+		fi
+		echo "Retrying in 2 seconds..."
+		sleep 2
+		ELAPSED=$((ELAPSED + 2))
+	done
+}
+
+# ---- Step 1: Erase SPI + flash preflash ihex ----
+echo "=== Step 1: Erase SPI and flash preflash ihex ==="
+PREFLASH_MATCHES=("$PREFLASH_DIR"/preflash-*.ihex)
+if [ ! -e "${PREFLASH_MATCHES[0]}" ]; then
+	echo "ERROR: No preflash .ihex found in $PREFLASH_DIR"
+	exit 1
+fi
+PREFLASH_IHEX="${PREFLASH_MATCHES[0]}"
+echo "Using preflash image: $PREFLASH_IHEX"
+FLM_DIR="$TT_Z_P_ROOT/scripts/tooling/blackhole_recovery/data/bh_flm"
+for cfg in "${PYOCD_CONFIGS[@]}"; do
+	echo "Erasing SPI and writing preflash via $cfg ..."
+	python3 -m pyocd flash -t "$PYOCD_TARGET" -O user_script="$FLM_DIR/$cfg" \
+		--erase chip --format hex "$PREFLASH_IHEX"
+done
+
+# ---- Step 2: Flash assembly test FW to DMC via pyocd ----
+echo "=== Step 2: Flash assembly test firmware to DMC ==="
+MCUBOOT_ELF="$MCUBOOT_DIR/zephyr.elf"
+APP_HEX="$ASSEMBLY_FW_DIR/zephyr.signed.hex"
+
+echo "Flashing MCUBoot bootloader: $MCUBOOT_ELF"
+echo "Flashing assembly test app: $APP_HEX"
+
+if [ ! -f "$MCUBOOT_ELF" ]; then
+	echo "ERROR: MCUBoot ELF not found at $MCUBOOT_ELF"
+	exit 1
+fi
+if [ ! -f "$APP_HEX" ]; then
+	echo "ERROR: Assembly test app hex not found at $APP_HEX"
+	exit 1
+fi
+python3 -m pyocd flash -t "$PYOCD_TARGET" --erase auto "$MCUBOOT_ELF" "$APP_HEX"
+
+# ---- Step 3: DMC reset (simulate power-on) ----
+echo "=== Step 3: DMC reset after assembly flash ==="
+python3 "$TT_Z_P_ROOT"/scripts/dmc_reset.py
+
+# ---- Step 4: Verify PCIe enumeration (assembly test FW + preflash) ----
+echo "=== Step 4: Verify PCIe enumeration (assembly test FW) ==="
+verify_pcie_enumeration "assembly test FW"
+
+# ---- Step 5: Flash full production fwbundle to SPI over PCIe (SMC on ARC) ----
+echo "=== Step 5: Flash production firmware bundle to SPI (PCIe / SMC) ==="
+FWBUNDLE_MATCHES=("$FWBUNDLE_DIR"/fw_pack*.fwbundle)
+if [ ! -e "${FWBUNDLE_MATCHES[0]}" ]; then
+	echo "ERROR: No firmware bundle found in $FWBUNDLE_DIR"
+	exit 1
+fi
+FWBUNDLE="${FWBUNDLE_MATCHES[0]}"
+echo "Using firmware bundle: $FWBUNDLE"
+python3 "$TT_Z_P_ROOT"/scripts/smc_spi_flash.py \
+	--board-name "$BOARD" -v flash-fwbundle "$FWBUNDLE"
+
+# ---- Step 6: DMC reset (simulate cold boot after bootstrap) ----
+echo "=== Step 6: DMC reset after production flash ==="
+python3 "$TT_Z_P_ROOT"/scripts/dmc_reset.py
+
+# ---- Step 7: Verify PCIe enumeration (production FW) ----
+echo "=== Step 7: Verify PCIe enumeration (production FW) ==="
+verify_pcie_enumeration "production FW"
+
+# ---- Step 8: Verify ARC + DMC are responsive (proves production FW booted) ----
+echo "=== Step 8: Verify production firmware is running ==="
+for ASIC_ID in $(seq 0 $((NUM_ASICS - 1))); do
+	echo "Checking ASIC $ASIC_ID..."
+	python3 "$TT_Z_P_ROOT"/scripts/check_card.py \
+		--asic-id "$ASIC_ID" --timeout 60
+done
+
+echo "=== Manufacturing test completed successfully! ==="

--- a/scripts/pyocd_utils.py
+++ b/scripts/pyocd_utils.py
@@ -6,7 +6,7 @@
 Shared pyocd / ST-Link helpers for PCIe card tooling.
 
 Consolidates probe-session creation, ST-Link USB recovery, and board
-metadata loading that were previously duplicated across spi_flash.py,
+metadata loading that were previously duplicated across smc_spi_flash.py,
 recover-blackhole.py, recover-wormhole.py, tt_bootstrap.py, and set-p300-jtag.py.
 """
 
@@ -47,6 +47,37 @@ def load_board_metadata(path=None):
     path = Path(path) if path else BOARD_METADATA_PATH
     with open(path) as f:
         return yaml.load(f.read(), Loader=SafeLoader)
+
+
+def select_asics(board_metadata, board_name, asic_index):
+    """Return the list of ``(index, asic)`` pairs to operate on.
+
+    If *asic_index* is ``None`` all ASICs for the board are returned.
+    Otherwise only the requested ASIC is returned (with validation).
+    Returns ``None`` (after logging) on unknown board / out-of-range index.
+    """
+    if board_name not in board_metadata:
+        logger.error(
+            "Unknown board name: %s. Supported: %s",
+            board_name,
+            list(board_metadata.keys()),
+        )
+        return None
+
+    asics = board_metadata[board_name]
+
+    if asic_index is not None:
+        if asic_index < 0 or asic_index >= len(asics):
+            logger.error(
+                "ASIC index %d out of range for board %s (has %d ASIC(s))",
+                asic_index,
+                board_name,
+                len(asics),
+            )
+            return None
+        return [(asic_index, asics[asic_index])]
+
+    return list(enumerate(asics))
 
 
 def recover_stlink():
@@ -112,6 +143,41 @@ def create_session(pyocd_config=None, adapter_id=None, no_prompt=False, target=N
     return session
 
 
+def add_common_args(parser, *, adapter_id=True, no_prompt=True, verbose=True):
+    """Add standard pyocd-related CLI arguments to an argparse parser.
+
+    Each flag can be individually disabled by passing ``False``.
+
+    Args:
+        parser:     The :class:`argparse.ArgumentParser` to extend.
+        adapter_id: Add ``--adapter-id`` flag.
+        no_prompt:  Add ``--no-prompt`` flag.
+        verbose:    Add ``-v``/``--verbose`` flag.
+    """
+    if adapter_id:
+        parser.add_argument(
+            "--adapter-id",
+            type=str,
+            default=None,
+            help="ST-Link adapter serial / unique ID",
+        )
+    if no_prompt:
+        parser.add_argument(
+            "--no-prompt",
+            action="store_true",
+            default=False,
+            help="Do not prompt for adapter selection; use the first available probe",
+        )
+    if verbose:
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            action="count",
+            default=0,
+            help="Increase logging verbosity (repeat for more)",
+        )
+
+
 def get_session(pyocd_config=None, adapter_id=None, no_prompt=False, target=None):
     """Like :func:`create_session`, but retries once after an ST-Link
     USB reset if the initial connection fails.
@@ -122,3 +188,16 @@ def get_session(pyocd_config=None, adapter_id=None, no_prompt=False, target=None
         logger.warning("Error connecting to probe, will attempt USB reset: %s", e)
         recover_stlink()
         return create_session(pyocd_config, adapter_id, no_prompt, target)
+
+
+def setup_logging(verbose):
+    """Configure root logging from a ``-v``/``--verbose`` count.
+
+    0 = WARNING, 1 = INFO, 2+ = DEBUG.
+    """
+    level = logging.WARNING
+    if verbose >= 2:
+        level = logging.DEBUG
+    elif verbose >= 1:
+        level = logging.INFO
+    logging.basicConfig(level=level, format="%(name)s: %(levelname)s: %(message)s")

--- a/scripts/set-p300-jtag.py
+++ b/scripts/set-p300-jtag.py
@@ -30,17 +30,7 @@ def parse_args():
         help="JTAG mux to configure: 'ARC' for ARC core, 'SYS' for system JTAG",
     )
     parser.add_argument("asic", type=int, choices=[0, 1], help="ASIC number (0 or 1)")
-    parser.add_argument(
-        "--adapter-id",
-        type=str,
-        help="Adapter ID for the ST-Link device used in recovery",
-    )
-    parser.add_argument(
-        "--no-prompt",
-        default=False,
-        help="Do not prompt for adapter if none is provided, use first available",
-        action="store_true",
-    )
+    pyocd_utils.add_common_args(parser, verbose=False)
     return parser.parse_args()
 
 

--- a/scripts/smc_spi_flash.py
+++ b/scripts/smc_spi_flash.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Flash SPI on Blackhole ASICs over PCIe using SMC messages.
+
+Flashes contents of a provided firmware bundle to the external SPI EEPROM
+on Blackhole ASICs over PCIe using SMC messages. By default the script operates
+on all ASICs of a board. Use ``--asic-index`` to target a single ASIC
+(e.g. on p300 boards which have two).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import logging
+import os
+import sys
+import tarfile
+import tempfile
+from intelhex import IntelHex
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import pcie_utils
+import pyluwen
+import pyocd_utils
+import tt_boot_fs
+
+logger = logging.getLogger(Path(__file__).stem)
+
+# Matches SPI sector size in lib/tenstorrent/bh_arc/spi_eeprom.c
+DEFAULT_CHUNK_BYTES = 4096
+
+WAIT_FOR_ENUM_S = 120
+
+
+# ---------------------------------------------------------------------------
+# Firmware bundle input
+# ---------------------------------------------------------------------------
+
+
+def _extract_tar_safe(tar: tarfile.TarFile, dest: str) -> None:
+    tar.extractall(path=dest, filter="data")
+
+
+def _bundle_asic_subdir(name: str) -> str:
+    """Reject path traversal in ASIC directory names from board metadata."""
+    if not name or name in (".", ".."):
+        raise ValueError(f"Invalid ASIC name: {name!r}")
+    return name
+
+
+def _read_bootfs_raw_from_b16(image_path: str | Path) -> bytes:
+    """Decode ``image.bin`` (base16 lines + optional ``@offset``) to raw bytes."""
+    data = bytearray()
+    with open(image_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("@"):
+                offset = int(line[1:], 10)
+                if offset > len(data):
+                    data.extend(b"\xff" * (offset - len(data)))
+            else:
+                data.extend(base64.b16decode(line))
+    return bytes(data)
+
+
+# ---------------------------------------------------------------------------
+# PCIe + Blackhole handle
+# ---------------------------------------------------------------------------
+
+
+def _open_all_blackholes(asic_indices: list[int]) -> dict[int, Any]:
+    """Ensure every ASIC is enumerated, then return ``{idx: PciBlackhole}``."""
+    for idx in asic_indices:
+        if not pcie_utils.wait_for_enum(asic_id=idx, timeout=WAIT_FOR_ENUM_S):
+            raise RuntimeError(
+                f"ASIC {idx} not ready within {WAIT_FOR_ENUM_S}s (enumeration/ping)"
+            )
+
+    chips = pyluwen.detect_chips()
+    handles = {}
+    for idx in asic_indices:
+        if idx >= len(chips):
+            raise RuntimeError(
+                f"detect_chips() found {len(chips)} chip(s); need index {idx}"
+            )
+        handles[idx] = chips[idx].as_bh()
+    return handles
+
+
+# ---------------------------------------------------------------------------
+# SPI programming (Intel HEX → spi_write)
+# ---------------------------------------------------------------------------
+
+
+def _spi_write_intel_hex(bh: Any, ihex_bytes: bytes | str) -> None:
+    """Parse Intel HEX and write each range in ``DEFAULT_CHUNK_BYTES`` slices via ``bh.spi_write``."""
+    text = ihex_bytes.decode("ascii") if isinstance(ihex_bytes, bytes) else ihex_bytes
+    ih = IntelHex()
+    ih.loadhex(io.StringIO(text))
+    for start, end in ih.segments():
+        addr = start
+        while addr < end:
+            n = min(DEFAULT_CHUNK_BYTES, end - addr)
+            payload = bytes(ih.tobinarray(start=addr, size=n))
+            bh.spi_write(int(addr), payload)
+            addr += n
+
+
+def flash_fwbundle_to_spi_smc(
+    board_name: str,
+    fwbundle_path: Path,
+    *,
+    asic_index: int | None,
+) -> None:
+    """Extract ``fwbundle_path`` and program each selected ASIC’s image to SPI."""
+    meta = pyocd_utils.load_board_metadata()
+    asics = pyocd_utils.select_asics(meta, board_name, asic_index)
+
+    if asics is None:
+        raise ValueError(
+            f"Invalid ASIC selection for board {board_name!r} (asic_index={asic_index})"
+        )
+
+    if not fwbundle_path.is_file():
+        raise FileNotFoundError(fwbundle_path)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        with tarfile.open(fwbundle_path, "r") as tar:
+            _extract_tar_safe(tar, tmp)
+        root = Path(tmp).resolve()
+
+        # Resolve handles to every ASIC up front. wait_for_enum rescans the
+        # PCIe bus, which must happen before any SPI is reprogrammed (see
+        # _open_all_blackholes).
+        logger.info("Opening PCIe for ASIC(s) %s...", [idx for idx, _ in asics])
+        handles = _open_all_blackholes([idx for idx, _ in asics])
+
+        for idx, asic in asics:
+            name = _bundle_asic_subdir(str(asic["name"]))
+            image_bin = root / name / "image.bin"
+            if not image_bin.is_file():
+                raise FileNotFoundError(f"Missing {name}/image.bin in {fwbundle_path}")
+            image_resolved = image_bin.resolve(strict=True)
+            if not image_resolved.is_relative_to(root):
+                raise ValueError(
+                    f"image.bin is outside of the expected temp directory: {image_resolved}"
+                )
+
+            logger.info("Decoding bootfs for ASIC %d (%s)...", idx, name)
+            raw = _read_bootfs_raw_from_b16(image_resolved)
+            bootfs = tt_boot_fs.BootFs.from_binary(raw)
+            ihex = bootfs.to_intel_hex(True)
+
+            logger.info(
+                "Programming SPI via spi_write (%d-byte slices)...",
+                DEFAULT_CHUNK_BYTES,
+            )
+            _spi_write_intel_hex(handles[idx], ihex)
+            logger.info("ASIC %d done.", idx)
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Flash SPI over PCIe using SMC messages.",
+        allow_abbrev=False,
+    )
+    p.add_argument(
+        "--board-name",
+        required=True,
+        help="Board name as listed in board_metadata.yaml (e.g. p100a, p150a, p300a)",
+    )
+    p.add_argument(
+        "--asic-index",
+        type=int,
+        default=None,
+        help="Operate on a single ASIC by index (0-based). "
+        "If omitted, all ASICs on the board are targeted.",
+    )
+    pyocd_utils.add_common_args(p, adapter_id=False, no_prompt=False)
+
+    sub = p.add_subparsers(dest="command", required=True)
+    flash = sub.add_parser(
+        "flash-fwbundle",
+        help="Unpack a .fwbundle and program each ASIC's image to SPI",
+    )
+    flash.add_argument("file", type=Path, help="Path to .fwbundle")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    pyocd_utils.setup_logging(args.verbose)
+
+    if args.command != "flash-fwbundle":
+        logger.error("No command given")
+        return os.EX_USAGE
+
+    try:
+        flash_fwbundle_to_spi_smc(
+            args.board_name,
+            args.file,
+            asic_index=args.asic_index,
+        )
+    except Exception:
+        logger.exception("flash-fwbundle failed")
+        return os.EX_SOFTWARE
+
+    logger.info("Done.")
+    return os.EX_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tooling/blackhole_recovery/recover-blackhole.py
+++ b/scripts/tooling/blackhole_recovery/recover-blackhole.py
@@ -55,17 +55,12 @@ def parse_args():
         default="auto",
         help="Board ID to program into the board's EEPROM",
     )
-    parser.add_argument("--adapter-id", help="Adapter ID to use for pyocd")
     parser.add_argument(
         "--force",
         action="store_true",
         help="Forcibly recover the card, even if sanity checks pass",
     )
-    parser.add_argument(
-        "--no-prompt",
-        action="store_true",
-        help="Don't prompt for adapter if multiple are found",
-    )
+    pyocd_utils.add_common_args(parser, verbose=False)
     return parser.parse_args()
 
 


### PR DESCRIPTION
Continuation of #1038 

Adds a manufacturing-test job to the HW Soak workflow that validates the full manufacturing flash and boot sequence on Blackhole boards.

tests:
- `run-manufacturing-test.sh` passes when run locally on p150a (with artifact assets downloaded)
- Passes in CI on p100a, p150a and p300a on when run as part of long-tests

resolves: SYS-2854