### PR TITLE
lib: bh_arc: KMD log

### DIFF
--- a/doc/services/index.rst
+++ b/doc/services/index.rst
@@ -7,6 +7,7 @@ Firmware Services
    :maxdepth: 1
 
    binary_descriptors/index.rst
+   kmd_logging/index.rst
    tracing/index.rst
    telemetry/index.rst
    runtime_telemetry/index.rst

--- a/doc/services/kmd_logging/index.rst
+++ b/doc/services/kmd_logging/index.rst
@@ -1,0 +1,167 @@
+.. _ttfw_kmd_logging:
+
+KMD Logging Mechanism
+=====================
+
+This page describes how firmware log records are forwarded to the host kernel
+module (KMD) through the ``tt_pcie_log`` backend.
+
+Overview
+--------
+
+The mechanism has two paths:
+
+1. Control path: KMD sends setup and release messages over the ARC message queue
+   (message ID ``TT_SMC_MSG_TT_PCIE_LOG`` / ``0xC7``).
+2. Data path: firmware writes framed log batches into a host DMA buffer and
+   raises a PCIe MSI interrupt so KMD can consume them.
+
+On firmware side, the implementation lives in
+``lib/tenstorrent/bh_arc/tt_pcie_log.c`` and is enabled by
+``CONFIG_TT_PCIE_LOG_BACKEND``.
+
+If the CONFIG is not enabled, FW logs will not be sent to host, but FW will enumerate and operate.
+Other logging backends may be used in conjunction with this backend.
+
+Handshake: Setup And Release
+----------------------------
+
+KMD uses sub-commands in ``tt_pcie_log_rqst``:
+
+``SETUP`` (subcmd ``1``): KMD allocates a coherent DMA buffer and sends DMA
+address (low/high 32-bit words) plus buffer size to firmware. Firmware
+validates size, configures NOC2AXI access, initializes the header, and starts
+periodic flush.
+
+``RELEASE`` (subcmd ``2``): KMD asks firmware to stop host logging. Firmware
+stops the flush timer and returns to local buffering only.
+
+If host is not set up, firmware still formats logs into a local staging buffer.
+Once setup succeeds, subsequent flushes transfer staged data to host memory.
+
+Shared Buffer Contract
+----------------------
+
+Firmware and KMD must agree on these packed headers:
+
+.. list-table:: Buffer Metadata (16 bytes)
+   :header-rows: 1
+   :widths: 20 12 12 56
+
+   * - Field
+     - Type
+     - Size
+     - Meaning
+   * - ``write_offset``
+     - ``uint32_t``
+     - 4
+     - End offset of valid payload bytes in the shared buffer.
+   * - ``buffer_size``
+     - ``uint32_t``
+     - 4
+     - Total host DMA buffer size in bytes.
+   * - ``magic``
+     - ``uint32_t``
+     - 4
+     - Constant ``0x544C4F47`` ("TLOG") for contract validation.
+   * - ``owner``
+     - ``uint8_t``
+     - 1
+     - Ownership byte: ``0`` = FW owns buffer, ``1`` = host owns buffer.
+   * - ``version``
+     - ``uint8_t``
+     - 1
+     - The version of the messaging protocol. Fw currently only supports Version 0.
+   * - ``reserved``
+     - ``uint8_t[2]``
+     - 2
+     - Reserved padding for future use.
+
+.. list-table:: Entry Header (12 bytes)
+   :header-rows: 1
+   :widths: 20 12 12 56
+
+   * - Field
+     - Type
+     - Size
+     - Meaning
+   * - ``msg_size``
+     - ``uint16_t``
+     - 2
+     - Total entry size (entry header + payload). Payload includes a trailing
+       ``\0`` byte.
+   * - ``log_level``
+     - ``uint8_t``
+     - 1
+     - Zephyr log level of the message.
+   * - ``source``
+     - ``uint8_t``
+     - 1
+     - Message source: ``0`` = SMC, ``1`` = DMC.
+   * - ``timestamp``
+     - ``uint32_t``
+     - 4
+     - Firmware timestamp captured for the log entry.
+   * - ``sequence``
+     - ``uint32_t``
+     - 4
+     - Monotonic sequence number used for gap detection.
+
+Payload bytes follow each entry header and are emitted by Zephyr's log output
+formatter in text mode. Firmware appends a trailing ``\0`` to each payload for
+host-side C-string consumers; this NUL byte is included in ``msg_size``.
+
+
+Data Flow
+---------
+
+1. Zephyr logging calls the backend ``process`` callback for each message.
+2. Firmware writes an entry header plus formatted text into a local framed
+   buffer.
+3. Flush occurs periodically (timer + work queue) or when near local capacity.
+4. During flush:
+   - firmware validates host ``magic``
+   - firmware checks ``owner`` is ``0`` (previous batch consumed)
+   - firmware copies bytes to host DMA buffer after the 16-byte buffer header
+   - firmware updates ``write_offset``
+   - firmware sets ``owner = 1`` (handoff to host)
+   - firmware triggers MSI so KMD can process promptly
+5. KMD interrupt handler schedules work, parses entries, prints them to kernel
+   log with level mapping, then clears ``owner`` back to ``0``.
+
+Current Behavior Notes
+----------------------
+
+- Firmware batches data and sends only when host is ready.
+- If host has not yet consumed the previous batch, firmware drops the pending
+  local batch for forward progress.
+- If local staged data exceeds available host payload space, firmware truncates
+  to fit.
+- Data is currently copied as a contiguous batch (not a true host-side circular
+  producer/consumer protocol yet).
+
+Configuration
+-------------
+
+Relevant Kconfig options:
+
+- ``CONFIG_TT_PCIE_LOG_BACKEND``: enable host logging backend.
+- ``CONFIG_TT_PCIE_LOG_BACKEND_BUFFER_SIZE``: local firmware staging size
+  (default ``4096`` bytes).
+
+This backend uses Zephyr text formatting. Other formatters are not supported.
+
+Minimum practical requirement for setup is host buffer size >=
+``sizeof(fw_log_buffer_header) + sizeof(fw_log_entry_header) + 1``.
+
+Troubleshooting
+---------------
+
+- Setup rejected by firmware: check host-provided buffer size and DMA address
+  validity.
+- No host logs appearing: ensure ``CONFIG_TT_PCIE_LOG_BACKEND=y`` in firmware
+  build and confirm KMD successfully sent setup message and enabled logging.
+- Gaps or dropped records: if host processing is slower than firmware
+  production, batches can be dropped by design. Reduce firmware log volume or
+  increase host consumption responsiveness.
+- Ensure the KMD version supports the feature

--- a/include/tenstorrent/msgqueue.h
+++ b/include/tenstorrent/msgqueue.h
@@ -910,6 +910,36 @@ struct confirm_flashed_spi_rqst {
 	uint32_t challenge_data;
 };
 
+/** @brief Host request to setup/release FW logging
+ * @details Messages of this type are processed by the logging handler.
+ *
+ * For SETUP sub-command, buffer_addr_lo/hi specify the host DMA buffer IOVA
+ * and buffer_size specifies the size in bytes. For RELEASE sub-command,
+ * only subcmd is used - other fields are ignored.
+ */
+struct tt_pcie_log_rqst {
+	/** @brief The command code corresponding to @ref TT_SMC_MSG_TT_PCIE_LOG */
+	uint8_t command_code;
+
+	/** @brief tt_pcie_log sub-command: 1=SETUP, 2=RELEASE */
+	uint8_t subcmd;
+
+	/** @brief Host version for tt_pcie_log protocol (for SETUP) */
+	uint8_t version;
+
+	/** @brief One byte of padding */
+	uint8_t pad;
+
+	/** @brief Lower 32 bits of host buffer IOVA (for SETUP) */
+	uint32_t buffer_addr_lo;
+
+	/** @brief Upper 32 bits of host buffer IOVA (for SETUP) */
+	uint32_t buffer_addr_hi;
+
+	/** @brief Buffer size in bytes (for SETUP) */
+	uint32_t buffer_size;
+};
+
 /** @brief A tenstorrent host request*/
 union request {
 	/** @brief The interpretation of the request as an array of uint32_t entries*/
@@ -1035,6 +1065,9 @@ union request {
 
 	/** @brief A confirm SPI flash request */
 	struct confirm_flashed_spi_rqst confirm_flashed_spi;
+
+	/** @brief A tt_pcie_log setup/release request */
+	struct tt_pcie_log_rqst tt_pcie_log;
 };
 
 /** @} */

--- a/include/tenstorrent/smc_msg.h
+++ b/include/tenstorrent/smc_msg.h
@@ -165,6 +165,9 @@ enum tt_smc_msg {
 
 	/** @brief @ref characterisation_rqst "Generic characterization message" */
 	TT_SMC_MSG_CHARACTERISATION = 0xC6,
+
+	/** @brief @ref tt_pcie_log_rqst "FW logging setup/release request" */
+	TT_SMC_MSG_TT_PCIE_LOG = 0xC7,
 };
 
 /** @brief Enumeration of characterization submessage IDs */

--- a/lib/tenstorrent/bh_arc/CMakeLists.txt
+++ b/lib/tenstorrent/bh_arc/CMakeLists.txt
@@ -27,6 +27,7 @@ zephyr_library_sources(
   noc2axi.c
   noc_init.c
   pcie.c
+  pcie_msi.c
   pll.c
   post_code.c
   reset.c
@@ -54,6 +55,8 @@ if(CONFIG_BH_FWTABLE)
   zephyr_library_add_dependencies(nanopb_generated_headers)
 endif()
 
+zephyr_library_sources_ifdef(CONFIG_TT_PCIE_LOG_BACKEND tt_pcie_log.c)
+
 zephyr_linker_sources(DATA_SECTIONS iterables.ld)
 if(CONFIG_ARC)
   zephyr_library_link_libraries(${ZEPHYR_CURRENT_MODULE_DIR}/zephyr/blobs/tt_blackhole_libpciesd.a)
@@ -75,7 +78,6 @@ if(NOT CONFIG_TT_SMC_RECOVERY)
     gddr.c
     i2c_messages.c
     pcie_dma.c
-    pcie_msi.c
     pvt.c
     regulator.c
     regulator_config.c

--- a/lib/tenstorrent/bh_arc/Kconfig
+++ b/lib/tenstorrent/bh_arc/Kconfig
@@ -27,7 +27,7 @@ config TT_BH_ARC_EMUL
 
 config TT_BH_ARC_NUM_MSG_CODES
 	int "Number of message codes"
-	default 199
+	default 200
 	help
 	  The number of message codes
 
@@ -113,5 +113,7 @@ config TT_BH_ARC_DMFW_PING_TIMEOUT
 module = BH_ARC
 module-str = bh_arc
 source "subsys/logging/Kconfig.template.log_config"
+
+rsource "Kconfig.tt_pcie_log"
 
 endif

--- a/lib/tenstorrent/bh_arc/Kconfig.tt_pcie_log
+++ b/lib/tenstorrent/bh_arc/Kconfig.tt_pcie_log
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+if LOG
+
+config TT_PCIE_LOG_BACKEND
+	bool "Enable Tenstorrent Host tt_pcie_log backend"
+	depends on !LOG_MODE_IMMEDIATE
+	select LOG_OUTPUT
+	help
+	  Enable tt_pcie_log backend that outputs logs to shared host memory buffer
+	  via DMA for kernel module consumption. When host is not available,
+	  logs are stored in local buffer and transferred when host connects.
+
+if TT_PCIE_LOG_BACKEND
+
+config TT_PCIE_LOG_BACKEND_BUFFER_SIZE
+	int "Local log buffer size in bytes"
+	default 4096
+	help
+	  Size of local buffer to aggregate logs into. Logs from this buffer
+	  are flushed on a timer, or when approaching capacity, and only if the
+	  host has messaged FW the buffer is available.
+
+endif # TT_PCIE_LOG_BACKEND
+
+endif # LOG

--- a/lib/tenstorrent/bh_arc/asic_state.c
+++ b/lib/tenstorrent/bh_arc/asic_state.c
@@ -7,6 +7,7 @@
 #include "asic_state.h"
 
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <tenstorrent/smc_msg.h>
 #include <tenstorrent/msgqueue.h>
 
@@ -14,11 +15,14 @@
 #include "aiclk_ppm.h"
 #include "voltage.h"
 
+LOG_MODULE_REGISTER(asic_state, CONFIG_LOG_DEFAULT_LEVEL);
+
 uint8_t asic_state = A0State;
 
 static void enter_state0(void)
 {
 	asic_state = A0State;
+	LOG_INF("ASIC entering A0 state (active)");
 }
 
 static void enter_state3(void)
@@ -28,12 +32,14 @@ static void enter_state3(void)
 	ForceVdd(750);
 #endif
 	asic_state = A3State;
+	LOG_INF("ASIC entering A3 state (low power)");
 }
 
 /* May be called from ISR. */
 void lock_down_for_reset(void)
 {
 	asic_state = A3State;
+	LOG_ERR("System locked down for reset");
 
 	/* More could be done here. We can shut down everything except the SMBus slave */
 	/* (and the I2C code it relies on). */

--- a/lib/tenstorrent/bh_arc/bh_power.c
+++ b/lib/tenstorrent/bh_arc/bh_power.c
@@ -123,7 +123,7 @@ static uint8_t power_setting_msg_handler(const union request *request, struct re
 	const struct power_setting_rqst *power_setting = &request->power_setting;
 
 	apply_power_settings(power_setting);
-	LOG_INF("Power State: GDDR-%u Tensix-%u AICLK-%u, L2CPU-%u",
+	LOG_DBG("Power State: GDDR-%u Tensix-%u AICLK-%u, L2CPU-%u",
 		power_state[BH_POWER_DOMAIN_MRISC], power_state[BH_POWER_DOMAIN_TENSIX],
 		power_state[BH_POWER_DOMAIN_AICLK], power_state[BH_POWER_DOMAIN_L2CPU]);
 

--- a/lib/tenstorrent/bh_arc/pcie_msi.c
+++ b/lib/tenstorrent/bh_arc/pcie_msi.c
@@ -61,7 +61,7 @@ void SendPcieMsi(uint8_t pcie_inst, uint32_t vector_id)
 		msi_data += vector_id;
 
 		const uint8_t ring = 0;
-		const uint8_t tlb_num = 0;
+		const uint8_t tlb_num = 12;
 		const uint8_t x = pcie_inst == 0 ? PCIE_INST0_LOGICAL_X : PCIE_INST1_LOGICAL_X;
 		const uint8_t y = PCIE_LOGICAL_Y;
 

--- a/lib/tenstorrent/bh_arc/pcie_msi.c
+++ b/lib/tenstorrent/bh_arc/pcie_msi.c
@@ -42,7 +42,7 @@ uint32_t GetVectorsAllowed(uint32_t mult_msg_en)
 	return 1 << mult_msg_en;
 }
 
-void SendPcieMsi(uint8_t pcie_inst, uint32_t vector_id)
+void SendPcieMsi(uint8_t x, uint8_t y, uint32_t vector_id)
 {
 	BH_PCIE_DWC_PCIE_USP_PF0_MSI_CAP_HDL_PATH_E982B20F_PCI_MSI_CAP_ID_NEXT_CTRL_REG_reg_u
 		pci_msi_cap;
@@ -62,8 +62,6 @@ void SendPcieMsi(uint8_t pcie_inst, uint32_t vector_id)
 
 		const uint8_t ring = 0;
 		const uint8_t tlb_num = 12;
-		const uint8_t x = pcie_inst == 0 ? PCIE_INST0_LOGICAL_X : PCIE_INST1_LOGICAL_X;
-		const uint8_t y = PCIE_LOGICAL_Y;
 
 		NOC2AXITlbSetup(ring, tlb_num, x, y, msi_addr);
 		NOC2AXIWrite32(ring, tlb_num, msi_addr, msi_data);
@@ -89,7 +87,10 @@ static uint8_t send_pcie_msi_handler(const union request *request, struct respon
 	uint8_t pcie_inst = request->send_pci_msi.pcie_inst;
 	uint32_t vector_id = request->send_pci_msi.vector_id;
 
-	SendPcieMsi(pcie_inst, vector_id);
+	const uint8_t x = pcie_inst == 0 ? PCIE_INST0_LOGICAL_X : PCIE_INST1_LOGICAL_X;
+	const uint8_t y = PCIE_LOGICAL_Y;
+
+	SendPcieMsi(x, y, vector_id);
 	return 0;
 }
 

--- a/lib/tenstorrent/bh_arc/tt_pcie_log.c
+++ b/lib/tenstorrent/bh_arc/tt_pcie_log.c
@@ -1,0 +1,472 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/logging/log_backend.h>
+#include <zephyr/logging/log_output.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log_msg.h>
+#include <string.h>
+#include <tenstorrent/smc_msg.h>
+#include <tenstorrent/msgqueue.h>
+#include <zephyr/logging/log_backend_std.h>
+
+#include "chip_info.h"
+#include "noc2axi.h"
+
+/* Forward declaration for PCIe MSI function */
+void SendPcieMsi(uint8_t pcie_inst, uint32_t vector_id);
+
+LOG_MODULE_REGISTER(fw_tt_pcie_log_backend, CONFIG_LOG_DEFAULT_LEVEL);
+
+/* tt_pcie_log sub-commands */
+#define TT_PCIE_LOG_SUBCMD_SETUP   1
+#define TT_PCIE_LOG_SUBCMD_RELEASE 2
+
+/* Log entry header structure (must match KMD definition) */
+struct fw_log_entry_header {
+	uint16_t msg_size;  /* Size of log message including header */
+	uint8_t log_level;  /* FW log level */
+	uint8_t source;     /* 0=SMC, 1=DMC */
+	uint32_t timestamp; /* FW timestamp in milliseconds */
+	uint32_t sequence;  /* Sequence number */
+} __packed;
+
+/* Buffer header at start of shared buffer (must match KMD definition) */
+struct fw_log_buffer_header {
+	uint32_t write_offset; /* Current write position */
+	uint32_t buffer_size;  /* Total buffer size */
+	uint32_t magic;        /* Magic number for validation */
+	uint8_t owner;         /* Buffer owner: FW or host */
+	uint8_t version;       /* FW max supported version */
+	uint8_t reserved[2];   /* Future use */
+} __packed;
+
+#define FW_LOG_SOURCE_SMC 0
+#define FW_LOG_SOURCE_DMC 1
+
+#define FW_LOG_BUFFER_MAGIC      0x544C4F47 /* "TLOG" */
+#define FW_LOG_BUFFER_OWNER_FW   0x0        /* Firmware owns buffer, host has consumed */
+#define FW_LOG_BUFFER_OWNER_HOST 0x1        /* Host owns buffer, firmware has produced data */
+#define FLUSH_THRESHOLD_BYTES    (sizeof(struct fw_log_entry_header) + 256)
+
+/* Static variables to track tt_pcie_log state */
+static bool host_available; /* True when host buffer is set up */
+static uint64_t log_buffer_iova;
+static uint32_t log_buffer_size;
+static uint32_t sequence_number;
+
+#define TT_PCIE_LOG_TLB 11
+
+/* NOC2AXI TLB configuration for direct host memory access */
+#define PCIE_X 19
+#define PCIE_Y 24
+
+static void flush_buffer_to_host(void);
+
+/* Buffer for accumulating framed log entries before host transmission */
+static uint8_t framed_log_buffer[CONFIG_TT_PCIE_LOG_BACKEND_BUFFER_SIZE];
+static uint32_t framed_buffer_pos; /* Current write position in framed buffer */
+
+/* Timer for periodic buffer flushing */
+static struct k_timer flush_timer;
+
+/* Work item for buffer flushing */
+static struct k_work flush_work;
+
+/* Mutex to protect framed_log_buffer access between backend and timer */
+static struct k_mutex buffer_mutex;
+
+/**
+ * @brief Work handler to flush framed buffer to host
+ * @param work Work item (unused)
+ */
+static void flush_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+	/* Lock mutex to prevent collision with backend_process */
+	if (k_mutex_lock(&buffer_mutex, K_MSEC(100)) != 0) {
+		/* Timeout - skip this flush cycle */
+		return;
+	}
+
+	flush_buffer_to_host();
+
+	k_mutex_unlock(&buffer_mutex);
+}
+
+/**
+ * @brief Timer callback to submit flush work
+ * @param timer Timer object (unused)
+ */
+static void flush_timer_callback(struct k_timer *timer)
+{
+	ARG_UNUSED(timer);
+	/* Submit work item to system work queue */
+	k_work_submit(&flush_work);
+}
+
+/**
+ * @brief Setup host tt_pcie_log by configuring NOC2AXI TLB and transferring local buffer
+ * @param buffer_addr_lo Lower 32 bits of host buffer IOVA
+ * @param buffer_addr_hi Upper 32 bits of host buffer IOVA
+ * @param buffer_size Size of buffer in bytes
+ * @param host_version Host version for tt_pcie_log protocol
+ * @return 0 on success, error code on failure
+ */
+static uint8_t setup_tt_pcie_log_backend(uint32_t buffer_addr_lo, uint32_t buffer_addr_hi,
+					 uint32_t buffer_size, uint8_t host_version)
+{
+	if (buffer_size <
+	    sizeof(struct fw_log_buffer_header) + sizeof(struct fw_log_entry_header) + 1) {
+		LOG_ERR("Host buffer too small: %u bytes", buffer_size);
+		return 1; /* EPERM - buffer too small */
+	}
+
+	/* Lock mutex to prevent collision with backend_process */
+	int res = k_mutex_lock(&buffer_mutex, K_MSEC(100));
+
+	if (res != 0) {
+		/* Timeout - skip this flush cycle */
+		return res;
+	}
+
+	struct fw_log_buffer_header header;
+	uint64_t new_buffer_iova = ((uint64_t)buffer_addr_hi << 32) | buffer_addr_lo;
+
+	if (host_available) {
+		LOG_INF("Host tt_pcie_log re-setup: old=0x%llx, new=0x%llx", log_buffer_iova,
+			new_buffer_iova);
+	}
+
+	/* Update to new buffer (could be same address if host reused buffer) */
+	log_buffer_iova = new_buffer_iova;
+	log_buffer_size = buffer_size;
+
+	/* Setup NOC2AXI TLB mapping for host memory access. */
+	uint8_t noc2axi_tlb = TT_PCIE_LOG_TLB;
+
+	NOC2AXITlbSetup(0, noc2axi_tlb, PCIE_X, PCIE_Y, log_buffer_iova);
+
+	/* Initialize buffer header */
+	header.write_offset = sizeof(struct fw_log_buffer_header);
+	header.buffer_size = buffer_size;
+	header.magic = FW_LOG_BUFFER_MAGIC;
+	header.owner = FW_LOG_BUFFER_OWNER_FW;
+	header.version = 0; /* The only version FW supports, currently */
+	header.reserved[0] = 0;
+	header.reserved[1] = 0;
+
+	/* Write header to start of buffer */
+	NOC2AXIWrite32(0, noc2axi_tlb, log_buffer_iova + 0, header.write_offset);
+	NOC2AXIWrite32(0, noc2axi_tlb, log_buffer_iova + 4, header.buffer_size);
+	NOC2AXIWrite32(0, noc2axi_tlb, log_buffer_iova + 8, header.magic);
+	/* owner at offset 12, version at offset 13 */
+	NOC2AXIWrite32(0, noc2axi_tlb, log_buffer_iova + 12,
+		       (FW_LOG_BUFFER_OWNER_FW) | ((uint32_t)header.version << 8));
+
+	/* Mark host as available */
+	host_available = true;
+
+	/* Initialize timer */
+	k_timer_start(&flush_timer, K_SECONDS(1), K_SECONDS(1));
+
+	k_mutex_unlock(&buffer_mutex);
+
+	LOG_INF("Host tt_pcie_log enabled: buffer=0x%llx, size=%u bytes", log_buffer_iova,
+		buffer_size);
+	return 0;
+}
+
+/**
+ * @brief Release host tt_pcie_log and revert to local buffer only
+ * @return 0 on success
+ */
+static uint8_t release_tt_pcie_log_backend(void)
+{
+	if (!host_available) {
+		LOG_WRN("Host tt_pcie_log not enabled, ignoring release request");
+		return 0; /* Not enabled, not an error */
+	}
+
+	int res = k_mutex_lock(&buffer_mutex, K_MSEC(100));
+
+	if (res != 0) {
+		/* Timeout - skip this flush cycle */
+		return res;
+	}
+	/* Stop the flush timer */
+	k_timer_stop(&flush_timer);
+
+	host_available = false;
+	log_buffer_iova = 0;
+	log_buffer_size = 0;
+	k_mutex_unlock(&buffer_mutex);
+
+	LOG_INF("Host tt_pcie_log disabled - reverting to local buffer");
+	return 0;
+}
+
+/**
+ * @brief Flush accumulated framed messages to host
+ */
+static void flush_buffer_to_host(void)
+{
+	uint32_t owner_word;
+	uint32_t magic_value;
+
+	if (framed_buffer_pos == 0 || !host_available) {
+		return; /* Nothing to flush or host not available */
+	}
+
+	/* Setup NOC2AXI TLB for host memory access. */
+	uint8_t noc2axi_tlb = TT_PCIE_LOG_TLB;
+
+	NOC2AXITlbSetup(0, noc2axi_tlb, PCIE_X, PCIE_Y, log_buffer_iova);
+
+	/* Check buffer magic number first - if corrupted, don't proceed */
+	magic_value = NOC2AXIRead32(0, noc2axi_tlb, log_buffer_iova + 8);
+	if (magic_value != FW_LOG_BUFFER_MAGIC) {
+		/* Buffer corrupted or invalid, reset position and return */
+		framed_buffer_pos = 0;
+		return;
+	}
+
+	/* Check buffer ownership before writing new data */
+	owner_word = NOC2AXIRead32(0, noc2axi_tlb, log_buffer_iova + 12);
+	if ((owner_word & 0xFF) == FW_LOG_BUFFER_OWNER_HOST) {
+		/* Host hasn't processed previous data yet, drop this batch */
+		framed_buffer_pos = 0;
+		return;
+	}
+
+	/* Write entire framed buffer to host starting after header */
+	uint32_t write_addr = log_buffer_iova + sizeof(struct fw_log_buffer_header);
+	/*
+	 * Clamp the amount we're writing to the available host log buffer data space
+	 * (total buffer size minus header size). We should look into doing this better,
+	 * e.g. as a ring buffer of framed messages, we could later send the additional buffer
+	 *
+	 * In practice, expectation is that FW buffer size is less than or equal to host's.
+	 */
+	uint32_t available_host_space = log_buffer_size - sizeof(struct fw_log_buffer_header);
+	uint32_t bytes_to_write = MIN(framed_buffer_pos, available_host_space);
+
+	/* Write in 32-bit word chunks for efficiency */
+	for (uint32_t i = 0; i < bytes_to_write; i += 4) {
+		uint32_t word_data = 0;
+		uint32_t bytes_to_copy = MIN(4, bytes_to_write - i);
+
+		/* Pack up to 4 bytes into a 32-bit word */
+		memcpy(&word_data, &framed_log_buffer[i], bytes_to_copy);
+		NOC2AXIWrite32(0, noc2axi_tlb, write_addr + i, word_data);
+	}
+
+	/* Update write_offset to reflect data size */
+	uint32_t new_write_offset = sizeof(struct fw_log_buffer_header) + bytes_to_write;
+
+	NOC2AXIWrite32(0, noc2axi_tlb, log_buffer_iova + 0, new_write_offset);
+
+	/* Hand ownership to host to indicate new data is ready */
+	NOC2AXIWrite32(0, noc2axi_tlb, log_buffer_iova + 12, FW_LOG_BUFFER_OWNER_HOST);
+
+	/* Trigger interrupt to notify host of new data */
+	SendPcieMsi(0, 0);
+
+	/* Reset framed buffer after successful write */
+	framed_buffer_pos = 0;
+}
+
+/**
+ * @brief Character output function for Zephyr log formatting - writes directly to 4KB buffer
+ * @param data Data to append to framed log buffer
+ * @param length Length of data
+ * @param ctx Context (unused)
+ * @return Length processed
+ */
+static int putc_in_frame(uint8_t *data, size_t length, void *ctx)
+{
+	ARG_UNUSED(ctx);
+
+	/*
+	 * Keep one byte reserved for explicit NUL termination that backend_process()
+	 * appends after formatting each message.
+	 */
+	size_t available = sizeof(framed_log_buffer) - framed_buffer_pos;
+	size_t bytes_to_copy = (available > 1) ? MIN(length, available - 1) : 0;
+
+	if (bytes_to_copy > 0) {
+		memcpy(framed_log_buffer + framed_buffer_pos, data, bytes_to_copy);
+		framed_buffer_pos += bytes_to_copy;
+	}
+
+	/*
+	 * log_output_write() expects forward progress. If we return 0 while input
+	 * remains, it loops forever. Any bytes that do not fit are intentionally
+	 * dropped.
+	 */
+	return length;
+}
+
+static char buf[1];
+LOG_OUTPUT_DEFINE(log_output_tt_pcie, putc_in_frame, buf, 1);
+
+/**
+ * @brief Zephyr log backend process function - called for each individual log message
+ * @param backend The backend instance
+ * @param msg The log message to process
+ */
+static void backend_process(const struct log_backend *const backend, union log_msg_generic *msg)
+{
+	ARG_UNUSED(backend);
+	struct fw_log_entry_header entry_header;
+	uint32_t flags;
+	log_format_func_t log_output_func;
+	uint32_t entry_start_pos;
+	uint32_t message_start_pos;
+
+	/* Lock mutex to prevent collision with flush timer */
+	if (k_mutex_lock(&buffer_mutex, K_MSEC(10)) != 0) {
+		/* Timeout - drop this data */
+		sequence_number++;
+		return;
+	}
+
+	/* Check if we need to flush buffer for space */
+	if (framed_buffer_pos + FLUSH_THRESHOLD_BYTES > sizeof(framed_log_buffer)) {
+		flush_buffer_to_host();
+	}
+
+	/* Verify there's enough space for at least the header after flush */
+	if (framed_buffer_pos + sizeof(entry_header) + 1 > sizeof(framed_log_buffer)) {
+		/* Not enough space even for header - drop this message */
+		sequence_number++;
+		k_mutex_unlock(&buffer_mutex);
+		return;
+	}
+
+	/* Mark where this entry starts */
+	entry_start_pos = framed_buffer_pos;
+
+	/* Create header and reserve space for it */
+	entry_header.msg_size = 0; /* Will be updated after formatting */
+	entry_header.log_level = log_msg_get_level(&msg->log);
+	entry_header.source = FW_LOG_SOURCE_SMC;
+	entry_header.timestamp = msg->log.hdr.timestamp;
+	entry_header.sequence = sequence_number++;
+
+	/* Write header to buffer and advance position */
+	memcpy(framed_log_buffer + framed_buffer_pos, &entry_header, sizeof(entry_header));
+	framed_buffer_pos += sizeof(entry_header);
+	message_start_pos = framed_buffer_pos;
+
+	/* Use Zephyr's log formatting system to write directly into framed_log_buffer */
+	flags = log_backend_std_get_flags();
+	log_output_func = log_format_func_t_get(LOG_OUTPUT_TEXT);
+	log_output_func(&log_output_tt_pcie, &msg->log, flags);
+
+	/* Explicitly NUL-terminate for host-side C-string consumers. */
+	framed_log_buffer[framed_buffer_pos++] = '\0';
+
+	/* Calculate actual sizes and update header */
+	uint32_t message_len = framed_buffer_pos - message_start_pos;
+	uint32_t total_size = sizeof(entry_header) + message_len;
+	uint16_t total_size_u16 = (uint16_t)total_size;
+
+	memcpy(framed_log_buffer + entry_start_pos, &total_size_u16, sizeof(total_size_u16));
+	k_mutex_unlock(&buffer_mutex);
+}
+
+/**
+ * @brief Zephyr log backend panic function - called when system panics
+ * @param backend The backend instance
+ */
+static void backend_panic(const struct log_backend *const backend)
+{
+	ARG_UNUSED(backend);
+
+	/* Try to acquire mutex with a short timeout during panic */
+	if (k_mutex_lock(&buffer_mutex, K_MSEC(10)) == 0) {
+		flush_buffer_to_host();
+		k_mutex_unlock(&buffer_mutex);
+	}
+	/* If mutex lock fails during panic, skip flush to avoid further issues */
+}
+
+/**
+ * @brief Zephyr log backend dropped function - called when messages are dropped
+ * @param backend The backend instance
+ * @param cnt Number of dropped messages
+ */
+static void backend_dropped(const struct log_backend *const backend, uint32_t cnt)
+{
+	ARG_UNUSED(backend);
+	ARG_UNUSED(cnt);
+}
+
+/**
+ * @brief Initialize the Zephyr log backend
+ * @param backend The backend instance
+ */
+static void backend_init(const struct log_backend *const backend)
+{
+	ARG_UNUSED(backend);
+
+	k_mutex_init(&buffer_mutex);
+	k_work_init(&flush_work, flush_work_handler);
+	k_timer_init(&flush_timer, flush_timer_callback, NULL);
+}
+
+/**
+ * @brief Handles the request to setup or release FW tt_pcie_log
+ * @param[in] request The request, of type @ref tt_pcie_log_rqst, with command code @ref
+ * TT_SMC_MSG_TT_PCIE_LOG
+ * @param[out] response The response to the host
+ * @return 0 for success, error code for failure
+ */
+static uint8_t tt_pcie_log_handler(const union request *request, struct response *response)
+{
+	ARG_UNUSED(response);
+	uint8_t result = 0;
+
+	if (!bh_chip_info_feature_noc_translation_en()) {
+		return 19; /* ENODEV */
+	}
+
+	switch (request->tt_pcie_log.subcmd) {
+	case TT_PCIE_LOG_SUBCMD_SETUP:
+		result = setup_tt_pcie_log_backend(
+			request->tt_pcie_log.buffer_addr_lo, request->tt_pcie_log.buffer_addr_hi,
+			request->tt_pcie_log.buffer_size, request->tt_pcie_log.version);
+		break;
+
+	case TT_PCIE_LOG_SUBCMD_RELEASE:
+		result = release_tt_pcie_log_backend();
+		break;
+
+	default:
+		LOG_ERR("Unknown tt_pcie_log sub-command: %u", request->tt_pcie_log.subcmd);
+		result = 22; /* EINVAL - invalid argument */
+		break;
+	}
+
+	return result;
+}
+
+/* Define the Zephyr log backend API */
+static struct log_backend_api backend_api = {
+	.process = backend_process,
+	.panic = backend_panic,
+	.init = backend_init,
+	.dropped = backend_dropped,
+};
+
+/* Register the message handler for tt_pcie_log commands */
+REGISTER_MESSAGE(TT_SMC_MSG_TT_PCIE_LOG, tt_pcie_log_handler);
+
+/* Define and initialize the log backend - always enabled */
+LOG_BACKEND_DEFINE(backend_tt_pcie_log, backend_api, true);

--- a/lib/tenstorrent/bh_arc/tt_pcie_log.c
+++ b/lib/tenstorrent/bh_arc/tt_pcie_log.c
@@ -19,7 +19,7 @@
 #include "noc2axi.h"
 
 /* Forward declaration for PCIe MSI function */
-void SendPcieMsi(uint8_t pcie_inst, uint32_t vector_id);
+void SendPcieMsi(uint8_t x, uint8_t y, uint32_t vector_id);
 
 LOG_MODULE_REGISTER(fw_tt_pcie_log_backend, CONFIG_LOG_DEFAULT_LEVEL);
 
@@ -275,7 +275,7 @@ static void flush_buffer_to_host(void)
 	NOC2AXIWrite32(0, noc2axi_tlb, log_buffer_iova + 12, FW_LOG_BUFFER_OWNER_HOST);
 
 	/* Trigger interrupt to notify host of new data */
-	SendPcieMsi(0, 0);
+	SendPcieMsi(PCIE_X, PCIE_Y, 0);
 
 	/* Reset framed buffer after successful write */
 	framed_buffer_pos = 0;

--- a/tests/lib/tenstorrent/bh_arc/src/msgqueue.c
+++ b/tests/lib/tenstorrent/bh_arc/src/msgqueue.c
@@ -29,6 +29,9 @@
 /* Custom fake for ReadReg to simulate timer progression */
 #define RESET_UNIT_REFCLK_CNT_LO_REG_ADDR         0x800300E0
 #define PLL_CNTL_WRAPPER_CLOCK_WAVE_CNTL_REG_ADDR 0x80020038
+#define ARC_NOC0_TLB_BASE_ADDR                    0xC0000000U
+#define ARC_NOC1_TLB_BASE_ADDR                    0xE0000000U
+#define ARC_NOC_TLB_WINDOW_SPAN                   0x10000000U
 static uint32_t timer_counter;
 static uint8_t i2c_read_buf_emul[256] = {0};
 static uint8_t i2c_read_buf_idx;
@@ -192,7 +195,10 @@ static void WriteReg_msgqueue_fake(uint32_t addr, uint32_t value)
 		clock_wave_value = value;
 	}
 
-	if (addr == 0xC0000000) {
+	if ((addr >= ARC_NOC0_TLB_BASE_ADDR &&
+	     addr < ARC_NOC0_TLB_BASE_ADDR + ARC_NOC_TLB_WINDOW_SPAN) ||
+	    (addr >= ARC_NOC1_TLB_BASE_ADDR &&
+	     addr < ARC_NOC1_TLB_BASE_ADDR + ARC_NOC_TLB_WINDOW_SPAN)) {
 		noc_2_axi_last_write = value;
 	}
 }


### PR DESCRIPTION
note: This PR does not turn on, or compile in, the KMD log by default. 

This is mostly to get early eyes on this @afongTT @slindsayTT @joelsmithTT @alewycky-tenstorrent 

This adds support for a "KMD PCIE" logging backend via Zephyr's logging infrastructure. KMD sends a message containing the pointer to the host allocated memory buffer to fill logs in. FW initializes header bytes in the buffer. 

FW logs to internal buffer on log push (LOG_INF, LOG_ERR, etc.) logs are framed with metadata at this point.

On timer, or as we approach a full buffer, we  flush that buffer out to the host allocated buffer. We mark the buffer as host owned and interrupt it to process.

(host implementation is something like: loop through all the logs up to the amount the fw indicated, print them, once done mark the buffer as FW owned.) 

Notes:

Zephyr supports multiple logging backends running at once, so we don't lose tt-console logs unless we specifically compile them out.

Tests: (July 10th, 2026)

On a KMD with support for the new logging:

1. smoke
2. metal 3X upstream container tests
3. Verified err/warn/info logs ends up in the right severity in dmesg.

Issues:

1. I seem to occassionally drop the last log right after init. Host correctly resyncs on next push and notes the sequence mismatch
3. I have, on various iterations of this, seen crashes during metal. i'm not totally convinced i have resolved the issues, but I haven't seen them recently. I will continue trying to reproduce. Failure mode is such that a pcie_rescan.sh recovers the connection to the SMC. - _I have not seen this since the beginning of development._

Todo before this can go in IMO

1. Documentation (assuming this design is greenlit)
2. Stress (with supported driver)
3. Flushing logic needs cleanup
4. Galaxy testing

Future Todo:

1. logging sub cmd for enabling/disabling modules per log level.