### PR TITLE
.github: ci_boards: upgrade metal to v0.74

### DIFF
--- a/.github/ci_boards.json
+++ b/.github/ci_boards.json
@@ -10,7 +10,7 @@
     {
       "board": "p100a",
       "supports_smoke": true,
-      "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh:v0.68.0-dev20260317-16-gbb89a89897",
+      "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh:v0.74.0",
       "metal-target": "blackhole",
       "arch-name": "blackhole",
       "metal-options": "--cap-add SYS_MODULE --device /dev/tenstorrent --user=root",
@@ -19,7 +19,7 @@
     {
       "board": "p150a",
       "supports_smoke": true,
-      "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh:v0.68.0-dev20260317-16-gbb89a89897",
+      "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh:v0.74.0",
       "metal-target": "blackhole",
       "arch-name": "blackhole",
       "metal-options": "--cap-add SYS_MODULE --device /dev/tenstorrent --user=root",
@@ -28,7 +28,7 @@
     {
       "board": "p300a",
       "supports_smoke": true,
-      "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-p300:v0.68.0-dev20260317-16-gbb89a89897",
+      "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-p300:v0.74.0",
       "metal-target": "blackhole_p300",
       "arch-name": "blackhole",
       "metal-options": "--cap-add SYS_MODULE --device /dev/tenstorrent --user=root",
@@ -36,7 +36,7 @@
     },
     {
       "board": "quietbox2",
-      "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh:v0.68.0-dev20260317-16-gbb89a89897",
+      "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-qb-ge:v0.74.0",
       "metal-target": "blackhole_qb_ge",
       "arch-name": "blackhole",
       "metal-options": "--cap-add SYS_MODULE --device /dev/tenstorrent --user=root",
@@ -44,7 +44,7 @@
     },
     {
       "board": "loudbox",
-      "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh:v0.68.0-dev20260317-16-gbb89a89897",
+      "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-loudbox:v0.74.0",
       "metal-target": "blackhole_loudbox",
       "arch-name": "blackhole",
       "metal-options": "--cap-add SYS_MODULE --device /dev/tenstorrent --user=root",
@@ -52,7 +52,7 @@
     },
     {
       "board": "bh-galaxy",
-      "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx:v0.68.0-dev20260317-16-gbb89a89897",
+      "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx:v0.74.0",
       "metal-target": "blackhole_glx",
       "arch-name": "blackhole",
       "metal-options": "--cap-add SYS_MODULE --device /dev/tenstorrent --device /dev/ipmi0 --user=root",

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -82,12 +82,10 @@ jobs:
       - name: Set model env
         shell: bash
         run: |
-          if [[ "${{ matrix.config.board }}" == "p300a" ]]; then
-            echo "HF_MODEL=/opt/tenstorrent/hf-models/meta-llama/Llama-3.1-8B/" >> $GITHUB_ENV
-          elif [[ "${{ matrix.config.board }}" == "bh-galaxy" || "${{ matrix.config.board }}" == "loudbox" || "${{ matrix.config.board }}" == "quietbox2" ]]; then
-            echo "HF_MODEL=/opt/tenstorrent/hf-models/meta-llama/Llama-3.3-70B-Instruct/" >> $GITHUB_ENV
-            echo "LLAMA_DIR=/opt/tenstorrent/hf-models/meta-llama/Llama-3.3-70B-Instruct/" >> $GITHUB_ENV
-          fi
+          MODEL_DIR=/opt/tenstorrent/hf-models/meta-llama/Llama-3.1-8B-Instruct
+          test -d "$MODEL_DIR"
+          echo "HF_MODEL=$MODEL_DIR" >> "$GITHUB_ENV"
+          echo "LLAMA_DIR=$MODEL_DIR" >> "$GITHUB_ENV"
 
       - id: mkdir-home-user-tt-metal
         run: |
@@ -117,24 +115,6 @@ jobs:
             SEARCH="echo \"\[upstream-tests\] Running BH upstream didt tests\""
             INSERT="    pytest tests/didt/test_resnet_conv.py::test_resnet_conv -k \"all\" --didt-workload-iterations 100 --determinism-check-interval 0"
             sed -i "/$SEARCH/a$INSERT" dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
-          fi
-
-          # On loudbox/quietbox2 the upstream script hardcodes data_parallel_devices to the
-          # mesh size, which replicates the 70B weights on every device and OOMs. Force
-          # data_parallel=1 so the mesh is used as a single tensor-parallel group instead.
-          if [ "${{ matrix.config.board }}" == "loudbox" ] || [ "${{ matrix.config.board }}" == "quietbox2" ]; then
-            sed -i 's/--data_parallel "\$data_parallel_devices"/--data_parallel 1/g' \
-              dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
-            sed -i 's/-k "performance and ci-32" --data_parallel 1 --timeout 1200/-k "performance and ci-32" --data_parallel 1 --timeout 3600/' \
-              dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
-
-            # Bump every Llama-3.3-70B entry in trace_region_config.py to 128 MiB.
-            # tt_metal's conftest reads this dict and overrides the parametrized
-            # trace_region_size; the configured 80MB / 84MB values are too tight
-            # for the TP=8 / batch=32 / ci-32 trace on loudbox/quietbox2.
-            sed -i -E '/"Llama-3\.3-70B":/,/},/ s/(":[[:space:]]+)[0-9]+/\1134217728/' \
-              models/tt_transformers/demo/trace_region_config.py
-            sed -n '/"Llama-3\.3-70B":/,/},/p' models/tt_transformers/demo/trace_region_config.py
           fi
 
           # Patch tests to remove determinism checks, which are only reliable


### PR DESCRIPTION
Upgrade metal to v0.74

Also use 8B instead of 70B Llama model as 8B is faster and is sufficient
enough for our testing as confirmed by the Metal team.