### PR TITLE
lib: bh_arc: add gddr ctf feature

### DIFF
--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -217,6 +217,25 @@ static bool process_led_blink_request(struct bh_chip *chip, uint8_t msg_id, uint
 	return false;
 }
 
+static bool process_gddr_therm_trip(struct bh_chip *chip, uint8_t msg_id, uint32_t msg_data)
+{
+	switch (msg_data) {
+	case kGddrThermTripReasonInstantaneous:
+		LOG_ERR("GDDR thermal trip: instantaneous temp >= %dC",
+			GDDR_THERM_TRIP_CRITICAL_TEMP);
+		break;
+	case kGddrThermTripReasonSustained:
+		LOG_ERR("GDDR thermal trip: sustained temp >= %dC for %d minute(s)",
+			GDDR_THERM_TRIP_TEMP, GDDR_THERM_TRIP_DURATION_MIN);
+		break;
+	default:
+		LOG_ERR("GDDR thermal trip: unknown reason %u", msg_data);
+		break;
+	}
+
+	return false;
+}
+
 void process_cm2dm_message(struct bh_chip *chip)
 {
 	typedef bool (*msg_processor_t)(struct bh_chip *chip, uint8_t msg_id, uint32_t msg_data);
@@ -230,6 +249,7 @@ void process_cm2dm_message(struct bh_chip *chip)
 		[kCm2DmMsgIdAutoResetTimeoutUpdate] = process_auto_reset_timeout_update,
 		[kCm2DmMsgTelemHeartbeatUpdate] = process_heartbeat_update,
 		[kCm2DmMsgIdLedBlink] = process_led_blink_request,
+		[kCm2DmMsgIdGddrThermTrip] = process_gddr_therm_trip,
 	};
 
 	for (uint32_t i = 0U; i < kCm2DmMsgCount; i++) {

--- a/app/smc/src/main.c
+++ b/app/smc/src/main.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "cat.h"
 #include "cm2dm_msg.h"
 #include "dvfs.h"
 #include "fan_ctrl.h"
@@ -72,6 +73,7 @@ int main(void)
 		if (dvfs_enabled) {
 			StartDVFSTimer();
 		}
+		StartGddrThermTripMonitor();
 	}
 
 	Dm2CmReadyRequest();

--- a/include/tenstorrent/bh_arc.h
+++ b/include/tenstorrent/bh_arc.h
@@ -31,6 +31,11 @@ typedef enum {
 	kCm2DmResetLevelDmc = 3,
 } Cm2DmResetLevel;
 
+/* GDDR thermal trip thresholds */
+#define GDDR_THERM_TRIP_TEMP          95  /* sustained over-temp threshold, degrees Celsius */
+#define GDDR_THERM_TRIP_CRITICAL_TEMP 110 /* instantaneous trip threshold, degrees Celsius */
+#define GDDR_THERM_TRIP_DURATION_MIN  1   /* sustained dwell time before trip, minutes */
+
 typedef struct dmStaticInfo {
 	/*
 	 * Non-zero for valid data

--- a/include/tenstorrent/bh_arc.h
+++ b/include/tenstorrent/bh_arc.h
@@ -22,6 +22,7 @@ typedef enum {
 	kCm2DmMsgTelemHeartbeatUpdate = 6,
 	kCm2DmMsgIdForcedFanSpeedUpdate = 7,
 	kCm2DmMsgIdLedBlink = 8,
+	kCm2DmMsgIdGddrThermTrip = 9,
 	kCm2DmMsgCount
 } Cm2DmMsgId;
 
@@ -30,6 +31,12 @@ typedef enum {
 	kCm2DmResetLevelAsic = 0,
 	kCm2DmResetLevelDmc = 3,
 } Cm2DmResetLevel;
+
+/* Payload for kCm2DmMsgIdGddrThermTrip. */
+typedef enum {
+	kGddrThermTripReasonSustained = 0,
+	kGddrThermTripReasonInstantaneous = 1,
+} GddrThermTripReason;
 
 /* GDDR thermal trip thresholds */
 #define GDDR_THERM_TRIP_TEMP          95  /* sustained over-temp threshold, degrees Celsius */

--- a/lib/tenstorrent/bh_arc/cat.c
+++ b/lib/tenstorrent/bh_arc/cat.c
@@ -6,12 +6,14 @@
 
 #include "cat.h"
 #include "reg.h"
+#include "telemetry.h"
 #include "timer.h"
 
 #include <stdbool.h>
 
 #include <tenstorrent/post_code.h>
 #include <tenstorrent/sys_init_defines.h>
+#include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/init.h>
@@ -48,6 +50,8 @@ typedef union {
 } RESET_UNIT_CATMON_THERM_TRIP_CNTL_reg_u;
 
 #ifndef CONFIG_TT_SMC_RECOVERY
+
+static const int gddr_therm_trip_interval = 100;
 
 static const struct device *const pvt = DEVICE_DT_GET(DT_NODELABEL(pvt));
 
@@ -200,4 +204,72 @@ static int CATInit(void)
 	return 0;
 }
 SYS_INIT_APP(CATInit);
+
+static void TriggerThermTrip(void)
+{
+	if (!IS_ENABLED(CONFIG_ARC)) {
+		return;
+	}
+
+	/* Configure catmon to trip at lowest temperature threshold (-56C) */
+	EnableCAT(TempToTrimCode(-56), true);
+}
+
+int MonitorGddrThermTrip(int64_t now, int max_temp)
+{
+	static bool tracking;
+	static int64_t over_temp_start_time;
+
+	if (max_temp >= CAT_GDDR_THERM_TRIP_CRITICAL_TEMP) {
+		LOG_ERR("Max GDDR temp %dC >= %dC, will trigger thermal trip", max_temp,
+			CAT_GDDR_THERM_TRIP_CRITICAL_TEMP);
+		tracking = false;
+		return max_temp;
+	}
+
+	if (max_temp < CAT_GDDR_THERM_TRIP_TEMP) {
+		tracking = false;
+		return 0;
+	}
+
+	if (!tracking) {
+		tracking = true;
+		over_temp_start_time = now;
+	} else if (now - over_temp_start_time >= CAT_GDDR_THERM_TRIP_DURATION_MS) {
+		LOG_ERR("Max GDDR temp %dC >= %dC for >= %d ms, will trigger thermal trip",
+			max_temp, CAT_GDDR_THERM_TRIP_TEMP, CAT_GDDR_THERM_TRIP_DURATION_MS);
+		tracking = false;
+		return max_temp;
+	}
+
+	return 0;
+}
+
+static void gddr_therm_trip_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	int max_temp = MonitorGddrThermTrip(k_uptime_get(), GetTelemetryTag(TAG_MAX_GDDR_TEMP));
+
+	if (max_temp) {
+		TriggerThermTrip();
+	}
+}
+
+static K_WORK_DEFINE(gddr_therm_trip_worker, gddr_therm_trip_work_handler);
+
+static void gddr_therm_trip_timer_handler(struct k_timer *timer)
+{
+	ARG_UNUSED(timer);
+
+	k_work_submit(&gddr_therm_trip_worker);
+}
+
+static K_TIMER_DEFINE(gddr_therm_trip_timer, gddr_therm_trip_timer_handler, NULL);
+
+void StartGddrThermTripMonitor(void)
+{
+	k_timer_start(&gddr_therm_trip_timer, K_MSEC(gddr_therm_trip_interval),
+		      K_MSEC(gddr_therm_trip_interval));
+}
 #endif

--- a/lib/tenstorrent/bh_arc/cat.c
+++ b/lib/tenstorrent/bh_arc/cat.c
@@ -5,6 +5,7 @@
  */
 
 #include "cat.h"
+#include "cm2dm_msg.h"
 #include "reg.h"
 #include "telemetry.h"
 #include "timer.h"
@@ -35,6 +36,8 @@ LOG_MODULE_REGISTER(cat);
 #define DEFAULT_CALIBRATION (CAT_EARLY_TRIP_TEMP - T_J_SHUTDOWN)
 
 #define TRIM_CODE_BITS 6
+
+#define GDDR_THERM_TRIP_DMC_NOTIFY_MS 50
 
 typedef struct {
 	uint32_t trim_code: TRIM_CODE_BITS;
@@ -245,14 +248,34 @@ int MonitorGddrThermTrip(int64_t now, int max_temp)
 	return 0;
 }
 
+static void gddr_therm_trip_trigger_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	TriggerThermTrip();
+}
+
+static K_WORK_DELAYABLE_DEFINE(gddr_therm_trip_trigger_work, gddr_therm_trip_trigger_handler);
+
 static void gddr_therm_trip_work_handler(struct k_work *work)
 {
 	ARG_UNUSED(work);
+	static bool trip_pending;
+
+	if (trip_pending) {
+		return;
+	}
 
 	int max_temp = MonitorGddrThermTrip(k_uptime_get(), GetTelemetryTag(TAG_MAX_GDDR_TEMP));
 
 	if (max_temp) {
-		TriggerThermTrip();
+		/* Notify DMC, then trigger therm trip after delay so DMC can read the message */
+		trip_pending = true;
+		ReportGddrThermTrip(max_temp >= CAT_GDDR_THERM_TRIP_CRITICAL_TEMP
+					    ? kGddrThermTripReasonInstantaneous
+					    : kGddrThermTripReasonSustained);
+		k_work_schedule(&gddr_therm_trip_trigger_work,
+				K_MSEC(GDDR_THERM_TRIP_DMC_NOTIFY_MS));
 	}
 }
 

--- a/lib/tenstorrent/bh_arc/cat.h
+++ b/lib/tenstorrent/bh_arc/cat.h
@@ -7,6 +7,15 @@
 #ifndef CAT_H
 #define CAT_H
 
+#include <tenstorrent/bh_arc.h>
+
 #define T_J_SHUTDOWN 110 /* BH Prod Spec 7.3 */
+
+#define CAT_GDDR_THERM_TRIP_TEMP          GDDR_THERM_TRIP_TEMP
+#define CAT_GDDR_THERM_TRIP_CRITICAL_TEMP GDDR_THERM_TRIP_CRITICAL_TEMP
+#define CAT_GDDR_THERM_TRIP_DURATION_MS   (GDDR_THERM_TRIP_DURATION_MIN * 60 * 1000)
+
+void StartGddrThermTripMonitor(void);
+int MonitorGddrThermTrip(int64_t now, int max_temp);
 
 #endif

--- a/lib/tenstorrent/bh_arc/cm2dm_msg.c
+++ b/lib/tenstorrent/bh_arc/cm2dm_msg.c
@@ -172,6 +172,11 @@ void RequestLedBlink(uint32_t blink_mode)
 	PostCm2DmMsg(kCm2DmMsgIdLedBlink, blink_mode);
 }
 
+void ReportGddrThermTrip(GddrThermTripReason reason)
+{
+	PostCm2DmMsg(kCm2DmMsgIdGddrThermTrip, (uint32_t)reason);
+}
+
 void reset_request_handler(struct k_timer *timer)
 {
 	ARG_UNUSED(timer);

--- a/lib/tenstorrent/bh_arc/cm2dm_msg.h
+++ b/lib/tenstorrent/bh_arc/cm2dm_msg.h
@@ -21,6 +21,7 @@ void Dm2CmReadyRequest(void);
 void UpdateAutoResetTimeoutRequest(uint32_t timeout);
 void UpdateTelemHeartbeatRequest(uint32_t heartbeat);
 void RequestLedBlink(uint32_t blink_mode);
+void ReportGddrThermTrip(GddrThermTripReason reason);
 
 int32_t Dm2CmSendDataHandler(const uint8_t *data, uint8_t size);
 int32_t Dm2CmPingHandler(const uint8_t *data, uint8_t size);

--- a/tests/lib/tenstorrent/bh_arc/src/cat.c
+++ b/tests/lib/tenstorrent/bh_arc/src/cat.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+
+#include <zephyr/ztest.h>
+#include <zephyr/sys/util.h>
+
+#include "cat.h"
+
+#define HOT      CAT_GDDR_THERM_TRIP_TEMP          /* at the sustained threshold */
+#define COLD     (CAT_GDDR_THERM_TRIP_TEMP - 1)    /* just below the threshold */
+#define CRITICAL CAT_GDDR_THERM_TRIP_CRITICAL_TEMP /* immediate-trip threshold */
+#define DUR      CAT_GDDR_THERM_TRIP_DURATION_MS
+
+/* Run one cold pass to clear the monitor's internal tracking between tests */
+static void cool(void)
+{
+	(void)MonitorGddrThermTrip(0, COLD);
+}
+
+static void before(void *fixture)
+{
+	ARG_UNUSED(fixture);
+	cool();
+}
+
+ZTEST(cat, test_all_cold_never_trips)
+{
+	/* Not hot, so even after a long time nothing trips */
+	zassert_equal(MonitorGddrThermTrip(DUR + 1000, COLD), 0);
+}
+
+ZTEST(cat, test_brief_spike_does_not_trip)
+{
+	zassert_equal(MonitorGddrThermTrip(0, HOT), 0, "should not trip on first hot reading");
+
+	/* Hot, but not yet for the full duration */
+	zassert_equal(MonitorGddrThermTrip(DUR - 1, HOT), 0,
+		      "should not trip before duration elapses");
+
+	/* Cools off before the window completes, must not trip afterward */
+	zassert_equal(MonitorGddrThermTrip(DUR + 1000, COLD), 0,
+		      "cooling off must reset the timer");
+}
+
+ZTEST(cat, test_sustained_over_temp_trips)
+{
+	zassert_equal(MonitorGddrThermTrip(0, HOT), 0);
+
+	/* One millisecond short of the duration, still no trip */
+	zassert_equal(MonitorGddrThermTrip(DUR - 1, HOT), 0);
+
+	/* Exactly at the duration boundary (>=), trip returning the max temp */
+	zassert_equal(MonitorGddrThermTrip(DUR, HOT), HOT, "sustained over-temp must trip");
+}
+
+ZTEST(cat, test_critical_temp_trips_immediately)
+{
+	/* At or above the critical temperature there is no dwell requirement */
+	zassert_equal(MonitorGddrThermTrip(0, CRITICAL), CRITICAL,
+		      "critical temp must trip immediately");
+}
+
+ZTEST_SUITE(cat, NULL, NULL, before, NULL, NULL);


### PR DESCRIPTION
Add CTF feature for gddr to trigger a therm trip when:
1) max gddr temperature is greater than or equal to 95 degrees for 1 minute.
2) max gddr temperature reaches 110 degrees.

Also add a native sim test to validate behaviour.

Resolves: SYS-3165, SYS-3374