### PR TITLE
west.yml: Grab libpldm

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -569,3 +569,10 @@ Tenstorrent Platforms:
   labels: []
   description: |
     Maintained upstream.
+
+"West project: libpldm":
+  status: odd fixes
+  files: []
+  labels: []
+  description: |
+    Maintained upstream.

--- a/west.yml
+++ b/west.yml
@@ -7,9 +7,15 @@ manifest:
       url-base: https://github.com/tenstorrent
     - name: tenstorrent-forks
       url-base: https://github.com/tenstorrent-forks
+    - name: openbmc
+      url-base: https://github.com/openbmc
 
   # zephyr-keep-sorted-start re(^\s+\- name:)
   projects:
+    - name: libpldm
+      remote: openbmc
+      path: modules/lib/libpldm
+      revision: 1c4a11442648a7ac670167b4d306a70376a35cc2
     - name: librpmi
       remote: tenstorrent-forks
       path: modules/lib/librpmi


### PR DESCRIPTION
Grab libpldm. Get a version slightly more recent that v0.16 since that version compiles with warnings.

tests:

This commit works to compile some pldm symbols inside the library that I need for nucleo work.