### PR TITLE
app: dmc: emul: add PLL1

### DIFF
--- a/app/dmc/boards/dmc_common.dtsi
+++ b/app/dmc/boards/dmc_common.dtsi
@@ -28,6 +28,11 @@
 		status = "okay";
 	};
 
+	pll1: pll1 {
+		compatible = "tenstorrent,clock-control-emul";
+		status = "okay";
+	};
+
 	pll4: pll4 {
 		compatible = "tenstorrent,clock-control-emul";
 		status = "okay";


### PR DESCRIPTION
Add PLL1 to the DT for emulated platforms

Tests:

This is part of the necessary changes for nativesim/Nucleo DMC to initialize correctly when SMC initialization is entirely in lib_bharc. When telemetry is initialized, PLL1 is polled. 

