### PR TITLE
Apostolu/grendel ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,7 @@
 workflow:
   rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+      when: always
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       when: always
     - when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 workflow:
   rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == "apostolu/grendel-ci"
       when: always
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       when: always

--- a/scripts/ci/run-grendel-smoke.sh
+++ b/scripts/ci/run-grendel-smoke.sh
@@ -34,8 +34,9 @@ find_artifact() {
 
 cd vdk-utils
 TWISTER_PLATFORM_DIR=$OUTDIR/tt_mimir_tt_mimir_smc
-ZEPHYR_ELF=$(find_artifact "$TWISTER_PLATFORM_DIR" \
-	"*/tt-system-firmware/tests/drivers/tt_smc_remoteproc/drivers.tt_smc_remoteproc.bl1_primary/tt_smc_remoteproc/zephyr/zephyr.elf")
+ELF_PATTERN="*/tt-system-firmware/tests/drivers/tt_smc_remoteproc/"
+ELF_PATTERN+="drivers.tt_smc_remoteproc.bl1_primary/tt_smc_remoteproc/zephyr/zephyr.elf"
+ZEPHYR_ELF=$(find_artifact "$TWISTER_PLATFORM_DIR" "$ELF_PATTERN")
 PROD_ROM_ELF=../tt_smc/firmware/prod_rom-1.1.1-20260117-794e39bc/build/release/bin/prod_rom.elf
 # Watch this command until it outputs "Test PASSED"
 mkdir ../vdk-logs
@@ -60,8 +61,9 @@ sed -i "s/run_args: +COCOTB_TEST=smc_zephyr_binary_loader_test"\
 " +COCOTB_TEST=smc_zephyr_binary_loader_test"\
 " +FW_TEST=grendel_smc_hello_world_smp_zephyr"\
 " +FW_TEST_TIMEOUT=1000000000/g" tb_uvm/yaml/regression_smc_chiplet.yaml
-UART_BIN=$(find_artifact "$TWISTER_PLATFORM_DIR" \
-	"*/tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary.grendel_uart/zephyr/zephyr.bin")
+UART_PATTERN="*/tests/drivers/uart/uart_elementary/"
+UART_PATTERN+="drivers.uart.uart_elementary.grendel_uart/zephyr/zephyr.bin"
+UART_BIN=$(find_artifact "$TWISTER_PLATFORM_DIR" "$UART_PATTERN")
 cp "$UART_BIN" \
    ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
 ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test \

--- a/scripts/ci/run-grendel-smoke.sh
+++ b/scripts/ci/run-grendel-smoke.sh
@@ -13,10 +13,29 @@ git clone git@yyz-gitlab.local.tenstorrent.com:syseng-platform/vdk-utils.git
 # Pull tt-smc repo to run Zephyr tests
 git clone git@yyz-gitlab.local.tenstorrent.com:tensix/tensix-hw/tt_smc.git
 
+# Locate a single build artifact under the twister output tree. Twister's
+# directory layout has changed across versions, so match on the stable tail of
+# the path instead of hardcoding it.
+find_artifact() {
+	local root=$1 pattern=$2
+	local matches
+	mapfile -t matches < <(find "$root" -path "$pattern" -type f)
+	if [ "${#matches[@]}" -eq 0 ]; then
+		echo "ERROR: no artifact matching '$pattern' under '$root'" >&2
+		exit 1
+	fi
+	if [ "${#matches[@]}" -gt 1 ]; then
+		echo "ERROR: multiple artifacts matching '$pattern' under '$root':" >&2
+		printf '  %s\n' "${matches[@]}" >&2
+		exit 1
+	fi
+	printf '%s\n' "${matches[0]}"
+}
+
 cd vdk-utils
-TWISTER_DIR=$OUTDIR/tt_mimir_tt_mimir_smc/zephyr
-ZEPHYR_ELF=$TWISTER_DIR/tt-system-firmware/tests/drivers/tt_smc_remoteproc/
-ZEPHYR_ELF+=drivers.tt_smc_remoteproc.bl1_primary/tt_smc_remoteproc/zephyr/zephyr.elf
+TWISTER_PLATFORM_DIR=$OUTDIR/tt_mimir_tt_mimir_smc
+ZEPHYR_ELF=$(find_artifact "$TWISTER_PLATFORM_DIR" \
+	"*/tt-system-firmware/tests/drivers/tt_smc_remoteproc/drivers.tt_smc_remoteproc.bl1_primary/tt_smc_remoteproc/zephyr/zephyr.elf")
 PROD_ROM_ELF=../tt_smc/firmware/prod_rom-1.1.1-20260117-794e39bc/build/release/bin/prod_rom.elf
 # Watch this command until it outputs "Test PASSED"
 mkdir ../vdk-logs
@@ -41,8 +60,9 @@ sed -i "s/run_args: +COCOTB_TEST=smc_zephyr_binary_loader_test"\
 " +COCOTB_TEST=smc_zephyr_binary_loader_test"\
 " +FW_TEST=grendel_smc_hello_world_smp_zephyr"\
 " +FW_TEST_TIMEOUT=1000000000/g" tb_uvm/yaml/regression_smc_chiplet.yaml
-cp "$TWISTER_DIR/tests/drivers/uart/"\
-"uart_elementary/drivers.uart.uart_elementary.grendel_uart/zephyr/zephyr.bin" \
+UART_BIN=$(find_artifact "$TWISTER_PLATFORM_DIR" \
+	"*/tests/drivers/uart/uart_elementary/drivers.uart.uart_elementary.grendel_uart/zephyr/zephyr.bin")
+cp "$UART_BIN" \
    ./firmware/zephyr/grendel_smc_hello_world_smp_zephyr/grendel_smc_hello_world_smp_zephyr.bin
 ttem tb_uvm/yaml/regression_smc_chiplet.yaml smc_zephyr_hello_world_smp_test \
 	--stack flist,cgen,compile_smc_chiplet,sim --no-wave --lsf --seed 1 --c compile_smc_chiplet

--- a/tests/drivers/tt_smc_remoteproc/prj.conf
+++ b/tests/drivers/tt_smc_remoteproc/prj.conf
@@ -5,3 +5,8 @@ CONFIG_TEST=y
 CONFIG_ZTEST=y
 # VDK simulation does not support programming the PMP with stack protection
 CONFIG_TEST_HW_STACK_PROTECTION=n
+# The board uses a coarse 50 Hz kernel tick (see board defconfig) so the
+# Cadence I3C driver's default 10ms computed transfer timeout rounds down to a
+# single tick, which the slow simulator cannot meet and every CCC times out.
+# Restore the pre-4.4 ~1s transfer timeout so DAA can complete under simulation.
+CONFIG_I3C_CADENCE_TRANSFER_TIMEOUT_MARGIN_US=1000000

--- a/tests/drivers/tt_smc_remoteproc/prj.conf
+++ b/tests/drivers/tt_smc_remoteproc/prj.conf
@@ -5,8 +5,3 @@ CONFIG_TEST=y
 CONFIG_ZTEST=y
 # VDK simulation does not support programming the PMP with stack protection
 CONFIG_TEST_HW_STACK_PROTECTION=n
-# The board uses a coarse 50 Hz kernel tick (see board defconfig) so the
-# Cadence I3C driver's default 10ms computed transfer timeout rounds down to a
-# single tick, which the slow simulator cannot meet and every CCC times out.
-# Restore the pre-4.4 ~1s transfer timeout so DAA can complete under simulation.
-CONFIG_I3C_CADENCE_TRANSFER_TIMEOUT_MARGIN_US=1000000

--- a/west.yml
+++ b/west.yml
@@ -23,7 +23,7 @@ manifest:
     - name: zephyr
       remote: tenstorrent
       repo-path: zephyr-fork
-      revision: i3c-cdns-revert-od-timing-regression
+      revision: i3c-cdns-restore-pre-4.4-bisect
       import:
         name-allowlist:
           - cmsis_6

--- a/west.yml
+++ b/west.yml
@@ -23,7 +23,7 @@ manifest:
     - name: zephyr
       remote: tenstorrent
       repo-path: zephyr-fork
-      revision: 68672ece76e299ae6f1711586fb4756390ffe574
+      revision: i3c-cdns-revert-od-timing-regression
       import:
         name-allowlist:
           - cmsis_6


### PR DESCRIPTION
Twister directory has changed before, causing Grendel CI to fail as it hardcoded the Twister directory path.

Instead, locate the Twister directory instead of hardcoding the path.

Will report back once Grendel CI clones and runs this branch