### PR TITLE
drivers: smbus_target: refactor for easier command registration

### DIFF
--- a/drivers/smbus/target/smbus_target.c
+++ b/drivers/smbus/target/smbus_target.c
@@ -24,21 +24,21 @@ LOG_MODULE_REGISTER(i2c_target);
 		LOG_ERR_RATELIMIT(fmt, ##__VA_ARGS__);                                             \
 	} while (0)
 
-typedef enum {
-	kSmbusStateIdle,
-	kSmbusStateCmd,
-	kSmbusStateRcvData,
-	kSmbusStateRcvPec,
-	kSmbusStateSendData,
-	kSmbusStateSendPec,
-	kSmbusStateWaitIdle, /* After transactions finish, and in error conditions */
-} SmbusState;
+enum smbus_state {
+	SMBUS_STATE_IDLE,
+	SMBUS_STATE_CMD,
+	SMBUS_STATE_RCV_DATA,
+	SMBUS_STATE_RCV_PEC,
+	SMBUS_STATE_SEND_DATA,
+	SMBUS_STATE_SEND_PEC,
+	SMBUS_STATE_WAIT_IDLE, /* After transactions finish, and in error conditions */
+};
 
 struct smbus_target_data {
 	struct i2c_target_config config;
-	const struct SmbusCmdDef *cmd_defs[256];
+	const struct smbus_cmd_def *cmd_defs[256];
 	atomic_t error_count;
-	SmbusState state;
+	enum smbus_state state;
 	uint8_t command;
 	uint8_t blocksize_r;
 	uint8_t blocksize_w;
@@ -52,7 +52,7 @@ struct smbus_target_config {
 	struct i2c_dt_spec bus;
 };
 
-static const struct SmbusCmdDef *get_cmd_def(struct smbus_target_data *smbus_data, uint8_t cmd)
+static const struct smbus_cmd_def *get_cmd_def(struct smbus_target_data *smbus_data, uint8_t cmd)
 {
 	return smbus_data->cmd_defs[cmd];
 }
@@ -83,9 +83,9 @@ static int smbus_write_handler(struct i2c_target_config *config, uint8_t val)
 	int32_t ret = 0;
 	struct smbus_target_data *smbus_data =
 		CONTAINER_OF(config, struct smbus_target_data, config);
-	const struct SmbusCmdDef *curr_cmd = get_cmd_def(smbus_data, smbus_data->command);
+	const struct smbus_cmd_def *curr_cmd = get_cmd_def(smbus_data, smbus_data->command);
 
-	if (smbus_data->state == kSmbusStateIdle) {
+	if (smbus_data->state == SMBUS_STATE_IDLE) {
 		/*Log something like WriteReg(I2C0_TARGET_DEBUG_STATE_REG_ADDR, 0xc0de1030); */
 		smbus_data->command = val;
 		curr_cmd = get_cmd_def(smbus_data, smbus_data->command);
@@ -93,15 +93,15 @@ static int smbus_write_handler(struct i2c_target_config *config, uint8_t val)
 			/* Command not implemented */
 			SMBUS_LOG_ERR_RATELIMIT(smbus_data, "SMBUS: command 0x%02x not implemented",
 						val);
-			smbus_data->state = kSmbusStateWaitIdle;
+			smbus_data->state = SMBUS_STATE_WAIT_IDLE;
 			return -1;
 		}
-		smbus_data->state = kSmbusStateCmd;
-	} else if (smbus_data->state == kSmbusStateCmd) {
+		smbus_data->state = SMBUS_STATE_CMD;
+	} else if (smbus_data->state == SMBUS_STATE_CMD) {
 		/*Log something like WriteReg(I2C0_TARGET_DEBUG_STATE_REG_ADDR, 0xc0de1040); */
 		switch (curr_cmd->trans_type) {
-		case kSmbusTransBlockWrite:
-		case kSmbusTransBlockWriteBlockRead:
+		case SMBUS_TRANS_WRITE_BLOCK:
+		case SMBUS_TRANS_READ_WRITE_BLOCK:
 			smbus_data->blocksize_w = val;
 			if (smbus_data->blocksize_w > CONFIG_SMBUS_MAX_MSG_SIZE) {
 				SMBUS_LOG_ERR_RATELIMIT(
@@ -109,63 +109,63 @@ static int smbus_write_handler(struct i2c_target_config *config, uint8_t val)
 					"SMBUS: oversized block write: %d bytes (max %d)",
 					smbus_data->blocksize_w, CONFIG_SMBUS_MAX_MSG_SIZE);
 				/* block size too big */
-				smbus_data->state = kSmbusStateWaitIdle;
+				smbus_data->state = SMBUS_STATE_WAIT_IDLE;
 				ret = -1;
 			} else {
-				smbus_data->state = kSmbusStateRcvData;
+				smbus_data->state = SMBUS_STATE_RCV_DATA;
 			}
 			break;
-		case kSmbusTransWriteByte:
+		case SMBUS_TRANS_WRITE_BYTE:
 			smbus_data->blocksize_w = 1;
 			smbus_data->received_data[smbus_data->rcv_index++] = val;
 
 			if (1U == curr_cmd->pec) {
-				smbus_data->state = kSmbusStateRcvPec;
+				smbus_data->state = SMBUS_STATE_RCV_PEC;
 			} else {
 				ret = curr_cmd->rcv_handler(smbus_data->received_data,
 							    smbus_data->blocksize_w);
 
-				smbus_data->state = kSmbusStateWaitIdle;
+				smbus_data->state = SMBUS_STATE_WAIT_IDLE;
 			}
 			break;
-		case kSmbusTransWriteWord:
+		case SMBUS_TRANS_WRITE_WORD:
 			smbus_data->blocksize_w = 2;
 			smbus_data->received_data[smbus_data->rcv_index++] = val;
-			smbus_data->state = kSmbusStateRcvData;
+			smbus_data->state = SMBUS_STATE_RCV_DATA;
 			break;
 		default:
 			/* Error, invalid command for write */
 			SMBUS_LOG_ERR_RATELIMIT(smbus_data,
 						"SMBUS: invalid transaction type %d for write",
 						curr_cmd->trans_type);
-			smbus_data->state = kSmbusStateWaitIdle;
+			smbus_data->state = SMBUS_STATE_WAIT_IDLE;
 			ret = -1;
 		}
-	} else if (smbus_data->state == kSmbusStateRcvData) {
+	} else if (smbus_data->state == SMBUS_STATE_RCV_DATA) {
 		/*Log something like WriteReg(I2C0_TARGET_DEBUG_STATE_REG_ADDR, 0xc0de1050); */
 		smbus_data->received_data[smbus_data->rcv_index++] = val;
 		if (smbus_data->rcv_index == smbus_data->blocksize_w) {
 			if (1U == curr_cmd->pec &&
-			    (curr_cmd->trans_type != kSmbusTransBlockWriteBlockRead)) {
-				smbus_data->state = kSmbusStateRcvPec;
+			    (curr_cmd->trans_type != SMBUS_TRANS_READ_WRITE_BLOCK)) {
+				smbus_data->state = SMBUS_STATE_RCV_PEC;
 			} else {
 				ret = curr_cmd->rcv_handler(smbus_data->received_data,
 							    smbus_data->blocksize_w);
 				if (ret == 0 &&
-				    curr_cmd->trans_type == kSmbusTransBlockWriteBlockRead) {
-					smbus_data->state = kSmbusStateCmd;
+				    curr_cmd->trans_type == SMBUS_TRANS_READ_WRITE_BLOCK) {
+					smbus_data->state = SMBUS_STATE_CMD;
 				} else if (ret != 0) {
 					SMBUS_LOG_ERR_RATELIMIT(
 						smbus_data,
 						"SMBUS: receive handler error (cmd 0x%02x)",
 						smbus_data->command);
-					smbus_data->state = kSmbusStateWaitIdle;
+					smbus_data->state = SMBUS_STATE_WAIT_IDLE;
 				} else {
-					smbus_data->state = kSmbusStateWaitIdle;
+					smbus_data->state = SMBUS_STATE_WAIT_IDLE;
 				}
 			}
 		}
-	} else if (smbus_data->state == kSmbusStateRcvPec) {
+	} else if (smbus_data->state == SMBUS_STATE_RCV_PEC) {
 		/*Log something like WriteReg(I2C0_TARGET_DEBUG_STATE_REG_ADDR, 0xc0de1060);*/
 		uint8_t rcv_pec = val;
 
@@ -175,7 +175,7 @@ static int smbus_write_handler(struct i2c_target_config *config, uint8_t val)
 		pec = pec_crc_8(pec, smbus_data->config.address << 1 |
 					     I2C_MSG_WRITE); /* start address byte */
 		pec = pec_crc_8(pec, smbus_data->command);
-		if (curr_cmd->trans_type == kSmbusTransBlockWrite) {
+		if (curr_cmd->trans_type == SMBUS_TRANS_WRITE_BLOCK) {
 			pec = pec_crc_8(pec, smbus_data->blocksize_w);
 		}
 		for (int i = 0; i < smbus_data->blocksize_w; i++) {
@@ -187,27 +187,27 @@ static int smbus_write_handler(struct i2c_target_config *config, uint8_t val)
 				smbus_data,
 				"SMBUS: PEC mismatch (cmd 0x%02x): expected 0x%02x, got 0x%02x",
 				smbus_data->command, pec, rcv_pec);
-			smbus_data->state = kSmbusStateWaitIdle;
+			smbus_data->state = SMBUS_STATE_WAIT_IDLE;
 			return -1;
 		}
 		ret = curr_cmd->rcv_handler(smbus_data->received_data, smbus_data->blocksize_w);
 
-		if (ret == 0 && curr_cmd->trans_type == kSmbusTransBlockWriteBlockRead) {
-			smbus_data->state = kSmbusStateCmd;
+		if (ret == 0 && curr_cmd->trans_type == SMBUS_TRANS_READ_WRITE_BLOCK) {
+			smbus_data->state = SMBUS_STATE_CMD;
 		} else if (ret != 0) {
 			SMBUS_LOG_ERR_RATELIMIT(smbus_data,
 						"SMBUS: PEC receive handler error (cmd 0x%02x)",
 						smbus_data->command);
-			smbus_data->state = kSmbusStateWaitIdle;
+			smbus_data->state = SMBUS_STATE_WAIT_IDLE;
 		} else {
-			smbus_data->state = kSmbusStateWaitIdle;
+			smbus_data->state = SMBUS_STATE_WAIT_IDLE;
 		}
 	} else {
 		/* Invalid state for write handler */
 		SMBUS_LOG_ERR_RATELIMIT(smbus_data,
 					"SMBUS: write handler called in invalid state %d",
 					smbus_data->state);
-		smbus_data->state = kSmbusStateWaitIdle;
+		smbus_data->state = SMBUS_STATE_WAIT_IDLE;
 		ret = -1;
 	}
 	return ret;
@@ -218,24 +218,24 @@ static int32_t smbus_read_handler(struct i2c_target_config *config, uint8_t *val
 	struct smbus_target_data *smbus_data =
 		CONTAINER_OF(config, struct smbus_target_data, config);
 
-	const struct SmbusCmdDef *curr_cmd = get_cmd_def(smbus_data, smbus_data->command);
+	const struct smbus_cmd_def *curr_cmd = get_cmd_def(smbus_data, smbus_data->command);
 
-	if (smbus_data->state == kSmbusStateCmd) {
+	if (smbus_data->state == SMBUS_STATE_CMD) {
 		/* Log something like WriteReg(I2C0_TARGET_DEBUG_STATE_REG_ADDR, 0xc0de0010); */
 
 		/* Calculate blocksize for different types of commands */
 		switch (curr_cmd->trans_type) {
-		case kSmbusTransBlockRead:
-		case kSmbusTransBlockWriteBlockRead:
-		case kSmbusTransReadByte:
-		case kSmbusTransReadWord:
+		case SMBUS_TRANS_READ_BLOCK:
+		case SMBUS_TRANS_READ_WRITE_BLOCK:
+		case SMBUS_TRANS_READ_BYTE:
+		case SMBUS_TRANS_READ_WORD:
 			break;
 		default:
 			/* Error, invalid command for read */
 			SMBUS_LOG_ERR_RATELIMIT(smbus_data,
 						"SMBUS: invalid transaction type %d for read",
 						curr_cmd->trans_type);
-			smbus_data->state = kSmbusStateWaitIdle;
+			smbus_data->state = SMBUS_STATE_WAIT_IDLE;
 			*val = 0xFF;
 			return -1;
 		}
@@ -245,46 +245,46 @@ static int32_t smbus_read_handler(struct i2c_target_config *config, uint8_t *val
 			SMBUS_LOG_ERR_RATELIMIT(smbus_data,
 						"SMBUS: send handler error (cmd 0x%02x)",
 						smbus_data->command);
-			smbus_data->state = kSmbusStateWaitIdle;
+			smbus_data->state = SMBUS_STATE_WAIT_IDLE;
 			*val = 0xFF;
 			return -1;
 		}
 		/* Send the correct data for different types of commands */
 		switch (curr_cmd->trans_type) {
-		case kSmbusTransBlockWriteBlockRead:
-		case kSmbusTransBlockRead:
+		case SMBUS_TRANS_READ_WRITE_BLOCK:
+		case SMBUS_TRANS_READ_BLOCK:
 			/*Log something like WriteReg(I2C0_TARGET_DEBUG_STATE_REG_ADDR,
 			 * 0xc0de0030);
 			 */
 			*val = smbus_data->blocksize_r;
-			smbus_data->state = kSmbusStateSendData;
+			smbus_data->state = SMBUS_STATE_SEND_DATA;
 			break;
-		case kSmbusTransReadByte:
+		case SMBUS_TRANS_READ_BYTE:
 			*val = smbus_data->send_data[smbus_data->send_index++];
 			smbus_data->state =
-				curr_cmd->pec ? kSmbusStateSendPec : kSmbusStateWaitIdle;
+				curr_cmd->pec ? SMBUS_STATE_SEND_PEC : SMBUS_STATE_WAIT_IDLE;
 			break;
-		case kSmbusTransReadWord:
+		case SMBUS_TRANS_READ_WORD:
 			*val = smbus_data->send_data[smbus_data->send_index++];
-			smbus_data->state = kSmbusStateSendData;
+			smbus_data->state = SMBUS_STATE_SEND_DATA;
 			break;
 		default:
 			/* Error, invalid command for read */
 			SMBUS_LOG_ERR_RATELIMIT(
 				smbus_data, "SMBUS: invalid transaction type %d for read response",
 				curr_cmd->trans_type);
-			smbus_data->state = kSmbusStateWaitIdle;
+			smbus_data->state = SMBUS_STATE_WAIT_IDLE;
 			*val = 0xFF;
 			return -1;
 		}
-	} else if (smbus_data->state == kSmbusStateSendData) {
+	} else if (smbus_data->state == SMBUS_STATE_SEND_DATA) {
 		/* Log something like WriteReg(I2C0_TARGET_DEBUG_STATE_REG_ADDR, 0xc0de0050); */
 		*val = smbus_data->send_data[smbus_data->send_index++];
 		if (smbus_data->send_index == smbus_data->blocksize_r) {
 			smbus_data->state =
-				curr_cmd->pec ? kSmbusStateSendPec : kSmbusStateWaitIdle;
+				curr_cmd->pec ? SMBUS_STATE_SEND_PEC : SMBUS_STATE_WAIT_IDLE;
 		}
-	} else if (smbus_data->state == kSmbusStateSendPec) {
+	} else if (smbus_data->state == SMBUS_STATE_SEND_PEC) {
 		/* Log something like WriteReg(I2C0_TARGET_DEBUG_STATE_REG_ADDR, 0xc0de0060);*/
 		/* Calculate and send PEC. This is a read-type operation, so it starts with a
 		 * sequence of writes, then some reads.
@@ -296,7 +296,7 @@ static int32_t smbus_read_handler(struct i2c_target_config *config, uint8_t *val
 					     I2C_MSG_WRITE); /* start address byte */
 		pec = pec_crc_8(pec, smbus_data->command);
 
-		if (curr_cmd->trans_type == kSmbusTransBlockWriteBlockRead) {
+		if (curr_cmd->trans_type == SMBUS_TRANS_READ_WRITE_BLOCK) {
 			pec = pec_crc_8(pec, smbus_data->blocksize_w);
 		}
 		/* any received data */
@@ -308,8 +308,8 @@ static int32_t smbus_read_handler(struct i2c_target_config *config, uint8_t *val
 					     I2C_MSG_READ); /* restart address byte */
 
 		/* sent data */
-		if (curr_cmd->trans_type == kSmbusTransBlockRead ||
-		    curr_cmd->trans_type == kSmbusTransBlockWriteBlockRead) {
+		if (curr_cmd->trans_type == SMBUS_TRANS_READ_BLOCK ||
+		    curr_cmd->trans_type == SMBUS_TRANS_READ_WRITE_BLOCK) {
 			pec = pec_crc_8(pec, smbus_data->blocksize_r);
 		}
 		for (int i = 0; i < smbus_data->blocksize_r; i++) {
@@ -317,13 +317,13 @@ static int32_t smbus_read_handler(struct i2c_target_config *config, uint8_t *val
 		}
 
 		*val = pec;
-		smbus_data->state = kSmbusStateWaitIdle;
+		smbus_data->state = SMBUS_STATE_WAIT_IDLE;
 	} else {
 		/* Invalid state for read handler */
 		SMBUS_LOG_ERR_RATELIMIT(smbus_data,
 					"SMBUS: read handler called in invalid state %d",
 					smbus_data->state);
-		smbus_data->state = kSmbusStateWaitIdle;
+		smbus_data->state = SMBUS_STATE_WAIT_IDLE;
 		*val = 0xFF;
 		return -1;
 	}
@@ -343,7 +343,7 @@ uint32_t smbus_target_get_error_count(const struct device *dev)
 
 static void reset_state_machine(struct smbus_target_data *smbus_data)
 {
-	smbus_data->state = kSmbusStateIdle;
+	smbus_data->state = SMBUS_STATE_IDLE;
 	smbus_data->command = 0;
 	smbus_data->blocksize_r = 0;
 	smbus_data->blocksize_w = 0;
@@ -400,7 +400,7 @@ static int32_t smbus_target_init(const struct device *dev)
 }
 
 int32_t smbus_target_register_cmd(const struct device *dev, uint8_t cmd_id,
-				  const struct SmbusCmdDef *smbus_cmd)
+				  const struct smbus_cmd_def *smbus_cmd)
 {
 	struct smbus_target_data *data = dev->data;
 
@@ -410,6 +410,24 @@ int32_t smbus_target_register_cmd(const struct device *dev, uint8_t cmd_id,
 	}
 
 	data->cmd_defs[cmd_id] = smbus_cmd;
+	return 0;
+}
+
+int32_t smbus_target_register_cmds(const struct device *dev,
+				   const struct smbus_cmd_registration *cmds, size_t num_cmds)
+{
+	if (cmds == NULL) {
+		return -EINVAL;
+	}
+
+	for (size_t i = 0; i < num_cmds; ++i) {
+		int32_t rc = smbus_target_register_cmd(dev, cmds[i].cmd, &cmds[i].def);
+
+		if (rc < 0) {
+			return rc;
+		}
+	}
+
 	return 0;
 }
 

--- a/include/tenstorrent/smbus_target.h
+++ b/include/tenstorrent/smbus_target.h
@@ -7,20 +7,21 @@
 #ifndef SMBUS_TARGET
 #define SMBUS_TARGET
 
+#include <stddef.h>
 #include <stdint.h>
 
 /**
  * @brief A list of supported SMBUS transaction types
  */
-typedef enum {
-	kSmbusTransWriteByte,
-	kSmbusTransReadByte,
-	kSmbusTransWriteWord,
-	kSmbusTransReadWord,
-	kSmbusTransBlockWrite,
-	kSmbusTransBlockRead,
-	kSmbusTransBlockWriteBlockRead
-} SmbusTransType;
+enum smbus_trans_type {
+	SMBUS_TRANS_WRITE_BYTE,
+	SMBUS_TRANS_READ_BYTE,
+	SMBUS_TRANS_WRITE_WORD,
+	SMBUS_TRANS_READ_WORD,
+	SMBUS_TRANS_WRITE_BLOCK,
+	SMBUS_TRANS_READ_BLOCK,
+	SMBUS_TRANS_READ_WRITE_BLOCK,
+};
 
 /**
  * @brief Definition of a SMBUS receive handler
@@ -28,7 +29,7 @@ typedef enum {
  *          the I2C controller to relay to the application. SMBUS receive handlers
  *          shall return 0 on success, and any other value on failure.
  */
-typedef int32_t (*SmbusRcvHandler)(const uint8_t *data, uint8_t size);
+typedef int32_t (*smbus_rcv_handler)(const uint8_t *data, uint8_t size);
 
 /**
  * @brief Definition of a SMBUS send handler
@@ -36,14 +37,99 @@ typedef int32_t (*SmbusRcvHandler)(const uint8_t *data, uint8_t size);
  *          application to send to the I2C controller. SMBUS send handlers shall
  *          return 0 on success, and any other value on failure.
  */
-typedef int32_t (*SmbusSendHandler)(uint8_t *data, uint8_t *size);
+typedef int32_t (*smbus_send_handler)(uint8_t *data, uint8_t *size);
 
-struct SmbusCmdDef {
-	SmbusTransType trans_type;
-	SmbusRcvHandler rcv_handler;
-	SmbusSendHandler send_handler;
+struct smbus_cmd_def {
+	enum smbus_trans_type trans_type;
+	smbus_rcv_handler rcv_handler;
+	smbus_send_handler send_handler;
 	uint8_t pec: 1;
 };
+
+/**
+ * @brief Command registration entry for table-driven SMBus setup.
+ */
+struct smbus_cmd_registration {
+	uint8_t cmd;
+	struct smbus_cmd_def def;
+};
+
+/**
+ * @brief Build a generic SMBus command registration entry.
+ */
+#define SMBUS_CMD_ENTRY(_cmd, _pec, _trans_type, _rcv, _send)                                      \
+	{                                                                                          \
+		.cmd = (_cmd),                                                                     \
+		.def = {.pec = (_pec),                                                             \
+			.trans_type = (_trans_type),                                               \
+			.rcv_handler = (_rcv),                                                     \
+			.send_handler = (_send)},                                                  \
+	}
+
+/**
+ * @brief Build handler-field initializers for WRITE direction.
+ */
+#define SMBUS_CMD_HANDLER_FIELDS_WRITE(_func) .rcv_handler = (_func), .send_handler = NULL
+
+/**
+ * @brief Build handler-field initializers for READ direction.
+ */
+#define SMBUS_CMD_HANDLER_FIELDS_READ(_func) .rcv_handler = NULL, .send_handler = (_func)
+
+/**
+ * @brief Build an entry by direction and transaction-kind suffix.
+ * @details `_dir` must be READ or WRITE.
+ * @details `_kind` must match a suffix from enum smbus_trans_type, e.g. BYTE, WORD, BLOCK.
+ */
+#define SMBUS_CMD_GEN_ENTRY(_cmd, _pec, _dir, _kind, _func)                                        \
+	{                                                                                          \
+		.cmd = (_cmd),                                                                     \
+		.def = {.pec = (_pec),                                                             \
+			.trans_type = SMBUS_TRANS_##_dir##_##_kind,                                \
+			SMBUS_CMD_HANDLER_FIELDS_##_dir(_func)},                                   \
+	}
+
+/**
+ * @brief Build an entry for SMBus block-read command handling.
+ */
+#define SMBUS_CMD_BLOCK_RD_ENTRY(_cmd, _pec, _send)                                                \
+	SMBUS_CMD_GEN_ENTRY(_cmd, _pec, READ, BLOCK, _send)
+
+/**
+ * @brief Build an entry for SMBus block-write command handling.
+ */
+#define SMBUS_CMD_BLOCK_WR_ENTRY(_cmd, _pec, _rcv)                                                 \
+	SMBUS_CMD_GEN_ENTRY(_cmd, _pec, WRITE, BLOCK, _rcv)
+
+/**
+ * @brief Build an entry for SMBus read-byte command handling.
+ */
+#define SMBUS_CMD_READ_BYTE_ENTRY(_cmd, _pec, _send)                                               \
+	SMBUS_CMD_GEN_ENTRY(_cmd, _pec, READ, BYTE, _send)
+
+/**
+ * @brief Build an entry for SMBus write-byte command handling.
+ */
+#define SMBUS_CMD_WRITE_BYTE_ENTRY(_cmd, _pec, _rcv)                                               \
+	SMBUS_CMD_GEN_ENTRY(_cmd, _pec, WRITE, BYTE, _rcv)
+
+/**
+ * @brief Build an entry for SMBus read-word command handling.
+ */
+#define SMBUS_CMD_READ_WORD_ENTRY(_cmd, _pec, _send)                                               \
+	SMBUS_CMD_GEN_ENTRY(_cmd, _pec, READ, WORD, _send)
+
+/**
+ * @brief Build an entry for SMBus write-word command handling.
+ */
+#define SMBUS_CMD_WRITE_WORD_ENTRY(_cmd, _pec, _rcv)                                               \
+	SMBUS_CMD_GEN_ENTRY(_cmd, _pec, WRITE, WORD, _rcv)
+
+/**
+ * @brief Build an entry for SMBus block-write-block-read command handling.
+ */
+#define SMBUS_CMD_BLOCK_WR_BLOCK_RD_ENTRY(_cmd, _pec, _rcv, _send)                                 \
+	SMBUS_CMD_ENTRY(_cmd, _pec, SMBUS_TRANS_READ_WRITE_BLOCK, _rcv, _send)
 
 /**
  * @brief Register the given command to the SMBUS target implementation
@@ -54,7 +140,17 @@ struct SmbusCmdDef {
  *                  registered to the I2C.
  */
 int32_t smbus_target_register_cmd(const struct device *dev, uint8_t cmd_id,
-				  const struct SmbusCmdDef *smbus_cmd);
+				  const struct smbus_cmd_def *smbus_cmd);
+
+/**
+ * @brief Register a table of commands to the SMBUS target implementation.
+ * @param dev The device to register commands for.
+ * @param cmds Pointer to command registration table.
+ * @param num_cmds Number of entries in cmds.
+ * @return 0 on success, otherwise a negative error code.
+ */
+int32_t smbus_target_register_cmds(const struct device *dev,
+				   const struct smbus_cmd_registration *cmds, size_t num_cmds);
 
 /**
  * @brief Get total number of SMBUS target errors

--- a/lib/tenstorrent/bh_arc/smbus_target.c
+++ b/lib/tenstorrent/bh_arc/smbus_target.c
@@ -24,6 +24,7 @@
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/crc.h>
+#include <zephyr/sys/util.h>
 
 /* DMFW to CMFW i2c interface is on I2C0 of tensix_sm */
 #define CM_I2C_DM_TARGET_INST 0
@@ -122,87 +123,36 @@ int32_t UpdateArcStateHandler(const uint8_t *data, uint8_t size)
 
 /***End of SMBus handlers***/
 
-static const struct SmbusCmdDef smbus_req_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransBlockRead, .send_handler = &Cm2DmMsgReqSmbusHandler};
-
-static const struct SmbusCmdDef smbus_ack_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransWriteWord, .rcv_handler = &Cm2DmMsgAckSmbusHandler};
-
-static const struct SmbusCmdDef smbus_update_arc_state_cmd_def = {
-	.pec = 0U, .trans_type = kSmbusTransBlockWrite, .rcv_handler = &UpdateArcStateHandler};
-
-static const struct SmbusCmdDef smbus_dm_static_info_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransBlockWrite, .rcv_handler = &Dm2CmSendDataHandler};
-
-static const struct SmbusCmdDef smbus_ping_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransWriteWord, .rcv_handler = &Dm2CmPingHandler};
-
-static const struct SmbusCmdDef smbus_fan_speed_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransWriteWord, .rcv_handler = &Dm2CmSendFanSpeedHandler};
-
-static const struct SmbusCmdDef smbus_fan_rpm_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransWriteWord, .rcv_handler = &Dm2CmSendFanRPMHandler};
-
+static const struct smbus_cmd_registration smbus_cmds[] = {
+	SMBUS_CMD_BLOCK_RD_ENTRY(CMFW_SMBUS_REQ, 1U, Cm2DmMsgReqSmbusHandler),
+	SMBUS_CMD_WRITE_WORD_ENTRY(CMFW_SMBUS_ACK, 1U, Cm2DmMsgAckSmbusHandler),
+	SMBUS_CMD_BLOCK_WR_ENTRY(CMFW_SMBUS_UPDATE_ARC_STATE, 0U, UpdateArcStateHandler),
+	SMBUS_CMD_BLOCK_WR_ENTRY(CMFW_SMBUS_DM_STATIC_INFO, 1U, Dm2CmSendDataHandler),
+	SMBUS_CMD_WRITE_WORD_ENTRY(CMFW_SMBUS_PING, 1U, Dm2CmPingHandler),
+	SMBUS_CMD_WRITE_WORD_ENTRY(CMFW_SMBUS_FAN_SPEED, 1U, Dm2CmSendFanSpeedHandler),
+	SMBUS_CMD_WRITE_WORD_ENTRY(CMFW_SMBUS_FAN_RPM, 1U, Dm2CmSendFanRPMHandler),
 #ifndef CONFIG_TT_SMC_RECOVERY
-static const struct SmbusCmdDef smbus_telem_read_cmd_def = {.pec = 0U,
-							    .trans_type =
-								    kSmbusTransBlockWriteBlockRead,
-							    .rcv_handler = SMBusTelemRegHandler,
-							    .send_handler = SMBusTelemDataHandler};
-
-static const struct SmbusCmdDef smbus_telem_write_cmd_def = {.pec = 0U,
-							     .trans_type =
-								     kSmbusTransBlockWriteBlockRead,
-							     .rcv_handler = Dm2CmWriteTelemetry,
-							     .send_handler = Dm2CmReadControlData};
-
-static const struct SmbusCmdDef smbus_power_limit_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransWriteWord, .rcv_handler = &Dm2CmSetBoardPowerLimit};
-
-static const struct SmbusCmdDef smbus_power_instant_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransWriteWord, .rcv_handler = &Dm2CmSendPowerHandler};
-
-static const struct SmbusCmdDef smbus_telem_reg_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransWriteByte, .rcv_handler = &SMBusTelemRegHandler};
-
-static const struct SmbusCmdDef smbus_telem_data_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransBlockRead, .send_handler = &SMBusTelemDataHandler};
-
-static const struct SmbusCmdDef smbus_therm_trip_count_cmd_def = {
-	.pec = 1U,
-	.trans_type = kSmbusTransWriteWord,
-	.rcv_handler = &Dm2CmSendThermTripCountHandler};
-
-#endif /*CONFIG_TT_SMC_RECOVERY*/
-static const struct SmbusCmdDef smbus_dmc_log_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransBlockWrite, .rcv_handler = &Dm2CmDMCLogHandler};
-
-static const struct SmbusCmdDef smbus_test_read_byte_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransReadByte, .send_handler = &ReadByteTest};
-
-static const struct SmbusCmdDef smbus_test_write_byte_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransWriteByte, .rcv_handler = &WriteByteTest};
-
-static const struct SmbusCmdDef smbus_test_read_word_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransReadWord, .send_handler = &ReadWordTest};
-
-static const struct SmbusCmdDef smbus_test_write_word_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransWriteWord, .rcv_handler = &WriteWordTest};
-
-static const struct SmbusCmdDef smbus_block_write_block_read_test = {
-	.pec = 1U,
-	.trans_type = kSmbusTransBlockWriteBlockRead,
-	.rcv_handler = &BlockWriteTest,
-	.send_handler = BlockReadTest};
-
-static const struct SmbusCmdDef smbus_test_read_block_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransBlockRead, .send_handler = &BlockReadTest};
-
-static const struct SmbusCmdDef smbus_test_write_block_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransBlockWrite, .rcv_handler = &BlockWriteTest};
-
-static const struct SmbusCmdDef smbus_ping_v2_cmd_def = {
-	.pec = 1U, .trans_type = kSmbusTransReadWord, .send_handler = &Dm2CmPingV2};
+	SMBUS_CMD_BLOCK_WR_BLOCK_RD_ENTRY(CMFW_SMBUS_TELEMETRY_READ, 0U, SMBusTelemRegHandler,
+					  SMBusTelemDataHandler),
+	SMBUS_CMD_BLOCK_WR_BLOCK_RD_ENTRY(CMFW_SMBUS_TELEMETRY_WRITE, 0U, Dm2CmWriteTelemetry,
+					  Dm2CmReadControlData),
+	SMBUS_CMD_WRITE_WORD_ENTRY(CMFW_SMBUS_POWER_LIMIT, 1U, Dm2CmSetBoardPowerLimit),
+	SMBUS_CMD_WRITE_WORD_ENTRY(CMFW_SMBUS_POWER_INSTANT, 1U, Dm2CmSendPowerHandler),
+	SMBUS_CMD_WRITE_BYTE_ENTRY(0x26, 1U, SMBusTelemRegHandler),
+	SMBUS_CMD_BLOCK_RD_ENTRY(0x27, 1U, SMBusTelemDataHandler),
+	SMBUS_CMD_WRITE_WORD_ENTRY(CMFW_SMBUS_THERM_TRIP_COUNT, 1U, Dm2CmSendThermTripCountHandler),
+#endif
+	SMBUS_CMD_BLOCK_WR_ENTRY(CMFW_SMBUS_DMC_LOG, 1U, Dm2CmDMCLogHandler),
+	SMBUS_CMD_READ_BYTE_ENTRY(CMFW_SMBUS_TEST_READ, 1U, ReadByteTest),
+	SMBUS_CMD_WRITE_BYTE_ENTRY(CMFW_SMBUS_TEST_WRITE, 1U, WriteByteTest),
+	SMBUS_CMD_READ_WORD_ENTRY(CMFW_SMBUS_TEST_READ_WORD, 1U, ReadWordTest),
+	SMBUS_CMD_WRITE_WORD_ENTRY(CMFW_SMBUS_TEST_WRITE_WORD, 1U, WriteWordTest),
+	SMBUS_CMD_BLOCK_RD_ENTRY(CMFW_SMBUS_TEST_READ_BLOCK, 1U, BlockReadTest),
+	SMBUS_CMD_BLOCK_WR_ENTRY(CMFW_SMBUS_TEST_WRITE_BLOCK, 1U, BlockWriteTest),
+	SMBUS_CMD_BLOCK_WR_BLOCK_RD_ENTRY(CMFW_SMBUS_TEST_WRITE_BLOCK_READ_BLOCK, 1U,
+					  BlockWriteTest, BlockReadTest),
+	SMBUS_CMD_READ_WORD_ENTRY(CMFW_SMBUS_PING_V2, 1U, Dm2CmPingV2),
+};
 
 static int InitSmbusTarget(void)
 {
@@ -222,45 +172,11 @@ static int InitSmbusTarget(void)
 		return 0;
 	}
 
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_REQ, &smbus_req_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_ACK, &smbus_ack_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_UPDATE_ARC_STATE,
-				  &smbus_update_arc_state_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_DM_STATIC_INFO,
-				  &smbus_dm_static_info_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_PING, &smbus_ping_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_FAN_SPEED, &smbus_fan_speed_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_FAN_RPM, &smbus_fan_rpm_cmd_def);
-#ifndef CONFIG_TT_SMC_RECOVERY
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_TELEMETRY_READ,
-				  &smbus_telem_read_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_TELEMETRY_WRITE,
-				  &smbus_telem_write_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_POWER_LIMIT, &smbus_power_limit_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_POWER_INSTANT,
-				  &smbus_power_instant_cmd_def);
-	smbus_target_register_cmd(smbus_target, 0x26, &smbus_telem_reg_cmd_def);
-	smbus_target_register_cmd(smbus_target, 0x27, &smbus_telem_data_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_THERM_TRIP_COUNT,
-				  &smbus_therm_trip_count_cmd_def);
-#endif
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_DMC_LOG, &smbus_dmc_log_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_TEST_READ,
-				  &smbus_test_read_byte_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_TEST_WRITE,
-				  &smbus_test_write_byte_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_TEST_READ_WORD,
-				  &smbus_test_read_word_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_TEST_WRITE_WORD,
-				  &smbus_test_write_word_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_TEST_READ_BLOCK,
-				  &smbus_test_read_block_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_TEST_WRITE_BLOCK,
-				  &smbus_test_write_block_cmd_def);
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_TEST_WRITE_BLOCK_READ_BLOCK,
-				  &smbus_block_write_block_read_test);
+	if (smbus_target_register_cmds(smbus_target, smbus_cmds, ARRAY_SIZE(smbus_cmds)) < 0) {
+		printk("Failed to register SMBUS target commands\n");
+		return 0;
+	}
 
-	smbus_target_register_cmd(smbus_target, CMFW_SMBUS_PING_V2, &smbus_ping_v2_cmd_def);
 	return 0;
 }
 SYS_INIT_APP(InitSmbusTarget);


### PR DESCRIPTION
### Overview
Refactor the SMBUS driver so command registration is easier. Provide helper macros for building an item, and provide a bulk register command. Follow zephyr style

This is just starting cleanup to hopefully make the usage of the driver easier for users, and thus more desirable for eventual upstream to zephyr.


### Tests:
smoke shoud run with our SMBUS test on.
Existing native sim lib bh_arc has tests verifying SMBUS behaviour

