### PR TITLE
docs: Compatability and feature capability/enablement advertisement 

### DIFF
--- a/doc/develop/guides/compatibility.rst
+++ b/doc/develop/guides/compatibility.rst
@@ -1,0 +1,217 @@
+.. _ttzp_compatibility:
+
+Compatibility Guidelines
+========================
+
+This guide documents compatibility guarantees for externally consumed firmware
+interfaces. The goal is to let newer firmware continue working with older
+controllers, and to let newer controllers detect and adapt to older firmware
+without relying on undefined behavior.
+
+Compatibility Model
+-------------------
+
+Tenstorrent firmware uses a stability-first model for published host-facing
+interfaces:
+
+- Existing telemetry tags keep their meaning.
+- Existing host message IDs and request layouts keep their meaning.
+- Existing SMBus register IDs and payload meanings keep their meaning.
+- New functionality is added by extension, not by repurposing an existing
+  field, message, or register.
+
+Controllers must assume that older firmware may not implement newly added
+features. Firmware must assume that older controllers may continue using older,
+previously documented interfaces indefinitely.
+
+Interface Rules
+---------------
+
+Telemetry Interface
+~~~~~~~~~~~~~~~~~~~
+
+The telemetry interface is defined in ``lib/tenstorrent/bh_arc/telemetry.h``.
+
+Compatibility Discovery
+***********************
+
+Controllers can and should detect newly added telemetry entries by reading the
+telemetry table metadata and tag table, rather than assuming a fixed tag set is
+present.
+
+As documented in
+`Procedure to Read Telemetry </tt-system-firmware/services/telemetry/index.html#procedure-to-read-telemetry>`_:
+
+- Read ``telemetry_table.entry_count``.
+- Walk the telemetry ``tag_table``.
+- Use the discovered tag-to-offset mapping to determine whether a given tag is
+  present in the running firmware.
+
+This is the preferred discovery mechanism for new telemetry entries.
+
+Compatibility Rules
+*******************
+
+- Do not rename an existing telemetry tag.
+- Do not repurpose an existing telemetry tag to mean something else.
+- Do not change the encoding or field definition of an existing telemetry tag.
+- Do not change the meaning of an existing bit in a published telemetry bitfield.
+- Best practice is to reserve unused bits explicitly, and keep them reading as 0 until they are
+  intentionally assigned in a new compatibility version.
+- Bits not marked as reserved may not be repurposed
+- Repurposing of documented reserved bits in an allocated telemetry field is allowed and expected.
+- Add new telemetry information by defining new tags
+- FW doxygen is the single source of truth for field definitions.
+
+Rationale
+*********
+
+Controllers may hardcode assumptions about the meaning, width, and encoding of
+existing tags and bit positions. If an existing field is silently repurposed,
+older controllers can misinterpret the data without any negotiation step.
+
+Host Message Interface
+~~~~~~~~~~~~~~~~~~~~~~
+
+The host message interface is documented in
+`Host Message Interface </tt-system-firmware/doxygen/group__tt__msg__apis.html>`_
+and is defined primarily in ``include/tenstorrent/smc_msg.h`` and
+``include/tenstorrent/msgqueue.h``.
+
+Compatibility Discovery
+***********************
+
+Message support can be discovered by attempting to send the message and
+checking the firmware response.
+
+If a message is not supported by the running firmware, the generic message
+dispatch path returns ``0xff`` in ``response.data[0]``.
+
+Controllers should treat this as "message not recognized by this firmware" and
+fall back accordingly.
+
+Compatibility Rules
+*******************
+
+- Do not repurpose an existing ``TT_SMC_MSG_*`` message ID.
+- Do not change the layout or semantic meaning of an existing request or
+  response structure once published.
+- Do not change the meaning of an existing field inside a published message.
+- Add new functionality by allocating a new message ID, a new submessage ID, or
+  a new request/response structure.
+- Extensions to existing messages are allowed, but they must be introduced as new protocol elements,
+  not as reinterpretations of existing ones.
+
+Rationale
+*********
+
+Controllers often serialize these messages directly and may not be updated in
+lockstep with firmware. A wire-compatible extension is safe; changing the
+meaning of an existing message is not.
+
+SMBus Register Interface
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The SMBus register interface is defined in
+``include/tenstorrent/tt_smbus_regs.h``.
+
+Compatibility Discovery
+***********************
+
+The SMBus interface does not provide a general in-band capability-discovery
+mechanism.
+
+Controllers should therefore treat the SMBus command map as a fixed,
+versioned contract:
+
+- Use only documented SMBus registers for the target firmware version.
+- Do not assume that probing unknown command IDs is a supported discovery
+  mechanism.
+- When SMBus behavior depends on newer firmware features, prefer discovering
+  those features through telemetry or firmware-version information before using
+  a newer SMBus command.
+
+Compatibility Rules
+*******************
+
+- Do not rename an existing ``CMFW_SMBUS_*`` register definition.
+- Do not repurpose an existing SMBus register address.
+- Do not change the meaning or payload contract of an existing SMBus register.
+- Do not extend an existing SMBus command by changing its payload size or
+  payload interpretation.
+- Add new SMBus functionality only by allocating a new register/command.
+
+Rationale
+*********
+
+SMBus integrations are often implemented in external controller firmware or
+board-management logic where message size and meaning are tightly coupled to a
+specific register address.
+
+Compatibility Matrix
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+
+   * - Controller
+     - Firmware
+     - Expected status
+     - Notes
+   * - Old
+     - Old
+     - Supported
+     - Baseline case.
+   * - Old
+     - New
+     - Supported
+     - New firmware must preserve all previously published telemetry tags,
+       message IDs, message layouts, and SMBus register definitions.
+   * - New
+     - Old
+     - Baseline supported
+     - New controllers must discover capabilities and only use features supported
+       by the older firmware. New optional functionality must degrade cleanly.
+   * - New
+     - New
+     - Supported
+     - Full functionality is available, including newly added features.
+
+Practical Guidance
+------------------
+
+When adding a new externally visible feature:
+
+1. Add a new capability indication if feature discovery is needed.
+2. Preserve all existing message, telemetry, and SMBus definitions.
+3. Prefer adding a new tag, new message ID, new submessage ID, or new SMBus
+   register over changing an existing one.
+4. Document the compatibility contract in the relevant header and update this
+   guide if the new interface introduces a new compatibility surface.
+
+Feature Capability Discovery
+----------------------------
+
+Feature capability and active-configuration telemetry are documented in
+`Feature Capabilities </tt-system-firmware/doxygen/group__telemetry__feature__capabilities.html>`_.
+
+That interface provides an explicit discovery path for optional or newly implemented behavior:
+
+- ``TAG_FW_CAPABILITIES_<x>`` reports whether firmware supports a feature.
+- ``TAG_FW_ACTIVE_CONFIG_<x>`` reports whether that feature is currently enabled.
+
+Where possible, controllers may use capability telemetry to decide whether it is safe to use
+optional or newly implemented functionality.
+
+ABI Breaks
+----------
+
+ABI breaks must be avoided wherever possible.
+
+If an ABI break is unavoidable:
+
+- Increment the major version.
+- Document the break and migration impact in the release notes.
+- Inform all relevant stakeholders before release so downstream integrations can
+  plan and validate the transition.

--- a/doc/develop/guides/index.rst
+++ b/doc/develop/guides/index.rst
@@ -6,5 +6,6 @@ Guides
 .. toctree::
    :maxdepth: 1
 
+   compatibility.rst
    signing_key_conflict.rst
    repo_management.rst

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -173,6 +173,8 @@ static struct telemetry_table telemetry_table = {
 		[70] = {TAG_KERNEL_THROTTLER, TELEM_OFFSET(TAG_KERNEL_THROTTLER)},
 		[71] = {TAG_NOP_START_COUNT, TELEM_OFFSET(TAG_NOP_START_COUNT)},
 		[72] = {TAG_NOP_ON_DURATION, TELEM_OFFSET(TAG_NOP_ON_DURATION)},
+		[73] = {TAG_FW_CAPABILITIES_0, TELEM_OFFSET(TAG_FW_CAPABILITIES_0)},
+		[74] = {TAG_FW_ACTIVE_CONFIG_0, TELEM_OFFSET(TAG_FW_ACTIVE_CONFIG_0)},
 	},
 };
 /* clang-format on */
@@ -249,7 +251,22 @@ void UpdateTelemetryHostAiclkLimit(uint32_t fmax)
 
 void UpdateTelemetryKernelThrottler(bool enabled, uint32_t stop_nops_freq)
 {
+	telemetry_feature_flags_0_t active_config = {
+		.u32_all = telemetry[TAG_FW_ACTIVE_CONFIG_0],
+	};
+
+	active_config.bits.kernel_nops_at_aiclk_fmin = enabled ? 1U : 0U;
+	telemetry[TAG_FW_ACTIVE_CONFIG_0] = active_config.u32_all;
 	telemetry[TAG_KERNEL_THROTTLER] = (enabled ? 1U : 0U) | ((stop_nops_freq & 0xFFFFU) << 16U);
+}
+
+telemetry_feature_flags_bits_0_t GetActiveFeatures(void)
+{
+	telemetry_feature_flags_0_t active_config = {
+		.u32_all = telemetry[TAG_FW_ACTIVE_CONFIG_0],
+	};
+
+	return active_config.bits;
 }
 
 bool GetTelemetryTagValid(uint16_t tag)
@@ -385,6 +402,9 @@ static uint32_t get_gddr_mrisc_endpoints(void)
 
 static void write_static_telemetry(uint32_t app_version)
 {
+	telemetry_feature_flags_0_t fw_capabilities = {0};
+	telemetry_feature_flags_0_t active_config = {0};
+
 	telemetry_table.version = TELEMETRY_VERSION; /* v0.1.0 - Only update when redefining the
 						      * meaning of an existing tag
 						      */
@@ -451,6 +471,14 @@ static void write_static_telemetry(uint32_t app_version)
 	telemetry[TAG_ASIC_LOCATION] = tt_bh_fwtable_get_asic_location(fwtable_dev);
 
 	telemetry[TAG_GDDR_MRISC_NOC2AXI_PORT] = get_gddr_mrisc_endpoints();
+
+	fw_capabilities.bits.kernel_nops_at_aiclk_fmin = 1U;
+	telemetry[TAG_FW_CAPABILITIES_0] = fw_capabilities.u32_all;
+
+	active_config.bits.kernel_nops_at_aiclk_fmin =
+		tt_bh_fwtable_get_fw_table(fwtable_dev)
+			->feature_enable.kernel_throttler_at_floor_en;
+	telemetry[TAG_FW_ACTIVE_CONFIG_0] = active_config.u32_all;
 }
 
 static void update_telemetry(void)

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -26,6 +26,63 @@
 #define TELEMETRY_VERSION 0x00000100
 
 /**
+ * @defgroup telemetry_feature_capabilities Feature Capabilities
+ * @ingroup telemetry
+ * @brief Feature capability and active-configuration telemetry definitions.
+ *
+ * Firmware feature capabilities are organized into telemetry register pairs:
+ * one register reports which features are supported by the firmware, and the
+ * matching register reports which of those features are currently enabled.
+ *
+ * The currently allocated telemetry pair is:
+ *
+ * <table>
+ * <tr>
+ * <th>Capability register</th><th>Active-config register</th><th>Shared bit layout</th>
+ * </tr>
+ * <tr>
+ * <td>@ref TAG_FW_CAPABILITIES_0</td>
+ * <td>@ref TAG_FW_ACTIVE_CONFIG_0</td>
+ * <td>@ref telemetry_feature_flags_bits_0_t</td>
+ * </tr>
+ * </table>
+ * @{
+ */
+
+/** @brief Bit definitions shared by firmware capability and active-configuration telemetry.
+ *
+ * These bit positions are shared by both @ref TAG_FW_CAPABILITIES_0 and
+ * @ref TAG_FW_ACTIVE_CONFIG_0.
+ *
+ * For any bit defined here:
+ *
+ * | Telemetry register | Meaning of bit value 1 |
+ * | --- | --- |
+ * | @ref TAG_FW_CAPABILITIES_0 | The firmware supports the feature. |
+ * | @ref TAG_FW_ACTIVE_CONFIG_0 | The feature is currently enabled. |
+ */
+typedef struct {
+	/** @brief Kernel-throttler-at-AICLK-floor feature.
+	 *
+	 * This bit is controlled at runtime by the host with
+	 * @ref TT_SMC_MSG_CHARACTERISATION using
+	 * @ref TT_SUB_MSG_SET_KERNEL_THROTTLER_ENABLED.
+	 */
+	uint32_t kernel_nops_at_aiclk_fmin: 1;
+
+	/** @brief Reserved for future use. */
+	uint32_t reserved: 31;
+} telemetry_feature_flags_bits_0_t;
+
+/** @brief Packed 32-bit representation of @ref telemetry_feature_flags_bits_0_t. */
+typedef union {
+	uint32_t u32_all;
+	telemetry_feature_flags_bits_0_t bits;
+} telemetry_feature_flags_0_t;
+
+/** @} */ /* end of telemetry_feature_capabilities */
+
+/**
  * @defgroup telemetry_tags Telemetry Tags
  * @ingroup telemetry
  * @brief Telemetry tag definitions
@@ -393,12 +450,35 @@
  */
 #define TAG_NOP_ON_DURATION 77
 
+/** @brief Firmware capability bitfield.
+ *
+ * Bits are defined by @ref telemetry_feature_flags_bits_0_t.
+ *
+ * Current assignments:
+ * - bit 0 (`kernel_nops_at_aiclk_fmin`): firmware supports the
+ *   kernel-throttler-at-AICLK-floor feature.
+ */
+#define TAG_FW_CAPABILITIES_0 78
+
+/** @brief Active firmware configuration bitfield.
+ *
+ * Bits are defined by @ref telemetry_feature_flags_bits_0_t.
+ *
+ * Current assignments:
+ * - bit 0 (`kernel_nops_at_aiclk_fmin`): kernel-throttler-at-AICLK-floor is enabled.
+ *
+ * Runtime control:
+ * - The host can enable or disable this bit with @ref TT_SMC_MSG_CHARACTERISATION
+ *   and @ref TT_SUB_MSG_SET_KERNEL_THROTTLER_ENABLED.
+ */
+#define TAG_FW_ACTIVE_CONFIG_0 79
+
 /** @} */ /* end of telemetry_tag group */
 
 /* Not a real tag, signifies the last tag in the list.
  * MUST be incremented if new tags are defined.
  */
-#define TAG_COUNT 78
+#define TAG_COUNT 80
 
 /* Telemetry tags are at offset `tag` in the telemetry buffer */
 #define TELEM_OFFSET(tag) (tag)
@@ -414,6 +494,13 @@ void UpdateTelemetryTdpLimit(uint32_t tdp_limit);
 void UpdateTelemetryThermTripCount(uint16_t therm_trip_count);
 void UpdateTelemetryHostAiclkLimit(uint32_t fmax);
 void UpdateTelemetryKernelThrottler(bool enabled, uint32_t stop_nops_freq);
+/** @brief Get the current active firmware feature bits from @ref TAG_FW_ACTIVE_CONFIG_0.
+ * @ingroup telemetry_feature_capabilities
+ *
+ * The returned struct uses the bit layout documented by
+ * @ref telemetry_feature_flags_bits_0_t.
+ */
+telemetry_feature_flags_bits_0_t GetActiveFeatures(void);
 bool GetTelemetryTagValid(uint16_t tag);
 uint32_t GetTelemetryTag(uint16_t tag);
 

--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -34,7 +34,6 @@ static const bool thermal_throttling = true;
  * chip_limits.kernel_throttler_stop_nops_freq), so they can be persisted in SPI
  * flash and overridden via bh-mod.
  */
-static bool kernel_throttler_at_aiclk_floor_enabled;
 static uint32_t kernel_throttler_stop_nops_freq;
 static uint32_t kernel_throttler_stop_nops_freq_default;
 
@@ -241,9 +240,6 @@ void InitThrottlers(void)
 	doppler_t2 = doppler;
 	doppler_t3 = doppler;
 
-	kernel_throttler_at_aiclk_floor_enabled =
-		tt_bh_fwtable_get_fw_table(fwtable_dev)
-			->feature_enable.kernel_throttler_at_floor_en;
 	kernel_throttler_stop_nops_freq_default =
 		tt_bh_fwtable_get_fw_table(fwtable_dev)
 			->chip_limits.kernel_throttler_stop_nops_freq;
@@ -260,7 +256,8 @@ void InitThrottlers(void)
 		kernel_throttler_stop_nops_freq_default = 0U;
 	}
 	kernel_throttler_stop_nops_freq = kernel_throttler_stop_nops_freq_default;
-	UpdateTelemetryKernelThrottler(kernel_throttler_at_aiclk_floor_enabled,
+	UpdateTelemetryKernelThrottler(tt_bh_fwtable_get_fw_table(fwtable_dev)
+					       ->feature_enable.kernel_throttler_at_floor_en,
 				       kernel_throttler_stop_nops_freq);
 
 	SetThrottlerLimit(kThrottlerTDP,
@@ -395,17 +392,22 @@ static void UpdateDoppler(const TelemetryInternalData *telemetry)
 
 /* Update kernel throttler NOPs state when running at the AICLK floor.
  *
- * Only active when feature_enable.kernel_throttler_at_floor_en is set. The stop
- * frequency is taken from chip_limits.kernel_throttler_stop_nops_freq when
- * non-zero, otherwise it falls back to the effective minimum arbiter frequency.
+ * This path is enabled when TAG_FW_ACTIVE_CONFIG_0 bit 0
+ * (kernel_nops_at_aiclk_fmin) is set. The bit is seeded from the fwtable at
+ * telemetry init and may later be changed at runtime via the characterization
+ * message path.
+ *
+ * The stop frequency comes from kernel_throttler_stop_nops_freq. When that
+ * value is 0, FW falls back to the effective minimum arbiter frequency.
  */
 static void UpdateKernelThrottler(float current_power, float tdp_limit)
 {
+	telemetry_feature_flags_bits_0_t active_config = GetActiveFeatures();
 	bool start_nops = false;
 	bool stop_nops = false;
 	enum aiclk_arb_min arb;
 
-	if (kernel_throttler_at_aiclk_floor_enabled) {
+	if (active_config.kernel_nops_at_aiclk_fmin) {
 		start_nops = GetAiclkTarg() == GetAiclkFmin() && current_power > tdp_limit;
 
 		uint32_t stop_freq = kernel_throttler_stop_nops_freq;
@@ -459,7 +461,6 @@ uint8_t ThrottlerSetKernelThrottlerEnabled(uint32_t enabled)
 		return 1;
 	}
 
-	kernel_throttler_at_aiclk_floor_enabled = (bool)enabled;
 	LOG_INF("kernel throttler at aiclk floor %s", enabled ? "enabled" : "disabled");
 
 	/* Release NOPs immediately if the feature is being disabled while active. */
@@ -468,8 +469,7 @@ uint8_t ThrottlerSetKernelThrottlerEnabled(uint32_t enabled)
 		SendKernelThrottlingMessage(false);
 	}
 
-	UpdateTelemetryKernelThrottler(kernel_throttler_at_aiclk_floor_enabled,
-				       kernel_throttler_stop_nops_freq);
+	UpdateTelemetryKernelThrottler((bool)enabled, kernel_throttler_stop_nops_freq);
 	return 0;
 }
 
@@ -479,10 +479,12 @@ uint8_t ThrottlerSetKernelThrottlerStopFreq(uint32_t frequency)
 	 * fall back to the effective minimum arbiter frequency at runtime).
 	 */
 	if (frequency == 0) {
+		telemetry_feature_flags_bits_0_t active_config = GetActiveFeatures();
+
 		kernel_throttler_stop_nops_freq = kernel_throttler_stop_nops_freq_default;
 		LOG_INF("kernel throttler stop nops frequency restored to fwtable default %u MHz",
 			kernel_throttler_stop_nops_freq);
-		UpdateTelemetryKernelThrottler(kernel_throttler_at_aiclk_floor_enabled,
+		UpdateTelemetryKernelThrottler(active_config.kernel_nops_at_aiclk_fmin,
 					       kernel_throttler_stop_nops_freq);
 		return 0;
 	}
@@ -492,9 +494,11 @@ uint8_t ThrottlerSetKernelThrottlerStopFreq(uint32_t frequency)
 		return 1;
 	}
 
+	telemetry_feature_flags_bits_0_t active_config = GetActiveFeatures();
+
 	kernel_throttler_stop_nops_freq = frequency;
 	LOG_INF("kernel throttler stop nops frequency set to %u MHz", frequency);
-	UpdateTelemetryKernelThrottler(kernel_throttler_at_aiclk_floor_enabled,
+	UpdateTelemetryKernelThrottler(active_config.kernel_nops_at_aiclk_fmin,
 				       kernel_throttler_stop_nops_freq);
 	return 0;
 }


### PR DESCRIPTION
Document our compatability strategy in open source.

Add feature capability bits and build in an example (kernel-nops)

tests:

We have smoke tests for kernel nops feature. Whatever tests we are lacking are out of scope for this document.

I verified the documentation builds. Though some links are broken locally, I'm hopeful that once published everything will be okay.