### PR TITLE
.github: workflows: produce-data.yml: only run on main

### DIFF
--- a/.github/workflows/produce-data.yml
+++ b/.github/workflows/produce-data.yml
@@ -59,6 +59,17 @@ jobs:
             echo "::notice::Skipping upload for run from '$head_repo' (not ${{ github.repository }})"
           fi
 
+          # The soak/long tests can be triggered on a PR via the 'long-tests'
+          # label, but we only want to upload their data for runs on the
+          # main branch.
+          workflow_name="${{ github.event.workflow_run.name }}"
+          head_branch="${{ github.event.workflow_run.head_branch }}"
+          default_branch="${{ github.event.repository.default_branch }}"
+          if [[ "$workflow_name" == "HW Soak" && "$head_branch" != "$default_branch" ]]; then
+            upload="false"
+            echo "::notice::Skipping upload for '$workflow_name' on branch '$head_branch' (only uploads on $default_branch)"
+          fi
+
           [[ -z "$run_id" ]] && { echo "::error::run_id is empty"; exit 1; }
           [[ -z "$run_attempt" ]] && { echo "::error::run_attempt is empty"; exit 1; }
 

--- a/scripts/ci/create_pipeline_json.py
+++ b/scripts/ci/create_pipeline_json.py
@@ -759,7 +759,7 @@ def create_pipeline_json(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     ts = pipeline.pipeline_start_ts.strftime("%Y%m%dT%H%M%SZ")
-    filename = f"pipeline_{run_id}_{ts}.json"
+    filename = f"pipeline_{run_id}_a{run_attempt}_{ts}.json"
     output_path = output_dir / filename
 
     with open(output_path, "w") as f:


### PR DESCRIPTION
Only produce Ci data on main branch. Sometimes you can trigger stress test on PRs but we don't want to inlcude that in our official CI database.