### PR TITLE
scripts: ci: add STM32 pack install to e2e test

### DIFF
--- a/.github/ci_boards.json
+++ b/.github/ci_boards.json
@@ -9,6 +9,7 @@
   "bh": [
     {
       "board": "p100a",
+      "runner-label": "p100a-test",
       "supports_smoke": true,
       "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh:v0.68.0-dev20260317-16-gbb89a89897",
       "metal-target": "blackhole",

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         config: ${{ fromJson(needs.gen-config.outputs.matrix-config-bh) }}
-    runs-on: ${{ matrix.config.board }}
+    runs-on: ${{ matrix.config.runner-label || matrix.config.board }}
     container:
       image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
       volumes:
@@ -150,7 +150,7 @@ jobs:
       fail-fast: false
       matrix:
         config: ${{ fromJson(needs.gen-config.outputs.matrix-config-bh) }}
-    runs-on: ${{ matrix.config.board }}
+    runs-on: ${{ matrix.config.runner-label || matrix.config.board }}
     container:
       image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
       volumes:


### PR DESCRIPTION
Similar to smoke test, make sure STM32 target support exists by adding the pyocd pack install command, to resolve issues on runner `syseng-gh-05`.

The runner was previously failing e2e-tests due to target type not being recognized: https://github.com/tenstorrent/tt-system-firmware/actions/runs/29436055931/job/87422917292#step:10:108