### PR TITLE
lib: tenstorrent: bh_arc: Include GDDR IO power in TDP throttler

### DIFF
--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -493,8 +493,9 @@ static void update_telemetry(void)
 		telemetry_internal_data
 			.vcore_voltage; /* reported in mV, will be truncated to uint32_t */
 	telemetry[TAG_TDP] =
+		telemetry_internal_data.vcore_power + telemetry_internal_data.gddr_io_power_east +
 		telemetry_internal_data
-			.vcore_power; /* reported in W, will be truncated to uint32_t */
+			.gddr_io_power_west; /* reported in W, will be truncated to uint32_t */
 	telemetry[TAG_TDC] =
 		telemetry_internal_data
 			.vcore_current; /* reported in A, will be truncated to uint32_t */

--- a/lib/tenstorrent/bh_arc/throttler.c
+++ b/lib/tenstorrent/bh_arc/throttler.c
@@ -436,12 +436,16 @@ void CalculateThrottlers(void)
 	if (DopplerActive()) {
 		UpdateDoppler(&telemetry_internal_data);
 	} else {
-		UpdateThrottler(kThrottlerTDP, telemetry_internal_data.vcore_power);
+		float tdp_power = telemetry_internal_data.vcore_power +
+				  telemetry_internal_data.gddr_io_power_east +
+				  telemetry_internal_data.gddr_io_power_west;
+
+		UpdateThrottler(kThrottlerTDP, tdp_power);
 		UpdateThrottler(kThrottlerFastTDC, telemetry_internal_data.vcore_current);
 		UpdateThrottler(kThrottlerTDC, telemetry_internal_data.vcore_current);
 		UpdateThrottler(kThrottlerBoardPower, GetInputPower());
 
-		float current_power = telemetry_internal_data.vcore_power;
+		float current_power = tdp_power;
 		float tdp_limit = throttler[kThrottlerTDP].limit;
 
 		UpdateKernelThrottler(current_power, tdp_limit);


### PR DESCRIPTION
The TDP throttler previously compared only the vcore power against the TDP limit. Redefine TDP to be the sum of vcore power plus the GDDR east and west IO rail powers, so the throttler regulates against the fuller on-die power draw rather than vcore alone.

CalculateThrottlers() now feeds vcore_power + gddr_io_power_east + gddr_io_power_west into both the kThrottlerTDP PID throttler and the kernel-NOP throttler (which compares against the same TDP limit), keeping the two consistent. The TAG_TDP telemetry value is updated to report the same combined sum so the host-visible TDP matches the quantity the throttler acts on.

This affects the non-Doppler path only; when Doppler is active the TDP throttler is unused. The GDDR IO powers are already collected each telemetry read, so no additional I2C traffic is introduced.

TODO: characterize new TDP limits against the new TDP definition
      (vcore + GDDR power).
TODO: confirm with Running Wan how the other two GDDR rails vary; that
      is the true test of whether the other GDDR rails need to be
      included in this TDP definition.
TODO: redefine the telemetry definitions of TDP.