### PR TITLE
ci: Stop unnecessary actions

### DIFF
--- a/app/smc/sample.yaml
+++ b/app/smc/sample.yaml
@@ -97,7 +97,6 @@ tests:
     build_only: true
     sysbuild: true
     tags:
-      - e2e-flash
       - build-ci
     extra_overlay_confs:
       - tracing.conf

--- a/scripts/ci/run-e2e.sh
+++ b/scripts/ci/run-e2e.sh
@@ -97,13 +97,4 @@ if [[ "$TEST_SET" == *"e2e-flash"* ]]; then
 		--extra-args=SB_CONFIG_BOOT_SIGNATURE_KEY_FILE=\"$KEYFILE\" \
 		-ll DEBUG \
 		$@
-	# Restore a stable DMFW, since the copy flashed by BL2 tests will
-	# leave the DMC flash in a different state than other tests expect
-	# We erase the DMC flash first to ensure no old image fragments remain
-	west build -p always -b $DMC_BOARD $TT_Z_P_ROOT/app/dmc -d $ZEPHYR_BASE/build-dmc \
-		--sysbuild
-	west flash -d $ZEPHYR_BASE/build-dmc --domain mcuboot --erase \
-		--cmd-erase 'flash erase_sector 0 0 last'
-	west flash -d $ZEPHYR_BASE/build-dmc --domain dmc
-	rm -rf $ZEPHYR_BASE/build-dmc
 fi


### PR DESCRIPTION
~~Remove the flash before step for our pytest runners. The e2e smoke tests have fixtures that run that are required to run in order to properly load the PR image.~~

That's a lie. We can't control that. 

Also remove the tracing build which is done elsewhere

Also don't cleanup in the e2e-smoke shell script. CI should clean up on the recovery runner. Locally on Dev builds I'm not immediately seeing any issue on re-run just straight on top of pytest.

Tests:

CI smoke