### PR TITLE
tt-system-firmware: Cov build  fixes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,6 +34,7 @@ ContinuationIndentWidth: 8
 ForEachMacros:
   - 'ARRAY_FOR_EACH'
   - 'ARRAY_FOR_EACH_PTR'
+  - 'ARRAY_FOR_EACH_BH_CHIP'
   - 'FOR_EACH'
   - 'FOR_EACH_FIXED_ARG'
   - 'FOR_EACH_IDX'

--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -71,7 +71,7 @@ void update_fan_speed(bool notify_smcs)
 		uint8_t fan_speed = 0;
 		uint8_t forced_fan_speed = 0;
 
-		ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+		ARRAY_FOR_EACH_BH_CHIP(chip) {
 			fan_speed = MAX(fan_speed, chip->data.fan_speed);
 			forced_fan_speed =
 				MAX(forced_fan_speed,
@@ -88,7 +88,7 @@ void update_fan_speed(bool notify_smcs)
 
 		if (notify_smcs) {
 			/* Broadcast final speed to all SMCs for telemetry */
-			ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+			ARRAY_FOR_EACH_BH_CHIP(chip) {
 				bharc_smbus_word_data_write(&chip->config.arc, CMFW_SMBUS_FAN_SPEED,
 							    fan_speed);
 			}
@@ -299,7 +299,7 @@ void ina228_power_update(void)
 	/* Only use integer part of sensor value */
 	int16_t power = sensor_val.val1 & 0xFFFF;
 
-	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+	ARRAY_FOR_EACH_BH_CHIP(chip) {
 		bh_chip_set_input_power(chip, power);
 	}
 }
@@ -411,7 +411,7 @@ static int bh_chip_run_smbus_tests(struct bh_chip *chip)
 
 static void handle_therm_trip(void)
 {
-	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+	ARRAY_FOR_EACH_BH_CHIP(chip) {
 		if (chip->data.therm_trip_triggered) {
 			chip->data.therm_trip_triggered = false;
 
@@ -455,7 +455,7 @@ static void handle_therm_trip(void)
 
 static void handle_watchdog_reset(void)
 {
-	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+	ARRAY_FOR_EACH_BH_CHIP(chip) {
 		if (chip->data.arc_wdog_triggered) {
 			chip->data.arc_wdog_triggered = false;
 			bh_chip_cancel_bus_transfer_clear(chip);
@@ -488,7 +488,7 @@ static void handle_watchdog_reset(void)
 
 static void handle_perst(void)
 {
-	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+	ARRAY_FOR_EACH_BH_CHIP(chip) {
 		if (atomic_set(&chip->data.trigger_reset, false)) {
 			chip->data.performing_reset = true;
 			chip->data.last_cm2dm_seq_num_valid = false;
@@ -521,14 +521,14 @@ static void handle_perst(void)
 
 static void handle_pgood_change(void)
 {
-	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+	ARRAY_FOR_EACH_BH_CHIP(chip) {
 		handle_pgood_event(chip, board_fault_led);
 	}
 }
 
 static void send_init_data(void)
 {
-	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+	ARRAY_FOR_EACH_BH_CHIP(chip) {
 		if (chip->data.arc_needs_init_msg) {
 			if (bh_chip_set_static_info(chip, &static_info) == 0 &&
 			    bh_chip_set_input_power_lim(chip, max_power) == 0 &&
@@ -558,7 +558,7 @@ static void fan_rpm_feedback(void)
 
 		rpm = (uint16_t)data.val1;
 
-		ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+		ARRAY_FOR_EACH_BH_CHIP(chip) {
 			bh_chip_set_fan_rpm(chip, rpm);
 		}
 	}
@@ -566,7 +566,7 @@ static void fan_rpm_feedback(void)
 
 static void handle_cm2dm_messages(void)
 {
-	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+	ARRAY_FOR_EACH_BH_CHIP(chip) {
 		process_cm2dm_message(chip);
 	}
 }
@@ -619,7 +619,7 @@ int main(void)
 		}
 	}
 
-	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+	ARRAY_FOR_EACH_BH_CHIP(chip) {
 		chip->data.fan_speed = INITIAL_FAN_SPEED;
 	}
 
@@ -635,7 +635,7 @@ int main(void)
 	}
 
 	/* Force all spi_muxes back to arc control */
-	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+	ARRAY_FOR_EACH_BH_CHIP(chip) {
 		if (chip->config.spi_mux.port != NULL) {
 			gpio_pin_configure_dt(&chip->config.spi_mux, GPIO_OUTPUT_ACTIVE);
 		}
@@ -646,7 +646,7 @@ int main(void)
 		gpio_pin_configure_dt(&board_fault_led, GPIO_OUTPUT_INACTIVE);
 	}
 
-	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+	ARRAY_FOR_EACH_BH_CHIP(chip) {
 		ret = therm_trip_gpio_setup(chip);
 		if (ret != 0) {
 			LOG_ERR("%s() failed: %d", "therm_trip_gpio_setup", ret);
@@ -665,7 +665,7 @@ int main(void)
 	max_power = detect_max_power();
 
 	if (IS_ENABLED(CONFIG_JTAG_LOAD_BOOTROM)) {
-		ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+		ARRAY_FOR_EACH_BH_CHIP(chip) {
 			ret = jtag_bootrom_init(chip);
 			if (ret != 0) {
 				LOG_ERR("%s() failed: %d", "jtag_bootrom_init", ret);
@@ -688,7 +688,7 @@ int main(void)
 		LOG_DBG("Bootrom workaround successfully applied");
 	}
 
-	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+	ARRAY_FOR_EACH_BH_CHIP(chip) {
 		const struct device *smbus = chip->config.arc.smbus.bus;
 
 		smbus_configure(smbus, SMBUS_MODE_CONTROLLER | SMBUS_MODE_PEC);

--- a/include/tenstorrent/bh_chip.h
+++ b/include/tenstorrent/bh_chip.h
@@ -118,6 +118,13 @@ struct bh_chip {
 #define BH_CHIP_COUNT                          DT_PROP_LEN_OR(DT_PATH(chips), chips, 0)
 extern struct bh_chip BH_CHIPS[BH_CHIP_COUNT];
 
+#if BH_CHIP_COUNT > 0
+#define ARRAY_FOR_EACH_BH_CHIP(chip) ARRAY_FOR_EACH_PTR(BH_CHIPS, chip)
+#else
+#define ARRAY_FOR_EACH_BH_CHIP(chip)                                                               \
+	for (struct bh_chip * (chip) = NULL; (chip) != NULL; (chip) = NULL)
+#endif
+
 #define MAKE_STRUCT_FIELD(n) .n
 
 #define INIT_STRAP(n) MAKE_STRUCT_FIELD(DT_NODE_FULL_NAME_TOKEN(n)) = GPIO_DT_SPEC_GET(n, gpios),

--- a/include/tenstorrent/jtag_bootrom.h
+++ b/include/tenstorrent/jtag_bootrom.h
@@ -33,11 +33,6 @@ void jtag_bootrom_soft_reset_arc(struct bh_chip *chip);
 void jtag_bootrom_set_cable_power_limit(struct bh_chip *chip, uint16_t power_limit);
 void jtag_bootrom_teardown(const struct bh_chip *chip);
 
-ALWAYS_INLINE int jtag_bootrom_patch(struct bh_chip *chip, const uint32_t *patch, size_t patch_len)
-{
-	return jtag_bootrom_patch_offset(chip, patch, patch_len, 0);
-}
-
 uint32_t jtag_bootrom_get_perst_start_time(void);
 
 /* for verification via gpio-emul */

--- a/lib/tenstorrent/bh_chip/strapping.c
+++ b/lib/tenstorrent/bh_chip/strapping.c
@@ -69,7 +69,7 @@ BUILD_ASSERT(CONFIG_TT_I2C_STRAP_INIT_PRIORITY < CONFIG_GPIO_PCA_SERIES_INIT_PRI
 
 int i2c_straps(void)
 {
-	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+	ARRAY_FOR_EACH_BH_CHIP(chip) {
 		/* Enable I2C bus connection for strapping */
 		bharc_enable_i2cbus(&chip->config.arc);
 	}
@@ -78,7 +78,7 @@ int i2c_straps(void)
 
 int deinit_i2c_straps(void)
 {
-	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+	ARRAY_FOR_EACH_BH_CHIP(chip) {
 		/* Disable I2C bus connection for strapping */
 		bharc_disable_i2cbus(&chip->config.arc);
 	}

--- a/lib/tenstorrent/jtag_bootrom/jtag_bootrom.c
+++ b/lib/tenstorrent/jtag_bootrom/jtag_bootrom.c
@@ -68,7 +68,7 @@ void gpio_asic_reset_callback(const struct device *port, struct gpio_callback *c
 {
 	perst_start_time = k_cycle_get_32();
 
-	ARRAY_FOR_EACH_PTR(BH_CHIPS, chip) {
+	ARRAY_FOR_EACH_BH_CHIP(chip) {
 		chip->data.perst_seen = true;
 		atomic_set(&chip->data.trigger_reset, true);
 		/* Set the bus cancel following the logic of (reset_triggered && !performing_reset)

--- a/tests/lib/tenstorrent/jtag_bootrom/src/main.c
+++ b/tests/lib/tenstorrent/jtag_bootrom/src/main.c
@@ -23,7 +23,7 @@ ZTEST(jtag_bootrom, test_jtag_bootrom)
 	const uint32_t *const patch = (const uint32_t *)get_bootcode();
 	const size_t patch_len = get_bootcode_len();
 
-	zassert_ok(jtag_bootrom_patch(&test_chip, patch, patch_len));
+	zassert_ok(jtag_bootrom_patch_offset(&test_chip, patch, patch_len, 0));
 	zassert_ok(jtag_bootrom_verify(test_chip.config.jtag, patch, patch_len));
 }
 


### PR DESCRIPTION
A) BH_CHIPS has array size 0 in some of the tests (pgood, jtag bootrom); cov build barks, normal one don't. Ez solution to shut up the linker warning is to explicitly not acecss BH_CHIP entries when  BH_CHIPS is 0. 
B) Something fishy went up with the `ALWAYS_INLINE` JTAG function. Making `static ALWAYS_INLINE` fixes it but there's no callers other than the testcase. So just remove it and manually inline it. 


tests:

`west twister -i -n --build-only -p native_sim -T tests --outdir twister-out --coverage`

Plus running tests generates coverage reports when built this way.

resolves: SYS-4857