### PR TITLE
lib: bh_arc: Add per-instance GDDR soft-harvest mask

### DIFF
--- a/drivers/misc/bh_fwtable/spirom_protobufs/fw_table.proto
+++ b/drivers/misc/bh_fwtable/spirom_protobufs/fw_table.proto
@@ -62,6 +62,7 @@ message FwTable {
   message DramTable {
     uint32 dram_mask = 1;
     bool dram_mask_en = 2;
+    uint32 soft_harvest_dram_mask = 3;
   }
 
   message ChipHarvestingTable {

--- a/lib/tenstorrent/bh_arc/harvesting.c
+++ b/lib/tenstorrent/bh_arc/harvesting.c
@@ -238,6 +238,16 @@ static int CalculateHarvesting(void)
 			tile_enable.eth_enabled = 0;
 		}
 
+		/* Soft-harvest specific GDDR instances requested via the fw_table.
+		 * A set bit in soft_harvest_dram_mask forces that channel harvested.
+		 * Applied before the count-based harvest below, and only ever clears
+		 * bits so a fuse-harvested DRAM can never be re-enabled.
+		 */
+		if (tt_bh_fwtable_get_fw_table(fwtable_dev)->has_dram_table) {
+			tile_enable.gddr_enabled &= ~tt_bh_fwtable_get_fw_table(fwtable_dev)
+							     ->dram_table.soft_harvest_dram_mask;
+		}
+
 		uint8_t desired_gddr_count =
 			8 - tt_bh_fwtable_get_fw_table(fwtable_dev)
 				    ->product_spec_harvesting.dram_disable_count;


### PR DESCRIPTION
The product-spec harvesting path can only disable a count of GDDR instances (dram_disable_count).

Added a soft_harvest_dram_mask field to the fw_table DramTable and apply it in CalculateHarvesting: each set bit clears the corresponding channel from tile_enable.gddr_enabled.

The field defaults to 0 (no-op) when a board's fw_table omits it, enabling testing of harvested-DRAM configs for future bin6 BH Galaxy parts which allow one DRAM to be harvested.

the code changes are tested by first rebuilding the bh-mod (with the bh-mod side changes) and trying to set, reset and get the soft_harvest_dram_mask field and logging in telemetry.c to verify that the value changed.