### PR TITLE
Modify the ARC-HS ISR to support 16 channels

### DIFF
--- a/drivers/dma/dma_arc_hs.c
+++ b/drivers/dma/dma_arc_hs.c
@@ -195,7 +195,9 @@ static int dma_arc_hs_config(const struct device *dev, uint32_t channel, struct 
 	}
 
 	__ASSERT(config != NULL, "Invalid config pointer");
-	__ASSERT(dev_config->descriptors <= 32, "Driver supports up to 32 descriptors (1 group)");
+	__ASSERT(dev_config->descriptors <= ARC_DMA_MAX_DESCRIPTORS,
+		 "Driver supports up to 256 descriptors (8 groups)");
+	__ASSERT(dev_config->channels <= ARC_DMA_MAX_CHANNELS, "Driver supports up to 16 channels");
 
 	if (config->block_count == 0) {
 		LOG_ERR("block_count must be at least 1");
@@ -859,6 +861,7 @@ static void dma_arc_hs_isr(const struct device *dev)
 		       "unsigned int must be <= uint32_t to safely pass as handle");
 
 	struct arc_dma_data *data = dev->data;
+	const struct arc_dma_config *config = dev->config;
 	uint32_t int_status;
 	uint32_t bits_to_clear = 0;
 
@@ -872,18 +875,6 @@ static void dma_arc_hs_isr(const struct device *dev)
 		/* clear the interrupt */
 		z_arc_v2_aux_reg_write(DMA_C_INTSTAT_CLR_AUX, int_status);
 
-		/* Read current done status for group 0 */
-		if ((int_status & DMA_C_INTSTAT_DONE) != 0) {
-			bits_to_clear = z_arc_v2_aux_reg_read(DMA_S_DONESTATD_AUX(0));
-		} else {
-			bits_to_clear = 0;
-		}
-
-		if (bits_to_clear != 0) {
-			/* clear the done status */
-			z_arc_v2_aux_reg_write(DMA_S_DONESTATD_CLR_AUX(0), bits_to_clear);
-		}
-
 		/* Handle bus error */
 		if ((int_status & DMA_C_INTSTAT_BUS_ERR) != 0) {
 			LOG_ERR("DMA bus error");
@@ -896,13 +887,28 @@ static void dma_arc_hs_isr(const struct device *dev)
 			/* TODO: Implement overflow handling */
 		}
 
-		if (((int_status & DMA_C_INTSTAT_DONE) != 0) && (bits_to_clear != 0)) {
-			/* Process all set bits */
-			while (bits_to_clear != 0) {
-				unsigned int bit = find_lsb_set(bits_to_clear) - 1;
+		if ((int_status & DMA_C_INTSTAT_DONE) == 0) {
+			break;
+		}
 
-				dma_arc_hs_process_handle(dev, data, bit);
-				bits_to_clear &= ~(1U << bit);
+		/* iterate through each DMA group */
+		for (uint32_t group = 0; group < DIV_ROUND_UP(config->descriptors, 32); group++) {
+
+			/* Read current done status for current group */
+			bits_to_clear = z_arc_v2_aux_reg_read(DMA_S_DONESTATD_AUX(group));
+
+			if (bits_to_clear != 0) {
+				/* clear the done status */
+				z_arc_v2_aux_reg_write(DMA_S_DONESTATD_CLR_AUX(group),
+						       bits_to_clear);
+				/* Process all set bits */
+				while (bits_to_clear != 0) {
+					unsigned int bit = find_lsb_set(bits_to_clear) - 1;
+					uint32_t handle = (group * 32) + bit;
+
+					dma_arc_hs_process_handle(dev, data, handle);
+					bits_to_clear &= ~(1U << bit);
+				}
 			}
 		}
 	}
@@ -942,7 +948,7 @@ static int dma_arc_hs_init(const struct device *dev)
 		/* Spinlocks are zero-initialized by default in Zephyr */
 	}
 
-	/* CLear all pending DMA done status bits*/
+	/* Clear all pending DMA done status bits*/
 	uint32_t num_groups = DIV_ROUND_UP(config->descriptors, 32);
 
 	for (uint32_t group = 0; group < num_groups; group++) {

--- a/dts/vendor/tenstorrent/tt_blackhole_smc.dtsi
+++ b/dts/vendor/tenstorrent/tt_blackhole_smc.dtsi
@@ -537,7 +537,8 @@
 			compatible = "snps,designware-dma-arc-hs";
 			reg = <0>;
 			#dma-cells = <1>;
-			dma-channels = <4>;
+			dma-channels = <16>;
+			dma-descriptors = <256>;
 			interrupts = <21 1>;
 			interrupt-parent = <&intc>;
 			status = "disabled";


### PR DESCRIPTION
Add support for 16 DMA channels in the interrupt handler
Add dma tests in the same manner as the default zephyr tests to support multiple channels