### PR TITLE
doc: release: 19.13: add notes for blackhole update

### DIFF
--- a/doc/release/release-notes-19.13.md
+++ b/doc/release/release-notes-19.13.md
@@ -14,8 +14,23 @@ Major enhancements with this release include:
 - Carve out a region of memory for Metal runtime telemetry and publish its address and size via `SCRATCH_EXT[0:1]`
   - Add `SCRATCH_EXT` as a fixed-address carve out of CSM for extra "scratch registers"
 
-
 ## Blackhole
+
+### Telemetry
+- Add telemetry reporting feature capabilities, distinguishing which features the firmware is capable of from which are currently enabled.
+- Add a `bh_arc` telemetry sensor driver for the DMC, exposing SMC telemetry through the standard Zephyr sensor API.
+
+### KMD Logging
+- Add a KMD logging backend that streams firmware log messages to a KMD-allocated buffer over PCIe (see the [KMD logging service documentation](https://github.com/tenstorrent/tt-system-firmware/tree/main/doc/services/kmd_logging/index.rst)). This backend is disabled by default on all builds and must be enabled via `CONFIG_TT_PCIE_LOG_BACKEND`.
+
+### GDDR Thermal
+- Move the GDDR thermal-trip catmon trigger behind a Kconfig (disabled by default), while keeping DMC logging of the event.
+
+### Ethernet
+- Gate loading of the alternative SerDes configuration (UBB boards) on the Ethernet speed override: it now only loads when no override is set or the override is 400G, and is skipped for other speed overrides.
+
+### Stability Improvements
+- Fix an intermittent Tensix reset hang by using NOC coordinates instead of physical coordinates when clock-gating a single tile.
 
 ## Grendel
 


### PR DESCRIPTION
Add Blackhole release notes for the 19.13 release, covering telemetry feature-capability reporting and the new bh_arc telemetry sensor driver, the KMD logging backend, the GDDR thermal-trip catmon Kconfig gate, the Ethernet alternative SerDes speed-override guard, and the tensix reset clock-gating stability fix.