### PR TITLE
scripts: tooling: Add verbose prints to vuart/console

### DIFF
--- a/scripts/tooling/console.c
+++ b/scripts/tooling/console.c
@@ -124,10 +124,16 @@ static int loop(struct console *const cons)
 	bool ctrl_a_pressed = false;
 	static bool press_ctrl_a_printed;
 
+	D(1, "loop begin: dev=%s discovery=0x%08x channel=%u magic=0x%08x skip_rescan=%d",
+	  cons->vuart.dev_name, cons->vuart.addr, cons->vuart.channel, cons->vuart.magic,
+	  cons->skip_rescan);
+
 	ret = vuart_open(&cons->vuart);
 	if (ret < 0) {
+		D(1, "vuart_open failed: %d", ret);
 		goto out;
 	}
+	D(1, "vuart_open success: tlb_id=%u tlb=%p", cons->vuart.tlb_id, cons->vuart.tlb);
 
 	if (!press_ctrl_a_printed) {
 		I("Press Ctrl-a,x to quit");
@@ -138,6 +144,7 @@ static int loop(struct console *const cons)
 		ret = vuart_start(&cons->vuart);
 		if (ret < 0) {
 			D(2, "Lost vuart connection..");
+			D(1, "vuart_start failed: %d", ret);
 			goto out;
 		}
 
@@ -195,6 +202,7 @@ static int loop(struct console *const cons)
 				if (vuart_space(&cons->vuart) > 0) {
 					vuart_putc(&cons->vuart, ch);
 				} else {
+					D_RL(1, 250, "host->fw backpressure: rx ring full, deferring char 0x%02x", ch);
 					ungetc(ch, stdin);
 				}
 			}
@@ -426,6 +434,10 @@ int main(int argc, char **argv)
 	if (parse_args(&_cons, argc, argv) < 0) {
 		return EXIT_FAILURE;
 	}
+
+	D(1, "config: dev=%s discovery=0x%08x channel=%u magic=0x%08x pci_dev=0x%04x timeout_ms=%lu",
+	  _cons.vuart.dev_name, _cons.vuart.addr, _cons.vuart.channel, _cons.vuart.magic,
+	  _cons.vuart.pci_device_id, _cons.timeout_rel_ms);
 
 	ret = install_handlers(&_cons);
 	if (ret < 0) {

--- a/scripts/tooling/vuart.c
+++ b/scripts/tooling/vuart.c
@@ -193,13 +193,18 @@ static int program_noc(const struct vuart_data *data, uint32_t x, uint32_t y, en
 		       uint64_t phys, uint64_t *adjust)
 {
 	uint64_t mask = (data->bar_idx == 0) ? TLB_2M_WINDOW_MASK : TLB_4G_WINDOW_MASK;
+	uint64_t base = phys & ~mask;
 	struct tenstorrent_configure_tlb tlb = {.in.id = data->tlb_id,
 						.in.config = (struct tenstorrent_noc_tlb_config){
-							.addr = phys & ~mask,
+							.addr = base,
 							.x_end = x,
 							.y_end = y,
 							.ordering = order,
 						}};
+
+	D(1, "program_noc: tlb=%u bar=%d x=%u y=%u order=%u phys=0x%llx base=0x%llx mask=0x%llx",
+	  data->tlb_id, data->bar_idx, x, y, order, (unsigned long long)phys,
+	  (unsigned long long)base, (unsigned long long)mask);
 
 	if (ioctl(data->fd, TENSTORRENT_IOCTL_CONFIGURE_TLB, &tlb) < 0) {
 		E("ioctl(TENSTORRENT_IOCTL_GET_DRIVER_INFO): %s", strerror(errno));
@@ -207,11 +212,12 @@ static int program_noc(const struct vuart_data *data, uint32_t x, uint32_t y, en
 	}
 
 	*adjust = phys & mask;
+	D(1, "program_noc: tlb=%u adjust=0x%llx", data->tlb_id, (unsigned long long)*adjust);
 
 	/* There isn't a new API for getting the current TLB programming */
 	/* D(2, "tlb[%u]: %s", data->tlb_id, tlb2m2str(reg)); */
-	D(2, "tlb[%u]: %llx", data->tlb_id, (long long)phys & ~mask);
-	printf("tlb[%u]: %llx\n", data->tlb_id, (long long)phys & ~mask);
+	D(2, "tlb[%u]: %llx", data->tlb_id, (unsigned long long)base);
+	printf("tlb[%u]: %llx\n", data->tlb_id, (unsigned long long)base);
 
 	return 0;
 }
@@ -232,6 +238,7 @@ static int64_t arc_read32(const struct vuart_data *data, uint32_t phys)
 
 	D(2, "32-bit read from (%p,%p) %p (phys,virt)", (void *)(uintptr_t)phys, virt,
 	  (void *)(uintptr_t)adjust);
+	D(1, "arc_read32: phys=0x%08x virt=%p val=0x%08x", phys, virt, *virt);
 
 	return *virt;
 }
@@ -459,6 +466,10 @@ int vuart_open(struct vuart_data *data)
 		return -EINVAL;
 	}
 
+	D(1, "vuart_open: dev=%s bar=%d discovery=0x%08x magic=0x%08x channel=%u pci_dev=0x%04x",
+	  data->dev_name, data->bar_idx, data->addr, data->magic, data->channel,
+	  data->pci_device_id);
+
 	ret = open_tt_dev(data);
 	if (ret < 0) {
 		goto fail;
@@ -509,7 +520,7 @@ int vuart_start(struct vuart_data *data)
 			return ret;
 		}
 		data->vuart_addr = ret;
-		D(2, "discovery address: 0x%08x", data->vuart_addr);
+		D(1, "discovery read: addr=0x%08x val=0x%08x", data->addr, data->vuart_addr);
 		if (data->vuart_addr == 0xffffffff) {
 			D(1, "Read 0xffffffff from ARC. Please reset the card and try again.");
 			return -ENOENT;
@@ -524,6 +535,8 @@ int vuart_start(struct vuart_data *data)
 			return ret;
 		}
 		data->vuart = (volatile struct tt_vuart *)(data->tlb + adjust);
+		D(1, "descriptor map: vuart_addr=0x%08x adjust=0x%llx mapped=%p", data->vuart_addr,
+		  (unsigned long long)adjust, data->vuart);
 
 		if (data->vuart->magic != data->magic) {
 			D(1, "0x%08x does not match expected magic 0x%08x", data->vuart->magic,
@@ -558,6 +571,8 @@ void vuart_putc(struct vuart_data *data, int ch)
 
 	if (tt_vuart_buf_space(vuart->rx_head, vuart->rx_tail, vuart->rx_cap) > 0) {
 		++vuart->rx_tail;
+		D_RL(2, 250, "putc: ch=0x%02x rx_head=%u rx_tail=%u rx_cap=%u", (uint8_t)ch,
+		     vuart->rx_head, vuart->rx_tail, vuart->rx_cap);
 	}
 }
 
@@ -598,6 +613,8 @@ int vuart_getc(struct vuart_data *data)
 	int ch = tx_buf[vuart->tx_head % vuart->tx_cap];
 
 	++vuart->tx_head;
+	D_RL(2, 250, "getc: ch=0x%02x tx_head=%u tx_tail=%u tx_cap=%u", (uint8_t)ch,
+	     vuart->tx_head, vuart->tx_tail, vuart->tx_cap);
 
 	return ch;
 }
@@ -640,6 +657,8 @@ int vuart_read(struct vuart_data *data, uint8_t *buf, size_t size)
 	memcpy(buf, (uint8_t *)&vuart->buf[offset], size);
 
 	vuart->tx_head += size;
+	D_RL(2, 250, "read: size=%zu tx_head=%u tx_tail=%u tx_cap=%u", size, vuart->tx_head,
+	     vuart->tx_tail, vuart->tx_cap);
 
 	return (int)size;
 }


### PR DESCRIPTION
Add some additional support prints to tt-fw-terminal in cases where the device might be in suspect condition, or to debug application changes.

tests:
rebuilt `tt-fw-terminal` and verified shell works as intended

Also  with -vvvv

```
D: main(): config: dev=/dev/tenstorrent/0 discovery=0x800304a0 channel=0 magic=0x775e21a1 pci_dev=0xb140 timeout_ms=0
D: loop(): loop begin: dev=/dev/tenstorrent/0 discovery=0x800304a0 channel=0 magic=0x775e21a1 skip_rescan=0
D: vuart_open(): vuart_open: dev=/dev/tenstorrent/0 bar=4 discovery=0x800304a0 magic=0x775e21a1 channel=0 pci_dev=0xb140
D: open_tt_dev(): opened /dev/tenstorrent/0 as fd 3
D: open_tt_dev(): opened 1e52:b140 01.00.0
D: map_tlb(): mapped 2097152@20000000 to 2097152@0x71962db86000 for TLB window 202 (size: 4294967296)
D: program_noc(): program_noc: tlb=202 bar=4 x=8 y=0 order=1 phys=0x80030060 base=0x0 mask=0xffffffff
D: program_noc(): program_noc: tlb=202 adjust=0x80030060
D: program_noc(): tlb[202]: 0
tlb[202]: 0
D: arc_read32(): 32-bit read from (0x80030060,0x7196adbb6060) 0x80030060 (phys,virt)
D: arc_read32(): arc_read32: phys=0x80030060 virt=0x7196adbb6060 val=0xc0de0041
D: check_post_code(): POST code: (c0de, 00, 0041)
D: loop(): vuart_open success: tlb_id=202 tlb=0x71962db86000
Press Ctrl-a,x to quit
D: program_noc(): program_noc: tlb=202 bar=4 x=8 y=0 order=1 phys=0x800304a0 base=0x0 mask=0xffffffff
D: program_noc(): program_noc: tlb=202 adjust=0x800304a0
D: program_noc(): tlb[202]: 0
tlb[202]: 0
D: arc_read32(): 32-bit read from (0x800304a0,0x7196adbb64a0) 0x800304a0 (phys,virt)
D: arc_read32(): arc_read32: phys=0x800304a0 virt=0x7196adbb64a0 val=0x100690f8
D: vuart_start(): discovery read: addr=0x800304a0 val=0x100690f8
D: program_noc(): program_noc: tlb=202 bar=4 x=8 y=0 order=1 phys=0x100690f8 base=0x0 mask=0xffffffff
D: program_noc(): program_noc: tlb=202 adjust=0x100690f8
D: program_noc(): tlb[202]: 0
tlb[202]: 0
D: vuart_start(): descriptor map: vuart_addr=0x100690f8 adjust=0x100690f8 mapped=0x71963dbef0f8
D: vuart_start(): found vuart descriptor at 0x71963dbef0f8
D: dump_vuart_desc(): vuart@0x71963dbef0f8:
  magic: 775e21a1
  rx_cap: 1024
  rx_head: 23
  rx_tail: 23
  tx_cap: 3036
  tx_head: 3758
  tx_oflow: 0
  tx_tail: 3758
  version: 00000000

```