### PR TITLE
lib: bh_arc: separate postcode config

### DIFF
--- a/lib/tenstorrent/bh_arc/Kconfig
+++ b/lib/tenstorrent/bh_arc/Kconfig
@@ -15,6 +15,12 @@ config TT_BH_ARC
 	help
 	  This option enables the Blackhole ARC firmware library.
 
+config TT_POST_CODE
+	bool
+	default y if BOARD_TT_BLACKHOLE
+	help
+	  Enables writing firmware post codes to the status scratch register.
+
 if TT_BH_ARC
 
 config TT_BH_ARC_EMUL

--- a/lib/tenstorrent/bh_arc/post_code.c
+++ b/lib/tenstorrent/bh_arc/post_code.c
@@ -11,7 +11,7 @@
 
 void SetPostCode(uint8_t fw_id, uint16_t post_code)
 {
-#ifdef CONFIG_BOARD_TT_BLACKHOLE
+#if defined(CONFIG_TT_POST_CODE)
 	WriteReg(RESET_UNIT_SCRATCH_REG_ADDR(0),
 		 (POST_CODE_PREFIX << 16) | (fw_id << 14) | (post_code & 0x3FFF));
 #endif


### PR DESCRIPTION
Have a designated KCONFIG for setting the post code. Select this KCONFIG always for tt_blackhole.

This allows us to "easily" bake in post code setting for different board targets other than BLACKHOLE, by having them select the same KCONFIG. 

tests:

Smoke here.  