### PR TITLE
lib: bh_arc: bind msgqueue ISRs from DTS

### DIFF
--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc.dts
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc.dts
@@ -27,6 +27,15 @@
 		dmc-vuart = &vuart2;
 	};
 
+	msgqueue_irqs: msgqueue_irqs {
+		compatible = "tenstorrent,msgqueue-irqs";
+		interrupt-parent = <&idu_intc>;
+		interrupts = <32 0>, <57 0>, <58 0>;
+		interrupt-names = "arc_misc_cntl_irq0", "msi_catcher_nonempty",
+				  "msi_catcher_overflow";
+		status = "okay";
+	};
+
 	pinctrl: pinctrl {
 		compatible = "tenstorrent,bh-pinctrl";
 

--- a/dts/bindings/misc/tenstorrent,msgqueue-irqs.yaml
+++ b/dts/bindings/misc/tenstorrent,msgqueue-irqs.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+description: Tenstorrent message queue interrupt specifiers
+
+compatible: "tenstorrent,msgqueue-irqs"
+
+include: base.yaml
+
+properties:
+  interrupts:
+    required: true
+
+  interrupt-names:
+    required: true

--- a/lib/tenstorrent/bh_arc/irqnum.h
+++ b/lib/tenstorrent/bh_arc/irqnum.h
@@ -7,11 +7,7 @@
 #define _IRQNUM_H_
 
 /* List of ARC IRQ numbers that aren't captured in Device Tree */
-#define IRQNUM_ARC_MISC_CNTL_IRQ0 32
 #define IRQNUM_PCIE0_ERR_INTR     47
 #define IRQNUM_PCIE1_ERR_INTR     54
-
-#define IRQNUM_MSI_CATCHER_NONEMPTY 57
-#define IRQNUM_MSI_CATCHER_OVERFLOW 58
 
 #endif

--- a/lib/tenstorrent/bh_arc/msgqueue.c
+++ b/lib/tenstorrent/bh_arc/msgqueue.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdatomic.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 
@@ -17,7 +18,13 @@
 #include <tenstorrent/sys_init_defines.h>
 #include "status_reg.h"
 #include "reg.h"
-#include "irqnum.h"
+
+#define MSGQUEUE_IRQS_NODE DT_NODELABEL(msgqueue_irqs)
+
+#if DT_NODE_HAS_STATUS(MSGQUEUE_IRQS_NODE, okay)
+#define MSGQUEUE_IRQN(_name)     DT_IRQN_BY_NAME(MSGQUEUE_IRQS_NODE, _name)
+#define MSGQUEUE_IRQ_PRIO(_name) DT_IRQ_BY_NAME(MSGQUEUE_IRQS_NODE, _name, priority)
+#endif
 
 #define MSGHANDLER_COMPAT_MASK 0x1
 
@@ -392,7 +399,7 @@ static int register_interrupt_handlers(void)
 SYS_INIT_APP(register_interrupt_handlers);
 #endif
 
-#ifdef CONFIG_BOARD_TT_BLACKHOLE
+#if DT_NODE_HAS_STATUS(MSGQUEUE_IRQS_NODE, okay)
 static void msgqueue_work_handler(struct k_work *work)
 {
 	process_message_queues();
@@ -458,15 +465,18 @@ void init_msgqueue(void)
 {
 	prepare_msg_queue();
 
-#ifdef CONFIG_BOARD_TT_BLACKHOLE
-	IRQ_CONNECT(IRQNUM_ARC_MISC_CNTL_IRQ0, 0, msgqueue_interrupt_handler, NULL, 0);
-	irq_enable(IRQNUM_ARC_MISC_CNTL_IRQ0);
+#if DT_NODE_HAS_STATUS(MSGQUEUE_IRQS_NODE, okay)
+	IRQ_CONNECT(MSGQUEUE_IRQN(arc_misc_cntl_irq0), MSGQUEUE_IRQ_PRIO(arc_misc_cntl_irq0),
+		    msgqueue_interrupt_handler, NULL, 0);
+	irq_enable(MSGQUEUE_IRQN(arc_misc_cntl_irq0));
 
-	IRQ_CONNECT(IRQNUM_MSI_CATCHER_NONEMPTY, 0, msgqueue_msi_interrupt_handler, NULL, 0);
-	irq_enable(IRQNUM_MSI_CATCHER_NONEMPTY);
+	IRQ_CONNECT(MSGQUEUE_IRQN(msi_catcher_nonempty), MSGQUEUE_IRQ_PRIO(msi_catcher_nonempty),
+		    msgqueue_msi_interrupt_handler, NULL, 0);
+	irq_enable(MSGQUEUE_IRQN(msi_catcher_nonempty));
 
-	IRQ_CONNECT(IRQNUM_MSI_CATCHER_OVERFLOW, 0, msgqueue_msi_overflow_handler, NULL, 0);
-	irq_enable(IRQNUM_MSI_CATCHER_OVERFLOW);
+	IRQ_CONNECT(MSGQUEUE_IRQN(msi_catcher_overflow), MSGQUEUE_IRQ_PRIO(msi_catcher_overflow),
+		    msgqueue_msi_overflow_handler, NULL, 0);
+	irq_enable(MSGQUEUE_IRQN(msi_catcher_overflow));
 
 	volatile STATUS_BOOT_STATUS0_reg_u *boot_status0 =
 		(volatile STATUS_BOOT_STATUS0_reg_u *)STATUS_BOOT_STATUS0_REG_ADDR;


### PR DESCRIPTION
Bind the msgqueue ISRs from the DTS. That will theoretically allow platforms with other interrupt setups to use msgqueue src.

Tests:
Smoke locally, and CI should be sufficient. If MSI was borked nothing would work. 