### PR TITLE
boards: tenstorrent: mk_bu_dmc: Bringup fixes

### DIFF
--- a/app/dm_test_app/prj.conf
+++ b/app/dm_test_app/prj.conf
@@ -47,3 +47,9 @@ CONFIG_I3C_SHELL=y
 CONFIG_SPI_SHELL=y
 CONFIG_FLASH_SHELL=y
 CONFIG_LOG_CMDS=y
+
+# BRING-UP: display subsystem so the maxim,max7219 driver is actually built.
+# Without CONFIG_DISPLAY the DT node compiles no driver at all, so nothing ever
+# initialises the MAX7221 (U67) and its registers stay at power-on defaults.
+CONFIG_DISPLAY=y
+CONFIG_DISPLAY_LOG_LEVEL_DBG=y

--- a/app/dm_test_app/src/main.c
+++ b/app/dm_test_app/src/main.c
@@ -85,7 +85,6 @@ static struct i3c_target_config i3c_target_config = {
 
 #endif
 
-
 #if DT_NODE_EXISTS(DT_NODELABEL(max7221))
 /*
  * POST-code display on the MAX7221 (U67) driving two LDQ-N514RI 4-digit
@@ -100,33 +99,33 @@ static struct i3c_target_config i3c_target_config = {
 #define MAX7221_REG_DIGIT0 0x01
 
 /* No-decode segment mapping (datasheet Table 6): D7=DP, D6..D0 = A,B,C,D,E,F,G */
-#define SEG_A 0x40
-#define SEG_B 0x20
-#define SEG_C 0x10
-#define SEG_D 0x08
-#define SEG_E 0x04
-#define SEG_F 0x02
-#define SEG_G 0x01
+#define SEG_A  0x40
+#define SEG_B  0x20
+#define SEG_C  0x10
+#define SEG_D  0x08
+#define SEG_E  0x04
+#define SEG_F  0x02
+#define SEG_G  0x01
 #define SEG_DP 0x80
 
 /* Hex font 0-F. */
 static const uint8_t post_font_hex[16] = {
-	SEG_A | SEG_B | SEG_C | SEG_D | SEG_E | SEG_F,          /* 0 */
-	SEG_B | SEG_C,                                          /* 1 */
-	SEG_A | SEG_B | SEG_D | SEG_E | SEG_G,                  /* 2 */
-	SEG_A | SEG_B | SEG_C | SEG_D | SEG_G,                  /* 3 */
-	SEG_B | SEG_C | SEG_F | SEG_G,                          /* 4 */
-	SEG_A | SEG_C | SEG_D | SEG_F | SEG_G,                  /* 5 */
-	SEG_A | SEG_C | SEG_D | SEG_E | SEG_F | SEG_G,          /* 6 */
-	SEG_A | SEG_B | SEG_C,                                  /* 7 */
-	SEG_A | SEG_B | SEG_C | SEG_D | SEG_E | SEG_F | SEG_G,  /* 8 */
-	SEG_A | SEG_B | SEG_C | SEG_D | SEG_F | SEG_G,          /* 9 */
-	SEG_A | SEG_B | SEG_C | SEG_E | SEG_F | SEG_G,          /* A */
-	SEG_C | SEG_D | SEG_E | SEG_F | SEG_G,                  /* b */
-	SEG_A | SEG_D | SEG_E | SEG_F,                          /* C */
-	SEG_B | SEG_C | SEG_D | SEG_E | SEG_G,                  /* d */
-	SEG_A | SEG_D | SEG_E | SEG_F | SEG_G,                  /* E */
-	SEG_A | SEG_E | SEG_F | SEG_G,                          /* F */
+	SEG_A | SEG_B | SEG_C | SEG_D | SEG_E | SEG_F,         /* 0 */
+	SEG_B | SEG_C,                                         /* 1 */
+	SEG_A | SEG_B | SEG_D | SEG_E | SEG_G,                 /* 2 */
+	SEG_A | SEG_B | SEG_C | SEG_D | SEG_G,                 /* 3 */
+	SEG_B | SEG_C | SEG_F | SEG_G,                         /* 4 */
+	SEG_A | SEG_C | SEG_D | SEG_F | SEG_G,                 /* 5 */
+	SEG_A | SEG_C | SEG_D | SEG_E | SEG_F | SEG_G,         /* 6 */
+	SEG_A | SEG_B | SEG_C,                                 /* 7 */
+	SEG_A | SEG_B | SEG_C | SEG_D | SEG_E | SEG_F | SEG_G, /* 8 */
+	SEG_A | SEG_B | SEG_C | SEG_D | SEG_F | SEG_G,         /* 9 */
+	SEG_A | SEG_B | SEG_C | SEG_E | SEG_F | SEG_G,         /* A */
+	SEG_C | SEG_D | SEG_E | SEG_F | SEG_G,                 /* b */
+	SEG_A | SEG_D | SEG_E | SEG_F,                         /* C */
+	SEG_B | SEG_C | SEG_D | SEG_E | SEG_G,                 /* d */
+	SEG_A | SEG_D | SEG_E | SEG_F | SEG_G,                 /* E */
+	SEG_A | SEG_E | SEG_F | SEG_G,                         /* F */
 };
 
 /* Letters used by the "POST" banner. */
@@ -136,7 +135,7 @@ static const uint8_t post_font_hex[16] = {
 #define GLYPH_T (SEG_D | SEG_E | SEG_F | SEG_G)
 
 static const struct spi_dt_spec max7221_spi =
-	SPI_DT_SPEC_GET(DT_NODELABEL(max7221), SPI_WORD_SET(8) | SPI_OP_MODE_MASTER, 0);
+	SPI_DT_SPEC_GET(DT_NODELABEL(max7221), SPI_WORD_SET(8) | SPI_OP_MODE_MASTER);
 
 static int max7221_write(uint8_t reg, uint8_t val)
 {
@@ -182,10 +181,13 @@ static int post_display_positions(const uint8_t pos_segs[8])
 }
 
 /* Show "POST" then a 4-digit hex code, in reading order. */
-int post_code_show(uint16_t code)
+static int post_code_show(uint16_t code)
 {
 	const uint8_t pos_segs[8] = {
-		GLYPH_P, GLYPH_O, GLYPH_S, GLYPH_T,
+		GLYPH_P,
+		GLYPH_O,
+		GLYPH_S,
+		GLYPH_T,
 		post_font_hex[(code >> 12) & 0xF],
 		post_font_hex[(code >> 8) & 0xF],
 		post_font_hex[(code >> 4) & 0xF],

--- a/app/dm_test_app/src/main.c
+++ b/app/dm_test_app/src/main.c
@@ -8,6 +8,12 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if DT_NODE_EXISTS(DT_NODELABEL(max7221))
+#include <zephyr/drivers/spi.h>
+#endif
 
 #ifdef CONFIG_I3C_TARGET
 #include <zephyr/drivers/i3c.h>
@@ -79,9 +85,212 @@ static struct i3c_target_config i3c_target_config = {
 
 #endif
 
+
+#if DT_NODE_EXISTS(DT_NODELABEL(max7221))
+/*
+ * POST-code display on the MAX7221 (U67) driving two LDQ-N514RI 4-digit
+ * displays -- 8 digits total.
+ *
+ * The Zephyr max7219 display driver initialises the part (out of shutdown,
+ * no-decode, intensity, scan limit); this writes the digit registers directly
+ * over the same SPI spec, which keeps CS and clock timing under the SPI
+ * driver's control. Frames assembled from separate shell commands do not latch
+ * reliably, so POST codes are written here rather than from the host.
+ */
+#define MAX7221_REG_DIGIT0 0x01
+
+/* No-decode segment mapping (datasheet Table 6): D7=DP, D6..D0 = A,B,C,D,E,F,G */
+#define SEG_A 0x40
+#define SEG_B 0x20
+#define SEG_C 0x10
+#define SEG_D 0x08
+#define SEG_E 0x04
+#define SEG_F 0x02
+#define SEG_G 0x01
+#define SEG_DP 0x80
+
+/* Hex font 0-F. */
+static const uint8_t post_font_hex[16] = {
+	SEG_A | SEG_B | SEG_C | SEG_D | SEG_E | SEG_F,          /* 0 */
+	SEG_B | SEG_C,                                          /* 1 */
+	SEG_A | SEG_B | SEG_D | SEG_E | SEG_G,                  /* 2 */
+	SEG_A | SEG_B | SEG_C | SEG_D | SEG_G,                  /* 3 */
+	SEG_B | SEG_C | SEG_F | SEG_G,                          /* 4 */
+	SEG_A | SEG_C | SEG_D | SEG_F | SEG_G,                  /* 5 */
+	SEG_A | SEG_C | SEG_D | SEG_E | SEG_F | SEG_G,          /* 6 */
+	SEG_A | SEG_B | SEG_C,                                  /* 7 */
+	SEG_A | SEG_B | SEG_C | SEG_D | SEG_E | SEG_F | SEG_G,  /* 8 */
+	SEG_A | SEG_B | SEG_C | SEG_D | SEG_F | SEG_G,          /* 9 */
+	SEG_A | SEG_B | SEG_C | SEG_E | SEG_F | SEG_G,          /* A */
+	SEG_C | SEG_D | SEG_E | SEG_F | SEG_G,                  /* b */
+	SEG_A | SEG_D | SEG_E | SEG_F,                          /* C */
+	SEG_B | SEG_C | SEG_D | SEG_E | SEG_G,                  /* d */
+	SEG_A | SEG_D | SEG_E | SEG_F | SEG_G,                  /* E */
+	SEG_A | SEG_E | SEG_F | SEG_G,                          /* F */
+};
+
+/* Letters used by the "POST" banner. */
+#define GLYPH_P (SEG_A | SEG_B | SEG_E | SEG_F | SEG_G)
+#define GLYPH_O (SEG_A | SEG_B | SEG_C | SEG_D | SEG_E | SEG_F)
+#define GLYPH_S (SEG_A | SEG_C | SEG_D | SEG_F | SEG_G)
+#define GLYPH_T (SEG_D | SEG_E | SEG_F | SEG_G)
+
+static const struct spi_dt_spec max7221_spi =
+	SPI_DT_SPEC_GET(DT_NODELABEL(max7221), SPI_WORD_SET(8) | SPI_OP_MODE_MASTER, 0);
+
+static int max7221_write(uint8_t reg, uint8_t val)
+{
+	uint8_t frame[2] = {reg, val};
+	const struct spi_buf buf = {.buf = frame, .len = sizeof(frame)};
+	const struct spi_buf_set tx = {.buffers = &buf, .count = 1};
+
+	return spi_write_dt(&max7221_spi, &tx);
+}
+
+/* Write the 8 digit registers from a segment-pattern array, DIG0 first. */
+static int post_display_raw(const uint8_t segs[8])
+{
+	for (int digit = 0; digit < 8; digit++) {
+		int ret = max7221_write(MAX7221_REG_DIGIT0 + digit, segs[digit]);
+
+		if (ret < 0) {
+			LOG_ERR("MAX7221 digit %d write failed: %d", digit, ret);
+			return ret;
+		}
+	}
+	return 0;
+}
+
+/*
+ * Physical left-to-right position -> MAX7221 DIG index.
+ *
+ * Measured on the bench with `post map`: the leftmost four positions are D21
+ * carrying DIG4..DIG7, then D22 carrying DIG0..DIG3. Everything above this
+ * function works in reading order and lets this table do the translation.
+ */
+static const uint8_t post_pos_to_dig[8] = {4, 5, 6, 7, 0, 1, 2, 3};
+
+/* Write segment patterns given in reading order (leftmost first). */
+static int post_display_positions(const uint8_t pos_segs[8])
+{
+	uint8_t segs[8] = {0};
+
+	for (int pos = 0; pos < 8; pos++) {
+		segs[post_pos_to_dig[pos]] = pos_segs[pos];
+	}
+	return post_display_raw(segs);
+}
+
+/* Show "POST" then a 4-digit hex code, in reading order. */
+int post_code_show(uint16_t code)
+{
+	const uint8_t pos_segs[8] = {
+		GLYPH_P, GLYPH_O, GLYPH_S, GLYPH_T,
+		post_font_hex[(code >> 12) & 0xF],
+		post_font_hex[(code >> 8) & 0xF],
+		post_font_hex[(code >> 4) & 0xF],
+		post_font_hex[code & 0xF],
+	};
+
+	LOG_INF("POST code %04x", code);
+	return post_display_positions(pos_segs);
+}
+
+/* Light every segment of every digit from the digit registers (not display
+ * test) -- proves each digit position works with real data.
+ */
+static int post_all_segments(void)
+{
+	uint8_t segs[8];
+
+	memset(segs, 0xFF, sizeof(segs));
+	return post_display_raw(segs);
+}
+
+/* Write numeral N into digit N: the display then spells out its own physical
+ * digit order, so the DIG-to-position mapping can be read at a glance.
+ */
+static int post_map_digits(void)
+{
+	uint8_t pos_segs[8];
+
+	/* Numeral N at physical position N: reads 01234567 left to right when
+	 * post_pos_to_dig is correct -- a one-glance self-check of the mapping.
+	 */
+	for (int pos = 0; pos < 8; pos++) {
+		pos_segs[pos] = post_font_hex[pos];
+	}
+	return post_display_positions(pos_segs);
+}
+
+/* Walk one digit at a time so a dead position is obvious. */
+static int post_walk_digits(const struct shell *sh)
+{
+	for (int pos = 0; pos < 8; pos++) {
+		uint8_t pos_segs[8] = {0};
+
+		pos_segs[pos] = 0xFF;
+		int ret = post_display_positions(pos_segs);
+
+		if (ret < 0) {
+			return ret;
+		}
+		shell_print(sh, "  position %d from left lit (DIG%d)", pos + 1,
+			    post_pos_to_dig[pos]);
+		k_sleep(K_MSEC(1200));
+	}
+	return 0;
+}
+
+static int cmd_post(const struct shell *sh, size_t argc, char **argv)
+{
+	int ret;
+
+	if (strcmp(argv[1], "test") == 0) {
+		ret = post_all_segments();
+		if (ret == 0) {
+			shell_print(sh, "all digits: every segment on (from digit data)");
+		}
+	} else if (strcmp(argv[1], "walk") == 0) {
+		ret = post_walk_digits(sh);
+	} else if (strcmp(argv[1], "map") == 0) {
+		ret = post_map_digits();
+		if (ret == 0) {
+			shell_print(sh, "digit N shows numeral N -- read the display "
+					"left to right to get the physical order");
+		}
+	} else {
+		uint16_t code = (uint16_t)strtoul(argv[1], NULL, 16);
+
+		ret = post_code_show(code);
+		if (ret == 0) {
+			shell_print(sh, "POST %04x displayed", code);
+		}
+	}
+
+	if (ret < 0) {
+		shell_error(sh, "failed to write display: %d", ret);
+	}
+	return ret;
+}
+
+SHELL_CMD_ARG_REGISTER(post, NULL,
+		       "MAX7221 POST-code display\n"
+		       "Usage: post <hex code>   e.g. post 0042\n"
+		       "       post test         all segments on, every digit\n"
+		       "       post walk         light one digit at a time\n"
+		       "       post map          write numeral N into digit N",
+		       cmd_post, 2, 0);
+#endif /* max7221 */
+
 int main(void)
 {
 	LOG_INF("Hello World! This is dm_test_app running on %s", CONFIG_BOARD);
+
+#if DT_NODE_EXISTS(DT_NODELABEL(max7221))
+	/* Boot POST code: 0x0001 = firmware reached main(). */
+	post_code_show(0x0001);
+#endif
 
 #ifdef CONFIG_I3C_TARGET
 	int ret;

--- a/boards/tenstorrent/tt_grendel_mk_bu_dmc/Kconfig.tt_grendel_mk_bu_dmc
+++ b/boards/tenstorrent/tt_grendel_mk_bu_dmc/Kconfig.tt_grendel_mk_bu_dmc
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_TT_GRENDEL_MK_BU_DMC
-	select SOC_STM32U385XX
+	select SOC_STM32U375XX

--- a/boards/tenstorrent/tt_grendel_mk_bu_dmc/board.cmake
+++ b/boards/tenstorrent/tt_grendel_mk_bu_dmc/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Configure pyocd runner for STM32U385
-board_runner_args(pyocd "--target=stm32u385rgtxq")
+# Configure pyocd runner for STM32U375
+board_runner_args(pyocd "--target=stm32u375rgt6")
 
 # Include common pyocd board configuration
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/tenstorrent/tt_grendel_mk_bu_dmc/board.yml
+++ b/boards/tenstorrent/tt_grendel_mk_bu_dmc/board.yml
@@ -3,4 +3,4 @@ board:
   full_name: Tenstorrent Grendel MK BU Device Management Controller
   vendor: tenstorrent
   socs:
-    - name: stm32u385xx
+    - name: stm32u375xx

--- a/boards/tenstorrent/tt_grendel_mk_bu_dmc/tt_grendel_mk_bu_dmc.dts
+++ b/boards/tenstorrent/tt_grendel_mk_bu_dmc/tt_grendel_mk_bu_dmc.dts
@@ -144,7 +144,7 @@
 		size = <0x20000000>;  /* 512 Mb (megabits) */
 	};
 
-	max7221: max7221@0 {
+	max7221: max7221@1 {
 		compatible = "maxim,max7219";
 		reg = <1>;
 		spi-max-frequency = <1000000>;

--- a/boards/tenstorrent/tt_grendel_mk_bu_dmc/tt_grendel_mk_bu_dmc.dts
+++ b/boards/tenstorrent/tt_grendel_mk_bu_dmc/tt_grendel_mk_bu_dmc.dts
@@ -5,8 +5,8 @@
  */
 
 /dts-v1/;
-#include <st/u3/stm32u385Xg.dtsi>
-#include <st/u3/stm32u385rgtxq-pinctrl.dtsi>
+#include <st/u3/stm32u375Xg.dtsi>
+#include <st/u3/stm32u375rgtx-pinctrl.dtsi>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 
 / {

--- a/boards/tenstorrent/tt_grendel_mk_bu_dmc/tt_grendel_mk_bu_dmc.dts
+++ b/boards/tenstorrent/tt_grendel_mk_bu_dmc/tt_grendel_mk_bu_dmc.dts
@@ -30,7 +30,12 @@
 };
 
 &clk_lse {
-	status = "okay";
+	/* BRING-UP: 32.768 kHz crystal not populated on this board. Zephyr's
+	 * STM32 clock init enables every "okay" clock and polls its ready flag
+	 * with no timeout, so an absent LSE hangs boot before console init.
+	 * LSI (enabled below) covers any low-speed clock need.
+	 */
+	status = "disabled";
 };
 
 &clk_msik {
@@ -39,7 +44,11 @@
 
 &clk_msis {
 	status = "okay";
-	msi-pll-mode;
+	/* BRING-UP: msi-pll-mode removed with clk_lse disabled -- MSI PLL-mode
+	 * auto-calibration requires LSE or HSE, neither populated on this board.
+	 * MSI then runs on factory trim only (slightly looser accuracy, fine for
+	 * a 115200 console).
+	 */
 	msi-range = <0>; /* 96MHz (reset value) */
 };
 
@@ -116,13 +125,22 @@
 		     &spi2_mosi_pc3>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&gpiob 9 GPIO_ACTIVE_LOW>, <&gpioc 9 GPIO_ACTIVE_LOW>;
+	/* BRING-UP FIX: cs-gpios index 1 named PC9, but PC9 is the SPI level
+	 * shifter ENABLE (active high) -- driving it as an active-low chip
+	 * select disabled the shifter during every transfer, blocking the
+	 * data it was trying to send. The MAX7221 chip select is PC7.
+	 */
+	cs-gpios = <&gpiob 9 GPIO_ACTIVE_LOW>, <&gpioc 7 GPIO_ACTIVE_LOW>;
 
 	mt35xu512: mt35xu512@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(48)>;
-		status = "okay";
+		/* BRING-UP: driver init reads the JEDEC ID; with the flash rail
+		 * unpowered the SPI shift loop never completes and boot hangs
+		 * before the shell starts. Re-enable once the rail is up.
+		 */
+		status = "disabled";
 		size = <0x20000000>;  /* 512 Mb (megabits) */
 	};
 
@@ -133,6 +151,7 @@
 		num-cascading = <1>;
 		intensity = <8>;
 		scan-limit = <7>;
+		status = "okay";  /* BRING-UP: re-enabled to drive via the Zephyr driver */
 	};
 };
 


### PR DESCRIPTION

Update to the U375; the U385 was chosen for pinctrl testing on the nucleo, but the actual board has a u375.

The board doesn't have an external oscillator; use the internal one.

CS for the MAX was scribed wrong, and we can enable the node now.

Tests:

Build the `dmc_test_app` with board type `mk_bu_dmc`

Andrews got the DM test app working, and is happy with the display