### PR TITLE
bh: fw_table: add soft GDDR harvest mask override

### DIFF
--- a/drivers/misc/bh_fwtable/bh_fwtable.c
+++ b/drivers/misc/bh_fwtable/bh_fwtable.c
@@ -394,6 +394,14 @@ void tt_bh_fwtable_apply_ccfgovr(const struct device *dev)
 				ovr.feature_enable.kernel_throttler_at_floor_en;
 		}
 
+		if (ovr.has_dram_table && ovr.dram_table.has_soft_harvest_dram_mask) {
+			LOG_INF("CCFGOVR override: dram_table.soft_harvest_dram_mask = 0x%x",
+				ovr.dram_table.soft_harvest_dram_mask);
+			data->fw_table.dram_table.soft_harvest_dram_mask =
+				ovr.dram_table.soft_harvest_dram_mask;
+			data->fw_table.has_dram_table = true;
+		}
+
 		return;
 	}
 

--- a/drivers/misc/bh_fwtable/spirom_protobufs/fw_table_override.proto
+++ b/drivers/misc/bh_fwtable/spirom_protobufs/fw_table_override.proto
@@ -19,10 +19,11 @@ message FwTableOverride {
    * (FwTable field 1) is deliberately reserved here so tt-mod cannot forge
    * a bundle version.
    */
-  reserved 1, 4, 5, 6, 7, 8, 9, 10;
+  reserved 1, 4, 6, 7, 8, 9, 10;
 
   optional ChipLimits chip_limits = 2;
   optional FeatureEnable feature_enable = 3;
+  optional DramTable dram_table = 5;
 
   message ChipLimits {
 
@@ -37,5 +38,12 @@ message FwTableOverride {
     reserved 1, 2, 3, 4, 5, 6, 7, 8, 9;
 
     optional bool kernel_throttler_at_floor_en = 10;
+  }
+
+  message DramTable {
+
+    reserved 1, 2;
+
+    optional uint32 soft_harvest_dram_mask = 3;
   }
 }

--- a/lib/tenstorrent/bh_arc/harvesting.c
+++ b/lib/tenstorrent/bh_arc/harvesting.c
@@ -240,8 +240,6 @@ static int CalculateHarvesting(void)
 
 		/* Soft-harvest specific GDDR instances requested via the fw_table.
 		 * A set bit in soft_harvest_dram_mask forces that channel harvested.
-		 * Applied before the count-based harvest below, and only ever clears
-		 * bits so a fuse-harvested DRAM can never be re-enabled.
 		 */
 		if (tt_bh_fwtable_get_fw_table(fwtable_dev)->has_dram_table) {
 			tile_enable.gddr_enabled &= ~tt_bh_fwtable_get_fw_table(fwtable_dev)


### PR DESCRIPTION
Add dram_table.soft_harvest_dram_mask to the BH fw_table and CCFGOVR override flow so specific GDDR channels can be soft-harvested at runtime. This updates the fw_table and override protobufs, applies the override in tt_bh_fwtable_apply_ccfgovr(), and feeds the mask into harvesting by clearing the selected bits from tile_enable.gddr_enabled. 

Testing: used bh-mod set options to verify that setting different dram soft harvest masks will apply the new mask 
in fw_table. Verified via telemetry logging