### PR TITLE
lib: bh_arc: move Dm2CmReady into init

### DIFF
--- a/app/smc/src/main.c
+++ b/app/smc/src/main.c
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "cm2dm_msg.h"
 #include "timer.h"
 
 #include <zephyr/kernel.h>
@@ -20,8 +19,6 @@ BUILD_ASSERT(PARTITION_EXISTS(cmfw), "cmfw fixed-partition does not exist");
 
 int main(void)
 {
-	Dm2CmReadyRequest();
-
 #ifdef CONFIG_BOOTLOADER_MCUBOOT
 	int rc;
 

--- a/lib/tenstorrent/bh_arc/init.c
+++ b/lib/tenstorrent/bh_arc/init.c
@@ -11,7 +11,7 @@
 #include "status_reg.h"
 #include "telemetry.h"
 #include "timer.h"
-
+#include "cm2dm_msg.h"
 #include <stdint.h>
 
 #if defined(HAS_APP_VERSION)
@@ -136,6 +136,7 @@ static int bh_arc_init_end(void)
 #endif
 	StartGddrThermTripMonitor();
 #endif
+	Dm2CmReadyRequest();
 	return 0;
 }
 SYS_INIT_APP(bh_arc_init_end);


### PR DESCRIPTION
Move Dm2Cm ready into init, that way, emulated
boards can get DMC through to get the DMC version

tests:

This works in emulated platforms to get the DM version into the SMC.
Smoke locally.