### PR TITLE
fw_log_kmd: enable FW forwarding logs to KMD by default

### DIFF
--- a/doc/release/release-notes-19.14.md
+++ b/doc/release/release-notes-19.14.md
@@ -1,0 +1,24 @@
+# v19.14.0
+
+> This is a working draft for the up-coming 19.14.0 release.
+
+We are pleased to announce the release of TT System Firmware version 19.14.0 🥳🎉.
+
+Major enhancements with this release include:
+
+## What's Changed
+
+## Blackhole
+
+### KMD Logging
+- Enable the KMD firmware logging backend by default on Blackhole SMC.
+
+## Migration guide
+
+An overview of required and recommended changes to make when migrating from the previous v19.13.0 release can be found in [19.14 Migration Guide](https://github.com/tenstorrent/tt-system-firmware/tree/main/doc/release/migration-guide-19.14.md).
+
+## Full ChangeLog
+
+The full ChangeLog from the previous v19.13.0 release can be found at the link below.
+
+https://github.com/tenstorrent/tt-system-firmware/compare/v19.13.0...v19.14.0

--- a/doc/services/kmd_logging/index.rst
+++ b/doc/services/kmd_logging/index.rst
@@ -133,6 +133,7 @@ Current Behavior Notes
 ----------------------
 
 - Firmware batches data and sends only when host is ready.
+- ``printk()`` output, including the boot banner, is not forwarded to KMD.
 - If host has not yet consumed the previous batch, firmware drops the pending
   local batch for forward progress.
 - If local staged data exceeds available host payload space, firmware truncates

--- a/lib/tenstorrent/bh_arc/Kconfig.tt_pcie_log
+++ b/lib/tenstorrent/bh_arc/Kconfig.tt_pcie_log
@@ -1,27 +1,21 @@
 # Copyright (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-if LOG
-
 config TT_PCIE_LOG_BACKEND
 	bool "Enable Tenstorrent Host tt_pcie_log backend"
-	depends on !LOG_MODE_IMMEDIATE
+	depends on LOG && LOG_MODE_DEFERRED
+	default y if SOC_TT_BLACKHOLE_SMC
 	select LOG_OUTPUT
 	help
 	  Enable tt_pcie_log backend that outputs logs to shared host memory buffer
 	  via DMA for kernel module consumption. When host is not available,
 	  logs are stored in local buffer and transferred when host connects.
 
-if TT_PCIE_LOG_BACKEND
-
 config TT_PCIE_LOG_BACKEND_BUFFER_SIZE
 	int "Local log buffer size in bytes"
+	depends on TT_PCIE_LOG_BACKEND
 	default 4096
 	help
 	  Size of local buffer to aggregate logs into. Logs from this buffer
 	  are flushed on a timer, or when approaching capacity, and only if the
 	  host has messaged FW the buffer is available.
-
-endif # TT_PCIE_LOG_BACKEND
-
-endif # LOG

--- a/lib/tenstorrent/bh_arc/tt_pcie_log.c
+++ b/lib/tenstorrent/bh_arc/tt_pcie_log.c
@@ -329,6 +329,12 @@ static void backend_process(const struct log_backend *const backend, union log_m
 	uint32_t entry_start_pos;
 	uint32_t message_start_pos;
 
+	/* Do not forward LOG_RAW or printk output to the host. */
+	if (log_msg_get_level(&msg->log) == LOG_LEVEL_NONE &&
+	    log_msg_get_source(&msg->log) == NULL) {
+		return;
+	}
+
 	/* Lock mutex to prevent collision with flush timer */
 	if (k_mutex_lock(&buffer_mutex, K_MSEC(10)) != 0) {
 		/* Timeout - drop this data */


### PR DESCRIPTION
Enable FW forwarding logs to KMD by default.

Tests: Smoke, Stress, KMD CI, and also visually inspected that no boot banner appeared