### PR TITLE
boards: tenstorrent: galaxy_2 Add spi3 node and max7221 subnode

### DIFF
--- a/boards/tenstorrent/tt_blackhole_glx2_dmc/tt_blackhole_glx2_dmc.dts
+++ b/boards/tenstorrent/tt_blackhole_glx2_dmc/tt_blackhole_glx2_dmc.dts
@@ -260,6 +260,22 @@
 	};
 };
 
+&spi3 {
+	pinctrl-0 = <&spi3_nss_pa4 &spi3_sck_pc10
+		     &spi3_miso_pb4 &spi3_mosi_pd6>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	max7221: max7221@0 {
+		compatible = "maxim,max7219";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		num-cascading = <1>;
+		intensity = <0>;
+		scan-limit = <7>;
+	};
+};
+
 &nv_flash {
 #include "../tt_blackhole/tt_blackhole_fixed_partitions.dtsi"
 };


### PR DESCRIPTION
Add spi3 node to galaxy2 dmc dts.
Add max7221 subnode on spi3 (binds to max7219 driver `zephyr/drivers/display/display_max7219.c`)
- The driver is interchangeable between max7219/max7221.
- Datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/max7219-max7221.pdf

Verification:
- Verified spi3, max7221 nodes exist in compiled device tree
- Verify existence of maxim driver symbols in built `zephr.elf`

Open question: do we want to define a cs-gpio instead of using nss? The display is the only device on SPI3.