### PR TITLE
Revert to the correct CPU hart mapping

### DIFF
--- a/dts/vendor/tenstorrent/tt_grendel_smc.dtsi
+++ b/dts/vendor/tenstorrent/tt_grendel_smc.dtsi
@@ -49,7 +49,7 @@
 			compatible = "sifive,rocket0", "riscv";
 			device_type = "cpu";
 			mmu-type = "riscv,sv48";
-			reg = <0x0>;
+			reg = <0x1>;
 			riscv,isa-base = "rv64i";
 			riscv,isa-extensions = "m", "a", "f", "d", "c", "zicond", "zicsr",
 					       "zifencei", "zihpm", "xrocket";
@@ -68,7 +68,7 @@
 			compatible = "sifive,rocket0", "riscv";
 			device_type = "cpu";
 			mmu-type = "riscv,sv48";
-			reg = <0x0>;
+			reg = <0x2>;
 			riscv,isa-base = "rv64i";
 			riscv,isa-extensions = "m", "a", "f", "d", "c", "zicond", "zicsr",
 					       "zifencei", "zihpm", "xrocket";
@@ -87,7 +87,7 @@
 			compatible = "sifive,rocket0", "riscv";
 			device_type = "cpu";
 			mmu-type = "riscv,sv48";
-			reg = <0x0>;
+			reg = <0x3>;
 			riscv,isa-base = "rv64i";
 			riscv,isa-extensions = "m", "a", "f", "d", "c", "zicond", "zicsr",
 					       "zifencei", "zihpm", "xrocket";

--- a/scripts/ci/run-grendel-smoke.sh
+++ b/scripts/ci/run-grendel-smoke.sh
@@ -14,7 +14,7 @@ git clone git@yyz-gitlab.local.tenstorrent.com:syseng-platform/vdk-utils.git
 git clone git@yyz-gitlab.local.tenstorrent.com:tensix/tensix-hw/tt_smc.git
 
 cd vdk-utils
-TWISTER_DIR=$OUTDIR/tt_mimir_tt_mimir_smc/zephyr
+TWISTER_DIR=$(ls -d "$OUTDIR"/tt_mimir_tt_mimir_smc/zephyr* 2>/dev/null | head -n1)
 ZEPHYR_ELF=$TWISTER_DIR/tt-system-firmware/tests/drivers/tt_smc_remoteproc/
 ZEPHYR_ELF+=drivers.tt_smc_remoteproc.bl1_primary/tt_smc_remoteproc/zephyr/zephyr.elf
 PROD_ROM_ELF=../tt_smc/firmware/prod_rom-1.1.1-20260117-794e39bc/build/release/bin/prod_rom.elf


### PR DESCRIPTION
Revert to the correct CPU hart mapping. We previously had the correct
CPU hart mapping, but it was mistakenly removed in https://github.com/tenstorrent/tt-system-firmware/commit/a84d4c9a9b61d4b05f1876553806981d0aa984f7, causing
Grendel CI failures.

Proof it fixes CI: (linked in SYS-4582)

resolves: SYS-4582