### PR TITLE
fw_table: add gddr ctf thresholds and enable to fw table

### DIFF
--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -222,12 +222,10 @@ static bool process_gddr_therm_trip(struct bh_chip *chip, uint8_t msg_id, uint32
 {
 	switch (msg_data) {
 	case kGddrThermTripReasonInstantaneous:
-		LOG_ERR("GDDR thermal trip: instantaneous temp >= %dC",
-			GDDR_THERM_TRIP_CRITICAL_TEMP);
+		LOG_ERR("GDDR thermal trip: instantaneous over-temperature");
 		break;
 	case kGddrThermTripReasonSustained:
-		LOG_ERR("GDDR thermal trip: sustained temp >= %dC for %d minute(s)",
-			GDDR_THERM_TRIP_TEMP, GDDR_THERM_TRIP_DURATION_MIN);
+		LOG_ERR("GDDR thermal trip: sustained over-temperature");
 		break;
 	default:
 		LOG_ERR("GDDR thermal trip: unknown reason %u", msg_data);

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY/fw_table.txt
@@ -16,6 +16,9 @@ chip_limits {
   frequency_margin: 0
   gddr_thm_limit: 89
   kernel_throttler_stop_nops_freq: 0
+  gddr_therm_trip_temp: 95
+  gddr_therm_trip_critical_temp: 110
+  gddr_therm_trip_duration_min: 1
   max_tdp_limit: 200
 }
 
@@ -30,6 +33,7 @@ feature_enable {
   harvesting_en: true
   doppler_en: false
   kernel_throttler_at_floor_en: false
+  gddr_therm_trip_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY_2/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY_2/fw_table.txt
@@ -16,6 +16,9 @@ chip_limits {
   frequency_margin: 0
   gddr_thm_limit: 89
   kernel_throttler_stop_nops_freq: 0
+  gddr_therm_trip_temp: 95
+  gddr_therm_trip_critical_temp: 110
+  gddr_therm_trip_duration_min: 1
   max_tdp_limit: 200
 }
 
@@ -30,6 +33,7 @@ feature_enable {
   harvesting_en: true
   doppler_en: false
   kernel_throttler_at_floor_en: false
+  gddr_therm_trip_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY_REVC/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY_REVC/fw_table.txt
@@ -16,6 +16,9 @@ chip_limits {
   frequency_margin: 0
   gddr_thm_limit: 89
   kernel_throttler_stop_nops_freq: 0
+  gddr_therm_trip_temp: 95
+  gddr_therm_trip_critical_temp: 110
+  gddr_therm_trip_duration_min: 1
   max_tdp_limit: 200
 }
 
@@ -30,6 +33,7 @@ feature_enable {
   harvesting_en: true
   doppler_en: false
   kernel_throttler_at_floor_en: false
+  gddr_therm_trip_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/ORION_SLT/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/ORION_SLT/fw_table.txt
@@ -16,6 +16,9 @@ chip_limits {
   frequency_margin: 0
   gddr_thm_limit: 89
   kernel_throttler_stop_nops_freq: 0
+  gddr_therm_trip_temp: 95
+  gddr_therm_trip_critical_temp: 110
+  gddr_therm_trip_duration_min: 1
 }
 
 feature_enable {
@@ -29,6 +32,7 @@ feature_enable {
   harvesting_en: true
   doppler_en: true
   kernel_throttler_at_floor_en: false
+  gddr_therm_trip_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100/fw_table.txt
@@ -16,6 +16,9 @@ chip_limits {
   frequency_margin: 0
   gddr_thm_limit: 89
   kernel_throttler_stop_nops_freq: 0
+  gddr_therm_trip_temp: 95
+  gddr_therm_trip_critical_temp: 110
+  gddr_therm_trip_duration_min: 1
 }
 
 feature_enable {
@@ -29,6 +32,7 @@ feature_enable {
   harvesting_en: true
   doppler_en: false
   kernel_throttler_at_floor_en: false
+  gddr_therm_trip_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P100A/fw_table.txt
@@ -16,6 +16,9 @@ chip_limits {
   frequency_margin: 0
   gddr_thm_limit: 89
   kernel_throttler_stop_nops_freq: 0
+  gddr_therm_trip_temp: 95
+  gddr_therm_trip_critical_temp: 110
+  gddr_therm_trip_duration_min: 1
   board_power_limit: 300
   additional_board_power: 20
 }
@@ -31,6 +34,7 @@ feature_enable {
   harvesting_en: true
   doppler_en: true
   kernel_throttler_at_floor_en: false
+  gddr_therm_trip_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150A/fw_table.txt
@@ -16,6 +16,9 @@ chip_limits {
   frequency_margin: 0
   gddr_thm_limit: 89
   kernel_throttler_stop_nops_freq: 0
+  gddr_therm_trip_temp: 95
+  gddr_therm_trip_critical_temp: 110
+  gddr_therm_trip_duration_min: 1
   board_power_limit: 300
   additional_board_power: 20
 }
@@ -31,6 +34,7 @@ feature_enable {
   harvesting_en: true
   doppler_en: true
   kernel_throttler_at_floor_en: false
+  gddr_therm_trip_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150B/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150B/fw_table.txt
@@ -16,6 +16,9 @@ chip_limits {
   frequency_margin: 0
   gddr_thm_limit: 89
   kernel_throttler_stop_nops_freq: 0
+  gddr_therm_trip_temp: 95
+  gddr_therm_trip_critical_temp: 110
+  gddr_therm_trip_duration_min: 1
   board_power_limit: 300
   additional_board_power: 20
 }
@@ -31,6 +34,7 @@ feature_enable {
   harvesting_en: true
   doppler_en: true
   kernel_throttler_at_floor_en: false
+  gddr_therm_trip_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P150C/fw_table.txt
@@ -16,6 +16,9 @@ chip_limits {
   frequency_margin: 0
   gddr_thm_limit: 89
   kernel_throttler_stop_nops_freq: 0
+  gddr_therm_trip_temp: 95
+  gddr_therm_trip_critical_temp: 110
+  gddr_therm_trip_duration_min: 1
   board_power_limit: 450
   additional_board_power: 20
 }
@@ -31,6 +34,7 @@ feature_enable {
   harvesting_en: true
   doppler_en: true
   kernel_throttler_at_floor_en: false
+  gddr_therm_trip_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_L/fw_table.txt
@@ -16,6 +16,9 @@ chip_limits {
   frequency_margin: 0
   gddr_thm_limit: 89
   kernel_throttler_stop_nops_freq: 0
+  gddr_therm_trip_temp: 95
+  gddr_therm_trip_critical_temp: 110
+  gddr_therm_trip_duration_min: 1
   board_power_limit: 450
 }
 
@@ -30,6 +33,7 @@ feature_enable {
   harvesting_en: true
   doppler_en: false
   kernel_throttler_at_floor_en: false
+  gddr_therm_trip_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300A_R/fw_table.txt
@@ -16,6 +16,9 @@ chip_limits {
   frequency_margin: 0
   gddr_thm_limit: 89
   kernel_throttler_stop_nops_freq: 0
+  gddr_therm_trip_temp: 95
+  gddr_therm_trip_critical_temp: 110
+  gddr_therm_trip_duration_min: 1
   board_power_limit: 450
 }
 
@@ -30,6 +33,7 @@ feature_enable {
   harvesting_en: true
   doppler_en: false
   kernel_throttler_at_floor_en: false
+  gddr_therm_trip_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_L/fw_table.txt
@@ -16,6 +16,9 @@ chip_limits {
   frequency_margin: 0
   gddr_thm_limit: 89
   kernel_throttler_stop_nops_freq: 0
+  gddr_therm_trip_temp: 95
+  gddr_therm_trip_critical_temp: 110
+  gddr_therm_trip_duration_min: 1
   board_power_limit: 450
 }
 
@@ -30,6 +33,7 @@ feature_enable {
   harvesting_en: true
   doppler_en: false
   kernel_throttler_at_floor_en: false
+  gddr_therm_trip_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300B_R/fw_table.txt
@@ -16,6 +16,9 @@ chip_limits {
   frequency_margin: 0
   gddr_thm_limit: 89
   kernel_throttler_stop_nops_freq: 0
+  gddr_therm_trip_temp: 95
+  gddr_therm_trip_critical_temp: 110
+  gddr_therm_trip_duration_min: 1
   board_power_limit: 450
 }
 
@@ -30,6 +33,7 @@ feature_enable {
   harvesting_en: true
   doppler_en: false
   kernel_throttler_at_floor_en: false
+  gddr_therm_trip_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_L/fw_table.txt
@@ -16,6 +16,9 @@ chip_limits {
   frequency_margin: 0
   gddr_thm_limit: 89
   kernel_throttler_stop_nops_freq: 0
+  gddr_therm_trip_temp: 95
+  gddr_therm_trip_critical_temp: 110
+  gddr_therm_trip_duration_min: 1
   board_power_limit: 550
 }
 
@@ -30,6 +33,7 @@ feature_enable {
   harvesting_en: true
   doppler_en: false
   kernel_throttler_at_floor_en: false
+  gddr_therm_trip_en: false
 }
 
 fan_table {

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/P300C_R/fw_table.txt
@@ -16,6 +16,9 @@ chip_limits {
   frequency_margin: 0
   gddr_thm_limit: 89
   kernel_throttler_stop_nops_freq: 0
+  gddr_therm_trip_temp: 95
+  gddr_therm_trip_critical_temp: 110
+  gddr_therm_trip_duration_min: 1
   board_power_limit: 550
 }
 
@@ -30,6 +33,7 @@ feature_enable {
   harvesting_en: true
   doppler_en: false
   kernel_throttler_at_floor_en: false
+  gddr_therm_trip_en: false
 }
 
 fan_table {

--- a/drivers/misc/bh_fwtable/spirom_protobufs/fw_table.proto
+++ b/drivers/misc/bh_fwtable/spirom_protobufs/fw_table.proto
@@ -37,6 +37,9 @@ message FwTable {
     uint32 additional_board_power = 15;
     uint32 max_tdp_limit = 16;
     uint32 kernel_throttler_stop_nops_freq = 17;
+    uint32 gddr_therm_trip_temp = 18;
+    uint32 gddr_therm_trip_critical_temp = 19;
+    uint32 gddr_therm_trip_duration_min = 20;
   }
 
   message FeatureEnable {
@@ -50,6 +53,7 @@ message FwTable {
     bool fan_ctrl_en = 8;
     bool doppler_en = 9;
     bool kernel_throttler_at_floor_en = 10;
+    bool gddr_therm_trip_en = 11;
   }
 
   message FanTable{

--- a/include/tenstorrent/bh_arc.h
+++ b/include/tenstorrent/bh_arc.h
@@ -38,11 +38,6 @@ typedef enum {
 	kGddrThermTripReasonInstantaneous = 1,
 } GddrThermTripReason;
 
-/* GDDR thermal trip thresholds */
-#define GDDR_THERM_TRIP_TEMP          95  /* sustained over-temp threshold, degrees Celsius */
-#define GDDR_THERM_TRIP_CRITICAL_TEMP 110 /* instantaneous trip threshold, degrees Celsius */
-#define GDDR_THERM_TRIP_DURATION_MIN  1   /* sustained dwell time before trip, minutes */
-
 typedef struct dmStaticInfo {
 	/*
 	 * Non-zero for valid data

--- a/include/tenstorrent/msgqueue.h
+++ b/include/tenstorrent/msgqueue.h
@@ -796,6 +796,16 @@ struct char_throttle_stop_freq_submsg {
 	uint32_t frequency;
 };
 
+/** @brief Submessage for enabling/disabling the GDDR thermal-trip action
+ * @details Payload is a single uint32_t:
+ * - Value == 0: Disable GDDR thermal-trip action
+ * - Value == 1: Enable GDDR thermal-trip action
+ */
+struct char_gddr_therm_trip_enabled_submsg {
+	/** @brief 0 to disable, 1 to enable */
+	uint32_t enabled;
+};
+
 /** @brief Union of all possible characterization submessage payloads */
 union characterisation_submsg_data {
 	/** @brief Set host-requested minimum frequency floor */
@@ -804,6 +814,8 @@ union characterisation_submsg_data {
 	struct char_throttle_enabled_submsg throttler_enabled;
 	/** @brief Set frequency limit for stopping kernel throttler */
 	struct char_throttle_stop_freq_submsg throttler_stop_freq;
+	/** @brief Enable/disable GDDR thermal-trip action */
+	struct char_gddr_therm_trip_enabled_submsg gddr_therm_trip_enabled;
 	/* add to this union to define more sub-message payloads */
 	/** @brief Generic fallback for raw access */
 	uint8_t raw_data[4];

--- a/include/tenstorrent/smc_msg.h
+++ b/include/tenstorrent/smc_msg.h
@@ -178,6 +178,8 @@ enum char_submsg_ids {
 	TT_SUB_MSG_SET_KERNEL_THROTTLER_ENABLED = 0x2,
 	/** @brief Set frequency limit for stopping kernel throttler */
 	TT_SUB_MSG_SET_KERNEL_THROTTLER_STOP_NOPS_FREQ = 0x3,
+	/** @brief Enable/disable GDDR thermal-trip action on over-temperature */
+	TT_SUB_MSG_SET_GDDR_THERM_TRIP_ENABLED = 0x4,
 };
 
 /** @} */

--- a/lib/tenstorrent/bh_arc/Kconfig
+++ b/lib/tenstorrent/bh_arc/Kconfig
@@ -62,13 +62,6 @@ config TT_BH_ARC_FAN_CTRL_GDDR_TEMP
 	help
 	  Enable to use GDDR temp in fan speed calculation
 
-config TT_BH_ARC_GDDR_THERM_TRIP_ACTION
-	bool "Engage CATMON thermal trip on GDDR over-temperature"
-	default n
-	help
-	  Enable to trigger a CATMON thermal trip (shutting the ASIC down)
-	  on GDDR over-temperature.
-
 config TT_BH_ARC_I2C_TIMEOUT
 	bool "Time out if I2C transaction exceeds given duration"
 	default y

--- a/lib/tenstorrent/bh_arc/aiclk_ppm.c
+++ b/lib/tenstorrent/bh_arc/aiclk_ppm.c
@@ -5,6 +5,7 @@
  */
 
 #include "aiclk_ppm.h"
+#include "cat.h"
 #include "dvfs.h"
 #include "telemetry.h"
 #include "throttler.h"
@@ -536,6 +537,10 @@ static uint8_t characterisation_handler(const union request *request, struct res
 	case TT_SUB_MSG_SET_KERNEL_THROTTLER_STOP_NOPS_FREQ:
 		return ThrottlerSetKernelThrottlerStopFreq(
 			request->characterisation_msg.submsg_data.throttler_stop_freq.frequency);
+
+	case TT_SUB_MSG_SET_GDDR_THERM_TRIP_ENABLED:
+		return CatSetGddrThermTripEnabled(
+			request->characterisation_msg.submsg_data.gddr_therm_trip_enabled.enabled);
 
 	default:
 		LOG_WRN("Unknown characterization submessage ID: 0x%02x",

--- a/lib/tenstorrent/bh_arc/cat.c
+++ b/lib/tenstorrent/bh_arc/cat.c
@@ -17,6 +17,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/init.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/sensor.h>
@@ -55,6 +56,15 @@ typedef union {
 #ifndef CONFIG_TT_SMC_RECOVERY
 
 static const int gddr_therm_trip_interval = 100;
+
+static bool gddr_therm_trip_enabled;
+
+/* Live trip thresholds, seeded from chip_limits at init */
+static int gddr_therm_trip_temp;
+static int gddr_therm_trip_critical_temp;
+static int64_t gddr_therm_trip_duration_ms;
+
+static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
 
 static const struct device *const pvt = DEVICE_DT_GET(DT_NODELABEL(pvt));
 
@@ -208,18 +218,19 @@ static int CATInit(void)
 }
 SYS_INIT_APP(CATInit);
 
-int MonitorGddrThermTrip(int64_t now, int max_temp)
+int EvaluateGddrThermTrip(int64_t now, int max_temp, int trip_temp, int critical_temp,
+			  int64_t duration_ms)
 {
 	static bool tracking;
 	static int64_t over_temp_start_time;
 
-	if (max_temp >= CAT_GDDR_THERM_TRIP_CRITICAL_TEMP) {
-		LOG_ERR("Max GDDR temp %dC >= %dC", max_temp, CAT_GDDR_THERM_TRIP_CRITICAL_TEMP);
+	if (critical_temp != 0 && max_temp >= critical_temp) {
+		LOG_ERR("Max GDDR temp %dC >= %dC", max_temp, critical_temp);
 		tracking = false;
 		return max_temp;
 	}
 
-	if (max_temp < CAT_GDDR_THERM_TRIP_TEMP) {
+	if (trip_temp == 0 || max_temp < trip_temp) {
 		tracking = false;
 		return 0;
 	}
@@ -227,9 +238,9 @@ int MonitorGddrThermTrip(int64_t now, int max_temp)
 	if (!tracking) {
 		tracking = true;
 		over_temp_start_time = now;
-	} else if (now - over_temp_start_time >= CAT_GDDR_THERM_TRIP_DURATION_MS) {
-		LOG_ERR("Max GDDR temp %dC >= %dC for >= %d ms", max_temp, CAT_GDDR_THERM_TRIP_TEMP,
-			CAT_GDDR_THERM_TRIP_DURATION_MS);
+	} else if (now - over_temp_start_time >= duration_ms) {
+		LOG_ERR("Max GDDR temp %dC >= %dC for >= %lld ms", max_temp, trip_temp,
+			(long long)duration_ms);
 		tracking = false;
 		return max_temp;
 	}
@@ -237,7 +248,12 @@ int MonitorGddrThermTrip(int64_t now, int max_temp)
 	return 0;
 }
 
-#ifdef CONFIG_TT_BH_ARC_GDDR_THERM_TRIP_ACTION
+static int MonitorGddrThermTrip(int64_t now, int max_temp)
+{
+	return EvaluateGddrThermTrip(now, max_temp, gddr_therm_trip_temp,
+				     gddr_therm_trip_critical_temp, gddr_therm_trip_duration_ms);
+}
+
 static void TriggerThermTrip(void)
 {
 	if (!IS_ENABLED(CONFIG_ARC)) {
@@ -256,7 +272,6 @@ static void gddr_therm_trip_trigger_handler(struct k_work *work)
 }
 
 static K_WORK_DELAYABLE_DEFINE(gddr_therm_trip_trigger_work, gddr_therm_trip_trigger_handler);
-#endif /* CONFIG_TT_BH_ARC_GDDR_THERM_TRIP_ACTION */
 
 static void gddr_therm_trip_work_handler(struct k_work *work)
 {
@@ -269,16 +284,15 @@ static void gddr_therm_trip_work_handler(struct k_work *work)
 
 	int max_temp = MonitorGddrThermTrip(k_uptime_get(), GetTelemetryTag(TAG_MAX_GDDR_TEMP));
 
-	if (max_temp) {
+	if (max_temp && gddr_therm_trip_enabled) {
 		/* Notify DMC, then trigger therm trip after delay so DMC can read the message */
 		trip_pending = true;
-		ReportGddrThermTrip(max_temp >= CAT_GDDR_THERM_TRIP_CRITICAL_TEMP
+		ReportGddrThermTrip(max_temp >= gddr_therm_trip_critical_temp &&
+						    gddr_therm_trip_critical_temp != 0
 					    ? kGddrThermTripReasonInstantaneous
 					    : kGddrThermTripReasonSustained);
-#ifdef CONFIG_TT_BH_ARC_GDDR_THERM_TRIP_ACTION
 		k_work_schedule(&gddr_therm_trip_trigger_work,
 				K_MSEC(GDDR_THERM_TRIP_DMC_NOTIFY_MS));
-#endif /* CONFIG_TT_BH_ARC_GDDR_THERM_TRIP_ACTION */
 	}
 }
 
@@ -295,6 +309,18 @@ static K_TIMER_DEFINE(gddr_therm_trip_timer, gddr_therm_trip_timer_handler, NULL
 
 void StartGddrThermTripMonitor(void)
 {
+	const FwTable *fw_table = tt_bh_fwtable_get_fw_table(fwtable_dev);
+
+	gddr_therm_trip_enabled = fw_table->feature_enable.gddr_therm_trip_en;
+
+	/* Thresholds come straight from chip_limits. A value of 0 means "unset"
+	 * and disables that trip path in MonitorGddrThermTrip
+	 */
+	gddr_therm_trip_temp = fw_table->chip_limits.gddr_therm_trip_temp;
+	gddr_therm_trip_critical_temp = fw_table->chip_limits.gddr_therm_trip_critical_temp;
+	gddr_therm_trip_duration_ms =
+		(int64_t)fw_table->chip_limits.gddr_therm_trip_duration_min * 60 * 1000;
+
 	k_timer_start(&gddr_therm_trip_timer, K_MSEC(gddr_therm_trip_interval),
 		      K_MSEC(gddr_therm_trip_interval));
 }

--- a/lib/tenstorrent/bh_arc/cat.c
+++ b/lib/tenstorrent/bh_arc/cat.c
@@ -57,8 +57,6 @@ typedef union {
 
 static const int gddr_therm_trip_interval = 100;
 
-static bool gddr_therm_trip_enabled;
-
 /* Live trip thresholds, seeded from chip_limits at init */
 static int gddr_therm_trip_temp;
 static int gddr_therm_trip_critical_temp;
@@ -273,6 +271,13 @@ static void gddr_therm_trip_trigger_handler(struct k_work *work)
 
 static K_WORK_DELAYABLE_DEFINE(gddr_therm_trip_trigger_work, gddr_therm_trip_trigger_handler);
 
+uint8_t CatSetGddrThermTripEnabled(bool enabled)
+{
+	LOG_INF("GDDR thermal trip action %s", enabled ? "enabled" : "disabled");
+	UpdateTelemetryGddrThermTrip(enabled);
+	return 0;
+}
+
 static void gddr_therm_trip_work_handler(struct k_work *work)
 {
 	ARG_UNUSED(work);
@@ -284,7 +289,7 @@ static void gddr_therm_trip_work_handler(struct k_work *work)
 
 	int max_temp = MonitorGddrThermTrip(k_uptime_get(), GetTelemetryTag(TAG_MAX_GDDR_TEMP));
 
-	if (max_temp && gddr_therm_trip_enabled) {
+	if (max_temp && GetActiveFeatures().gddr_therm_trip) {
 		/* Notify DMC, then trigger therm trip after delay so DMC can read the message */
 		trip_pending = true;
 		ReportGddrThermTrip(max_temp >= gddr_therm_trip_critical_temp &&
@@ -310,8 +315,6 @@ static K_TIMER_DEFINE(gddr_therm_trip_timer, gddr_therm_trip_timer_handler, NULL
 void StartGddrThermTripMonitor(void)
 {
 	const FwTable *fw_table = tt_bh_fwtable_get_fw_table(fwtable_dev);
-
-	gddr_therm_trip_enabled = fw_table->feature_enable.gddr_therm_trip_en;
 
 	/* Thresholds come straight from chip_limits. A value of 0 means "unset"
 	 * and disables that trip path in MonitorGddrThermTrip

--- a/lib/tenstorrent/bh_arc/cat.h
+++ b/lib/tenstorrent/bh_arc/cat.h
@@ -7,6 +7,8 @@
 #ifndef CAT_H
 #define CAT_H
 
+#include <stdbool.h>
+
 #include <tenstorrent/bh_arc.h>
 
 #define T_J_SHUTDOWN 110 /* BH Prod Spec 7.3 */
@@ -28,5 +30,12 @@ void StartGddrThermTripMonitor(void);
  */
 int EvaluateGddrThermTrip(int64_t now, int max_temp, int trip_temp, int critical_temp,
 			  int64_t duration_ms);
+
+/** @brief Enable or disable the GDDR thermal-trip action at runtime.
+ *
+ * @param enabled false to disable, true to enable.
+ * @return 0 on success.
+ */
+uint8_t CatSetGddrThermTripEnabled(bool enabled);
 
 #endif

--- a/lib/tenstorrent/bh_arc/cat.h
+++ b/lib/tenstorrent/bh_arc/cat.h
@@ -11,11 +11,22 @@
 
 #define T_J_SHUTDOWN 110 /* BH Prod Spec 7.3 */
 
-#define CAT_GDDR_THERM_TRIP_TEMP          GDDR_THERM_TRIP_TEMP
-#define CAT_GDDR_THERM_TRIP_CRITICAL_TEMP GDDR_THERM_TRIP_CRITICAL_TEMP
-#define CAT_GDDR_THERM_TRIP_DURATION_MS   (GDDR_THERM_TRIP_DURATION_MIN * 60 * 1000)
-
 void StartGddrThermTripMonitor(void);
-int MonitorGddrThermTrip(int64_t now, int max_temp);
+
+/** @brief Evaluate the GDDR thermal-trip state machine for one sample against
+ * the supplied thresholds.
+ *
+ * Production code uses the internal MonitorGddrThermTrip wrapper, which supplies
+ * the thresholds seeded from the firmware table at init.
+ *
+ * @param now            Current uptime in milliseconds.
+ * @param max_temp       Highest observed GDDR temperature in degrees Celsius.
+ * @param trip_temp      Sustained over-temp threshold in degrees Celsius.
+ * @param critical_temp  Instantaneous (no-dwell) trip threshold in degrees Celsius.
+ * @param duration_ms    Sustained dwell time before tripping, in milliseconds.
+ * @return The tripping temperature (non-zero) when a trip fires, otherwise 0.
+ */
+int EvaluateGddrThermTrip(int64_t now, int max_temp, int trip_temp, int critical_temp,
+			  int64_t duration_ms);
 
 #endif

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -260,6 +260,16 @@ void UpdateTelemetryKernelThrottler(bool enabled, uint32_t stop_nops_freq)
 	telemetry[TAG_KERNEL_THROTTLER] = (enabled ? 1U : 0U) | ((stop_nops_freq & 0xFFFFU) << 16U);
 }
 
+void UpdateTelemetryGddrThermTrip(bool enabled)
+{
+	telemetry_feature_flags_0_t active_config = {
+		.u32_all = telemetry[TAG_FW_ACTIVE_CONFIG_0],
+	};
+
+	active_config.bits.gddr_therm_trip = enabled ? 1U : 0U;
+	telemetry[TAG_FW_ACTIVE_CONFIG_0] = active_config.u32_all;
+}
+
 telemetry_feature_flags_bits_0_t GetActiveFeatures(void)
 {
 	telemetry_feature_flags_0_t active_config = {
@@ -473,11 +483,14 @@ static void write_static_telemetry(uint32_t app_version)
 	telemetry[TAG_GDDR_MRISC_NOC2AXI_PORT] = get_gddr_mrisc_endpoints();
 
 	fw_capabilities.bits.kernel_nops_at_aiclk_fmin = 1U;
+	fw_capabilities.bits.gddr_therm_trip = 1U;
 	telemetry[TAG_FW_CAPABILITIES_0] = fw_capabilities.u32_all;
 
 	active_config.bits.kernel_nops_at_aiclk_fmin =
 		tt_bh_fwtable_get_fw_table(fwtable_dev)
 			->feature_enable.kernel_throttler_at_floor_en;
+	active_config.bits.gddr_therm_trip =
+		tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.gddr_therm_trip_en;
 	telemetry[TAG_FW_ACTIVE_CONFIG_0] = active_config.u32_all;
 }
 

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -70,8 +70,17 @@ typedef struct {
 	 */
 	uint32_t kernel_nops_at_aiclk_fmin: 1;
 
+	/** @brief GDDR thermal-trip action feature.
+	 *
+	 * When enabled, sustained or critical GDDR over-temperature engages a
+	 * CATMON thermal trip (shutting the ASIC down). This bit is controlled
+	 * at runtime by the host with @ref TT_SMC_MSG_CHARACTERISATION using
+	 * @ref TT_SUB_MSG_SET_GDDR_THERM_TRIP_ENABLED.
+	 */
+	uint32_t gddr_therm_trip: 1;
+
 	/** @brief Reserved for future use. */
-	uint32_t reserved: 31;
+	uint32_t reserved: 30;
 } telemetry_feature_flags_bits_0_t;
 
 /** @brief Packed 32-bit representation of @ref telemetry_feature_flags_bits_0_t. */
@@ -457,6 +466,7 @@ typedef union {
  * Current assignments:
  * - bit 0 (`kernel_nops_at_aiclk_fmin`): firmware supports the
  *   kernel-throttler-at-AICLK-floor feature.
+ * - bit 1 (`gddr_therm_trip`): firmware supports the GDDR thermal-trip action.
  */
 #define TAG_FW_CAPABILITIES_0 78
 
@@ -466,10 +476,13 @@ typedef union {
  *
  * Current assignments:
  * - bit 0 (`kernel_nops_at_aiclk_fmin`): kernel-throttler-at-AICLK-floor is enabled.
+ * - bit 1 (`gddr_therm_trip`): GDDR thermal-trip action is enabled.
  *
  * Runtime control:
- * - The host can enable or disable this bit with @ref TT_SMC_MSG_CHARACTERISATION
+ * - The host can enable or disable bit 0 with @ref TT_SMC_MSG_CHARACTERISATION
  *   and @ref TT_SUB_MSG_SET_KERNEL_THROTTLER_ENABLED.
+ * - The host can enable or disable bit 1 with @ref TT_SMC_MSG_CHARACTERISATION
+ *   and @ref TT_SUB_MSG_SET_GDDR_THERM_TRIP_ENABLED.
  */
 #define TAG_FW_ACTIVE_CONFIG_0 79
 
@@ -494,6 +507,8 @@ void UpdateTelemetryTdpLimit(uint32_t tdp_limit);
 void UpdateTelemetryThermTripCount(uint16_t therm_trip_count);
 void UpdateTelemetryHostAiclkLimit(uint32_t fmax);
 void UpdateTelemetryKernelThrottler(bool enabled, uint32_t stop_nops_freq);
+/** @brief Update the GDDR thermal-trip active-config bit in @ref TAG_FW_ACTIVE_CONFIG_0. */
+void UpdateTelemetryGddrThermTrip(bool enabled);
 /** @brief Get the current active firmware feature bits from @ref TAG_FW_ACTIVE_CONFIG_0.
  * @ingroup telemetry_feature_capabilities
  *

--- a/tests/lib/tenstorrent/bh_arc/src/cat.c
+++ b/tests/lib/tenstorrent/bh_arc/src/cat.c
@@ -11,15 +11,21 @@
 
 #include "cat.h"
 
-#define HOT      CAT_GDDR_THERM_TRIP_TEMP          /* at the sustained threshold */
-#define COLD     (CAT_GDDR_THERM_TRIP_TEMP - 1)    /* just below the threshold */
-#define CRITICAL CAT_GDDR_THERM_TRIP_CRITICAL_TEMP /* immediate-trip threshold */
-#define DUR      CAT_GDDR_THERM_TRIP_DURATION_MS
+/* Representative thresholds for exercising the state machine; these are local
+ * to the test and independent of any firmware-table values.
+ */
+#define HOT      95              /* at the sustained threshold */
+#define COLD     (HOT - 1)       /* just below the threshold */
+#define CRITICAL 110             /* immediate-trip threshold */
+#define DUR      (1 * 60 * 1000) /* sustained dwell time, ms */
+
+/* Exercise the monitor with the default thresholds. */
+#define MONITOR(now, temp) EvaluateGddrThermTrip((now), (temp), HOT, CRITICAL, DUR)
 
 /* Run one cold pass to clear the monitor's internal tracking between tests */
 static void cool(void)
 {
-	(void)MonitorGddrThermTrip(0, COLD);
+	(void)MONITOR(0, COLD);
 }
 
 static void before(void *fixture)
@@ -31,38 +37,44 @@ static void before(void *fixture)
 ZTEST(cat, test_all_cold_never_trips)
 {
 	/* Not hot, so even after a long time nothing trips */
-	zassert_equal(MonitorGddrThermTrip(DUR + 1000, COLD), 0);
+	zassert_equal(MONITOR(DUR + 1000, COLD), 0);
 }
 
 ZTEST(cat, test_brief_spike_does_not_trip)
 {
-	zassert_equal(MonitorGddrThermTrip(0, HOT), 0, "should not trip on first hot reading");
+	zassert_equal(MONITOR(0, HOT), 0, "should not trip on first hot reading");
 
 	/* Hot, but not yet for the full duration */
-	zassert_equal(MonitorGddrThermTrip(DUR - 1, HOT), 0,
-		      "should not trip before duration elapses");
+	zassert_equal(MONITOR(DUR - 1, HOT), 0, "should not trip prior to duration elapsing");
 
 	/* Cools off before the window completes, must not trip afterward */
-	zassert_equal(MonitorGddrThermTrip(DUR + 1000, COLD), 0,
-		      "cooling off must reset the timer");
+	zassert_equal(MONITOR(DUR + 1000, COLD), 0, "cooling off must reset the timer");
 }
 
 ZTEST(cat, test_sustained_over_temp_trips)
 {
-	zassert_equal(MonitorGddrThermTrip(0, HOT), 0);
+	zassert_equal(MONITOR(0, HOT), 0);
 
 	/* One millisecond short of the duration, still no trip */
-	zassert_equal(MonitorGddrThermTrip(DUR - 1, HOT), 0);
+	zassert_equal(MONITOR(DUR - 1, HOT), 0);
 
 	/* Exactly at the duration boundary (>=), trip returning the max temp */
-	zassert_equal(MonitorGddrThermTrip(DUR, HOT), HOT, "sustained over-temp must trip");
+	zassert_equal(MONITOR(DUR, HOT), HOT, "sustained over-temp must trip");
 }
 
 ZTEST(cat, test_critical_temp_trips_immediately)
 {
 	/* At or above the critical temperature there is no dwell requirement */
-	zassert_equal(MonitorGddrThermTrip(0, CRITICAL), CRITICAL,
-		      "critical temp must trip immediately");
+	zassert_equal(MONITOR(0, CRITICAL), CRITICAL, "critical temp must trip immediately");
+}
+
+ZTEST(cat, test_zero_thresholds_never_trip)
+{
+	/* Unset (0) thresholds disable their trip path, even at a scorching temp. */
+	zassert_equal(EvaluateGddrThermTrip(0, 200, 0, 0, DUR), 0,
+		      "zero thresholds must not trip on the first reading");
+	zassert_equal(EvaluateGddrThermTrip(DUR + 1000, 200, 0, 0, DUR), 0,
+		      "zero thresholds must not trip after the dwell time either");
 }
 
 ZTEST_SUITE(cat, NULL, NULL, before, NULL, NULL);


### PR DESCRIPTION
Add gddr therm trip thresholds (ie. temp, critical temp and duration) to chip limits and add gddr therm trip enable to feature enable of firmware table. Also add characterization submessage to enable/disable this feature, with default set to disabled.

Follow up PRs will include: KMD logging, ccfgovr support

Tests:
- Characterization submsg enables and disables feature as reported in telemetry
- Enablement causes gddr ctf trip (with modified threshold for test), but does not trip when disabled

Tested on p150a

Resolves: SYS-4907