### PR TITLE
boards: tenstorrent: Add second SPI mux for galaxy 2

### DIFF
--- a/app/dmc/src/main.c
+++ b/app/dmc/src/main.c
@@ -638,10 +638,13 @@ int main(void)
 		LOG_INF("Firmware update is confirmed.");
 	}
 
-	/* Force all spi_muxes back to arc control */
+	/* Force spi_mux back to arc (flash -> BH); on GLX2 also park mux1 on DMC */
 	ARRAY_FOR_EACH_BH_CHIP(chip) {
 		if (chip->config.spi_mux.port != NULL) {
 			gpio_pin_configure_dt(&chip->config.spi_mux, GPIO_OUTPUT_ACTIVE);
+		}
+		if (chip->config.spi_mux1.port != NULL) {
+			gpio_pin_configure_dt(&chip->config.spi_mux1, GPIO_OUTPUT_ACTIVE);
 		}
 	}
 

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_dmc.dtsi
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_dmc.dtsi
@@ -38,7 +38,7 @@
 
 		flash = <&flash1>;
 
-		/* Line to spi mux, drive low to enable dmfw -> eeprom */
+		/* SPI flash mux: low = flash <-> BH, high = flash <-> DMC */
 		spi_mux {
 			compatible = "zephyr,gpio-line";
 			gpios = <&gpiob 5 GPIO_ACTIVE_LOW>;

--- a/boards/tenstorrent/tt_blackhole_glx2_dmc/tt_blackhole_glx2_dmc.dts
+++ b/boards/tenstorrent/tt_blackhole_glx2_dmc/tt_blackhole_glx2_dmc.dts
@@ -51,10 +51,16 @@
 
 		flash = <&flash1>;
 
-		/* Line to spi mux, drive low to enable dmfw -> eeprom */
+		/* SPI flash mux0: low = flash <-> BH, high = flash <-> secondary (mux1) */
 		spi_mux {
 			compatible = "zephyr,gpio-line";
 			gpios = <&gpiob 0 GPIO_ACTIVE_LOW>;
+		};
+
+		/* SPI flash mux1: when mux0 high, low = flash <-> DMC, high = flash <-> B2B */
+		spi_mux1 {
+			compatible = "zephyr,gpio-line";
+			gpios = <&gpiob 1 GPIO_ACTIVE_LOW>;
 		};
 
 		/* Line to spi reset */
@@ -220,6 +226,28 @@
 			reg = <0xa>;
 			status = "okay";
 		};
+	};
+};
+
+/*
+ * Boot default: mux0 high + mux1 low -> DMC <-> flash
+ *   mux0 low             -> flash <-> BH
+ *   mux0 high, mux1 low  -> flash <-> DMC
+ *   mux0 high, mux1 high -> flash <-> B2B
+ */
+&gpiob {
+	status = "okay";
+
+	spi-flash-mux0 {
+		gpio-hog;
+		gpios = <0 GPIO_ACTIVE_HIGH>;
+		output-high; /* mux0 high: secondary path (see mux1) */
+	};
+
+	spi-flash-mux1 {
+		gpio-hog;
+		gpios = <1 GPIO_ACTIVE_HIGH>;
+		output-low; /* mux1 low: DMC <-> flash */
 	};
 };
 

--- a/include/tenstorrent/bh_chip.h
+++ b/include/tenstorrent/bh_chip.h
@@ -28,6 +28,7 @@ struct bh_chip_config {
 	struct gpio_dt_spec asic_reset;
 	struct gpio_dt_spec spi_reset;
 	struct gpio_dt_spec spi_mux;
+	struct gpio_dt_spec spi_mux1;
 	struct gpio_dt_spec pgood;
 	struct gpio_dt_spec therm_trip;
 	const struct device *flash;
@@ -147,6 +148,9 @@ extern struct bh_chip BH_CHIPS[BH_CHIP_COUNT];
 			.spi_mux = GPIO_DT_SPEC_GET(                                               \
 				DT_PHANDLE_OR_CHILD(DT_PHANDLE_BY_IDX(n, prop, idx), spi_mux),     \
 				gpios),                                                            \
+			.spi_mux1 = GPIO_DT_SPEC_GET_OR(                                           \
+				DT_PHANDLE_OR_CHILD(DT_PHANDLE_BY_IDX(n, prop, idx), spi_mux1),    \
+				gpios, {0}),                                                       \
 			.pgood = GPIO_DT_SPEC_GET(                                                 \
 				DT_PHANDLE_OR_CHILD(DT_PHANDLE_BY_IDX(n, prop, idx), pgood),       \
 				gpios),                                                            \


### PR DESCRIPTION
Add second SPI mux, `spi_mux1` for galaxy 2 which allows board to board (B2B) to access the flash.
mux0 (`spi_mux`) is the same as on blackhole PCIe cards.

MUX truth table (0 = low, active)
```
MUX0 | MUX1 | Route
0    |    x | flash → BH
1    |    0 | DMC → flash
1    |    1 | B2B → flash
```

Note that the gpio hog (pre-init) on blackhole PCIe cards (and on galaxy 2) is physical HIGH, ie. connects DMC to flash.
`main.c::main` then connects flash to SMC.