### PR TITLE
boards: tt_blackhole: build galaxy_2 boot images from source

### DIFF
--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_galaxy_2.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_galaxy_2.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * galaxy_2 postdates the v19.12.0 release, so no signed MCUBoot or recovery
+ * artifacts have been published for it. Build both from source until its blobs
+ * ship in a release.
+ */
+
+&cmfw {
+	binary-path = "$BUILD_DIR/mcuboot/zephyr/zephyr.bin";
+};
+
+&smc_recovery {
+	binary-path = "$BUILD_DIR/recovery/zephyr/zephyr.signed.bin";
+};
+
+&boot_fallback {
+	binary-path = "$BUILD_DIR/mcuboot/zephyr/zephyr.bin";
+};


### PR DESCRIPTION
Commit fdd8301 switched cmfw, safeimg and failover to prebuilt signed blobs named after $PROD_NAME, but only added blobs for the boards that existed at the time. galaxy_2 landed just before it, so the bootfs step now fails on a missing tt_blackhole_mcuboot_GALAXY_2.bin.

The blobs cannot simply be added: they come from a release's per-board fwbundle, and galaxy_2 postdates v19.12.0. Override the three partitions for this revision so both images are built from source until the board is validated on hardware and its blobs ship in a release, at which point deleting the overlay switches it over.

Tests: Build workflow in CI passes for galaxy 2