### PR TITLE
dts: update GPIO line labels in device tree overlays

### DIFF
--- a/app/dmc/boards/dmc_common.dtsi
+++ b/app/dmc/boards/dmc_common.dtsi
@@ -72,33 +72,33 @@
 			port-write-cycles = <2>;
 		};
 
+		/* Line to asic reset */
 		asic_reset {
 			compatible = "zephyr,gpio-line";
-			label = "Line to asic reset";
 			gpios = <&emul_gpio 0 GPIO_ACTIVE_LOW>;
 		};
 
+		/* Line to spi reset */
 		spi_reset {
 			compatible = "zephyr,gpio-line";
-			label = "Line to spi reset";
 			gpios = <&emul_gpio 1 GPIO_ACTIVE_LOW>;
 		};
 
+		/* Power good indicator */
 		pgood {
 			compatible = "zephyr,gpio-line";
-			label = "Power good indicator";
 			gpios = <&emul_gpio 3 GPIO_PULL_DOWN>;
 		};
 
+		/* Thermal trip indicator */
 		therm_trip {
 			compatible = "zephyr,gpio-line";
-			label = "Thermal trip indicator";
 			gpios = <&emul_gpio 2 GPIO_ACTIVE_HIGH>;
 		};
 
+		/* Line to spi mux */
 		spi_mux {
 			compatible = "zephyr,gpio-line";
-			label = "Line to spi mux";
 			gpios = <&emul_gpio 4 GPIO_ACTIVE_LOW>;
 		};
 
@@ -111,27 +111,27 @@
 		primary = <0>;
 	};
 
+	/* Input from PCIe card edge triggering an asic reset */
 	preset_trigger {
 		compatible = "zephyr,gpio-line";
-		label = "Input from PCIe card edge triggering an asic reset";
 		gpios = <&emul_gpio 5 GPIO_ACTIVE_LOW>;
 	};
 
+	/* PSU Sense 0 from 12V-2x6 connector */
 	psu_sense0 {
 		compatible = "zephyr,gpio-line";
-		label = "PSU Sense 0 from 12V-2x6 connector";
 		gpios = <&emul_gpio 6 GPIO_ACTIVE_HIGH>;
 	};
 
+	/* PSU Sense 1 from 12V-2x6 connector */
 	psu_sense1 {
 		compatible = "zephyr,gpio-line";
-		label = "PSU Sense 1 from 12V-2x6 connector";
 		gpios = <&emul_gpio 7 GPIO_ACTIVE_HIGH>;
 	};
 
+	/* LED Output to board fault indicator */
 	board_fault_led {
 		compatible = "zephyr,gpio-line";
-		label = "LED Output to board fault indicator";
 		gpios = <&emul_gpio 8 GPIO_ACTIVE_HIGH>;
 	};
 

--- a/app/dmc/boards/qemu_riscv32.overlay
+++ b/app/dmc/boards/qemu_riscv32.overlay
@@ -29,32 +29,32 @@
 		port-write-cycles = <2>;
 	};
 
+	/* ASIC reset line */
 	mcureset {
 		compatible = "zephyr,gpio-line";
-		label = "ASIC reset line";
 		gpios = <&gpio0 5 GPIO_PULL_DOWN>;
 	};
 
+	/* Spi reset line */
 	spireset {
 		compatible = "zephyr,gpio-line";
-		label = "Spi reset line";
 		gpios = <&gpio0 6 GPIO_PULL_DOWN>;
 	};
 
+	/* Power good indicator */
 	pgood {
 		compatible = "zephyr,gpio-line";
-		label = "Power good indicator";
 		gpios = <&gpio0 8 GPIO_PULL_DOWN>;
 	};
 
+	/* Enable to select the arc jtag, disable to select rambus */
 	arc_rambus_jtag_mux_sel: arc_rambus_jtag_mux_enable {
-		label = "Enable to select the arc jtag, disable to select rambus";
 		compatible = "zephyr,gpio-line";
 		gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 	};
 
+	/* Enable to select the arc jtag, disable to select l2cpu */
 	arc_l2_jtag_mux_sel: arc_l2_jtag_mux_enable {
-		label = "Enable to select the arc jtag, disable to select l2cpu";
 		compatible = "zephyr,gpio-line";
 		gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 	};

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_dmc.dtsi
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_dmc.dtsi
@@ -12,74 +12,74 @@
 	chip0: chip0 {
 		compatible = "tenstorrent,bh-chip";
 
+		/* Line to asic reset */
 		asic_reset {
 			compatible = "zephyr,gpio-line";
-			label = "Line to asic reset";
 			gpios = <&gpiob 0 GPIO_ACTIVE_LOW>;
 		};
 
+		/* Line to spi reset */
 		spi_reset {
 			compatible = "zephyr,gpio-line";
-			label = "Line to spi reset";
 			gpios = <&gpioc 7 GPIO_ACTIVE_LOW>;
 		};
 
+		/* Power good indicator */
 		pgood {
 			compatible = "zephyr,gpio-line";
-			label = "Power good indicator";
 			gpios = <&gpioc 14 GPIO_PULL_DOWN>;
 		};
 
+		/* Thermal trip indicator */
 		therm_trip {
 			compatible = "zephyr,gpio-line";
-			label = "Thermal trip indicator";
 			gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
 		};
 
 		flash = <&flash1>;
 
+		/* Line to spi mux, drive low to enable dmfw -> eeprom */
 		spi_mux {
 			compatible = "zephyr,gpio-line";
-			label = "Line to spi mux, drive low to enable dmfw -> eeprom";
 			gpios = <&gpiob 5 GPIO_ACTIVE_LOW>;
 		};
 
 		arc = <&chip0_arc>;
 	};
 
+	/* Input from PCIe card edge triggering an asic reset */
 	preset_trigger {
 		compatible = "zephyr,gpio-line";
-		label = "Input from PCIe card edge triggering an asic reset";
 		gpios = <&gpioa 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	};
 
+	/* LED Output to board fault indicator */
 	board_fault_led {
 		compatible = "zephyr,gpio-line";
-		label = "LED Output to board fault indicator";
 		gpios = <&gpioc 15 GPIO_ACTIVE_HIGH>;
 	};
 
+	/* PSU Sense 0 from 12V-2x6 connector */
 	psu_sense0 {
 		compatible = "zephyr,gpio-line";
-		label = "PSU Sense 0 from 12V-2x6 connector";
 		gpios = <&gpioa 6 GPIO_ACTIVE_HIGH>;
 	};
 
+	/* PSU Sense 1 from 12V-2x6 connector */
 	psu_sense1 {
 		compatible = "zephyr,gpio-line";
-		label = "PSU Sense 1 from 12V-2x6 connector";
 		gpios = <&gpiob 9 GPIO_ACTIVE_HIGH>;
 	};
 
+	/* Board ID 0 indicator */
 	board_id0 {
 		compatible = "zephyr,gpio-line";
-		label = "Board ID 0 indicator";
 		gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
 	};
 
+	/* Power reset */
 	powerreset {
 		compatible = "zephyr,gpio-line";
-		label = "Power reset";
 		gpios = <&gpiod 1 GPIO_ACTIVE_LOW>;
 	};
 };
@@ -253,7 +253,7 @@
 	max6639: max6639@2c {
 		status = "okay";
 		compatible = "maxim,max6639";
-		reg = <0x2C>;
+		reg = <0x2c>;
 
 		max6639_pwm: pwm {
 			label = "max6639_pwm";
@@ -375,7 +375,7 @@
 };
 
 &nv_flash {
-	#include "tt_blackhole_fixed_partitions.dtsi"
+#include "tt_blackhole_fixed_partitions.dtsi"
 };
 
 /* Define the DMC firmware partition for MCUBoot */

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc.dts
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc.dts
@@ -35,21 +35,21 @@
 
 	strapping {
 		/* Use QUAD DDR SPI mode, GPIO[39:38] = 2 is QUAD mode, GPIO40 is DDR_EN */
+		/* GPIO pin representing strap GPIO38_SPI_MODE_0 */
 		gpio38 {
 			compatible = "zephyr,gpio-line";
-			label = "GPIO pin representing strap GPIO38_SPI_MODE_0";
 			gpios = <&gpiox2 3 GPIO_ACTIVE_LOW>;
 		};
 
+		/* GPIO pin representing strap GPIO39_SPI_MODE_1 */
 		gpio39 {
 			compatible = "zephyr,gpio-line";
-			label = "GPIO pin representing strap GPIO39_SPI_MODE_1";
 			gpios = <&gpiox2 4 GPIO_ACTIVE_HIGH>;
 		};
 
+		/* GPIO pin representing strap GPIO40_SPI_DDR_EN */
 		gpio40 {
 			compatible = "zephyr,gpio-line";
-			label = "GPIO pin representing strap GPIO40_SPI_DDR_EN";
 			gpios = <&gpiox2 5 GPIO_ACTIVE_HIGH>;
 		};
 	};
@@ -100,8 +100,8 @@
 	pinctrl-0 = <&i2c3_scl_pa7 &i2c3_sda_pb4>;
 	pinctrl-names = "default";
 
-	chip0_arc: bh_arc@A {
+	chip0_arc: bh_arc@a {
 		compatible = "tenstorrent,bh-arc";
-		reg = <0xA>;
+		reg = <0xa>;
 	};
 };

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p100.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p100.overlay
@@ -67,21 +67,21 @@
 &chip0 {
 	/* Use OCTAL DDR SPI mode, GPIO[39:38] = 3 is OCTAL mode, GPIO40 is DDR_EN */
 	strapping {
+		/* GPIO pin representing strap GPIO38_SPI_MODE_0 */
 		gpio38 {
 			compatible = "zephyr,gpio-line";
-			label = "GPIO pin representing strap GPIO38_SPI_MODE_0";
 			gpios = <&gpiox7 3 GPIO_ACTIVE_HIGH>;
 		};
 
+		/* GPIO pin representing strap GPIO39_SPI_MODE_1 */
 		gpio39 {
 			compatible = "zephyr,gpio-line";
-			label = "GPIO pin representing strap GPIO39_SPI_MODE_1";
 			gpios = <&gpiox7 4 GPIO_ACTIVE_HIGH>;
 		};
 
+		/* GPIO pin representing strap GPIO40_SPI_DDR_EN */
 		gpio40 {
 			compatible = "zephyr,gpio-line";
-			label = "GPIO pin representing strap GPIO40_SPI_DDR_EN";
 			gpios = <&gpiox7 5 GPIO_ACTIVE_HIGH>;
 		};
 	};

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300a.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_dmc_p300a.overlay
@@ -43,27 +43,27 @@
 	chip1: chip1 {
 		compatible = "tenstorrent,bh-chip";
 
+		/* Line to asic reset */
 		asic_reset {
 			compatible = "zephyr,gpio-line";
-			label = "Line to asic reset";
 			gpios = <&gpiob 1 GPIO_ACTIVE_LOW>;
 		};
 
+		/* Line to SPI reset */
 		spi_reset {
 			compatible = "zephyr,gpio-line";
-			label = "Line to SPI reset";
 			gpios = <&gpioc 8 GPIO_ACTIVE_LOW>;
 		};
 
+		/* PGOOD signal for asic 1 */
 		pgood {
 			compatible = "zephyr,gpio-line";
-			label = "PGOOD signal for asic 1";
 			gpios = <&gpioc 5 GPIO_PULL_DOWN>;
 		};
 
+		/* Thermal trip indicator */
 		therm_trip {
 			compatible = "zephyr,gpio-line";
-			label = "Thermal trip indicator";
 			gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
 		};
 
@@ -79,52 +79,52 @@
 		};
 
 		strapping {
+			/* GPIO pin representing strap GPIO6_PCIE_BOOT_INSTANCE */
 			gpio6 {
 				compatible = "zephyr,gpio-line";
-				label = "GPIO pin representing strap GPIO6_PCIE_BOOT_INSTANCE";
 				gpios = <&gpiox0 4 GPIO_ACTIVE_HIGH>;
 			};
 
 			/* Use QUAD DDR SPI mode, GPIO[39:38] = 2 is QUAD mode, GPIO40 is DDR_EN */
+			/* GPIO pin representing strap GPIO38_SPI_MODE_0 */
 			gpio38 {
 				compatible = "zephyr,gpio-line";
-				label = "GPIO pin representing strap GPIO38_SPI_MODE_0";
 				gpios = <&gpiox0 13 GPIO_ACTIVE_LOW>;
 			};
 
+			/* GPIO pin representing strap GPIO39_SPI_MODE_1 */
 			gpio39 {
 				compatible = "zephyr,gpio-line";
-				label = "GPIO pin representing strap GPIO39_SPI_MODE_1";
 				gpios = <&gpiox0 14 GPIO_ACTIVE_HIGH>;
 			};
 
+			/* GPIO pin representing strap GPIO40_SPI_DDR_EN */
 			gpio40 {
 				compatible = "zephyr,gpio-line";
-				label = "GPIO pin representing strap GPIO40_SPI_DDR_EN";
 				gpios = <&gpiox0 15 GPIO_ACTIVE_HIGH>;
 			};
 		};
 
 		flash = <&chip1_flash>;
 
+		/* Line to spi mux, drive low to enable dmfw -> eeprom */
 		spi_mux {
 			compatible = "zephyr,gpio-line";
-			label = "Line to spi mux, drive low to enable dmfw -> eeprom";
 			gpios = <&gpiob 6 GPIO_ACTIVE_LOW>;
 		};
 
 		arc = <&chip1_arc>;
 	};
 
+	/* Line to SYS JTAG mux, drive low to enable dmfw -> eeprom */
 	arc_jtag_mux {
 		compatible = "zephyr,gpio-line";
-		label = "Line to SYS JTAG mux, drive low to enable dmfw -> eeprom";
 		gpios = <&gpiod 13 GPIO_ACTIVE_HIGH>;
 	};
 
+	/* Line to SYS JTAG mux, drive low to enable dmfw -> eeprom */
 	sys_jtag_mux {
 		compatible = "zephyr,gpio-line";
-		label = "Line to SYS JTAG mux, drive low to enable dmfw -> eeprom";
 		gpios = <&gpiod 14 GPIO_ACTIVE_HIGH>;
 	};
 
@@ -217,21 +217,21 @@
 
 	strapping {
 		/* Use QUAD DDR SPI mode, GPIO[39:38] = 2 is QUAD mode, GPIO40 is DDR_EN */
+		/* GPIO pin representing strap GPIO38_SPI_MODE_0 */
 		gpio38 {
 			compatible = "zephyr,gpio-line";
-			label = "GPIO pin representing strap GPIO38_SPI_MODE_0";
 			gpios = <&gpiox1 13 GPIO_ACTIVE_LOW>;
 		};
 
+		/* GPIO pin representing strap GPIO39_SPI_MODE_1 */
 		gpio39 {
 			compatible = "zephyr,gpio-line";
-			label = "GPIO pin representing strap GPIO39_SPI_MODE_1";
 			gpios = <&gpiox1 14 GPIO_ACTIVE_HIGH>;
 		};
 
+		/* GPIO pin representing strap GPIO40_SPI_DDR_EN */
 		gpio40 {
 			compatible = "zephyr,gpio-line";
-			label = "GPIO pin representing strap GPIO40_SPI_DDR_EN";
 			gpios = <&gpiox1 15 GPIO_ACTIVE_HIGH>;
 		};
 	};
@@ -245,9 +245,9 @@
 &smbus1 {
 	status = "okay";
 
-	chip0_arc: bh_arc@A {
+	chip0_arc: bh_arc@a {
 		compatible = "tenstorrent,bh-arc";
-		reg = <0xA>;
+		reg = <0xa>;
 
 		gpios = <&gpiof 8 GPIO_ACTIVE_LOW>;
 	};
@@ -293,9 +293,9 @@
 &smbus3 {
 	status = "okay";
 
-	chip1_arc: bh_arc@A {
+	chip1_arc: bh_arc@a {
 		compatible = "tenstorrent,bh-arc";
-		reg = <0xA>;
+		reg = <0xa>;
 
 		gpios = <&gpiof 9 GPIO_ACTIVE_LOW>;
 	};

--- a/boards/tenstorrent/tt_blackhole_glx2_dmc/tt_blackhole_glx2_dmc.dts
+++ b/boards/tenstorrent/tt_blackhole_glx2_dmc/tt_blackhole_glx2_dmc.dts
@@ -22,44 +22,44 @@
 		watchdog0 = &iwdg;
 	};
 
+	/* LED Output to board fault indicator */
 	board_fault_led {
 		compatible = "zephyr,gpio-line";
-		label = "LED Output to board fault indicator";
 		gpios = <&gpioc 3 GPIO_ACTIVE_HIGH>;
 	};
 
 	chip0: chip0 {
 		compatible = "tenstorrent,bh-chip";
 
+		/* Power good indicator */
 		pgood {
 			compatible = "zephyr,gpio-line";
-			label = "Power good indicator";
 			gpios = <&gpioc 9 GPIO_PULL_DOWN>;
 		};
 
+		/* Line to asic reset */
 		asic_reset {
 			compatible = "zephyr,gpio-line";
-			label = "Line to asic reset";
 			gpios = <&gpioc 4 GPIO_ACTIVE_LOW>;
 		};
 
+		/* Thermal trip indicator */
 		therm_trip {
 			compatible = "zephyr,gpio-line";
-			label = "Thermal trip indicator";
 			gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
 		};
 
 		flash = <&flash1>;
 
+		/* Line to spi mux, drive low to enable dmfw -> eeprom */
 		spi_mux {
 			compatible = "zephyr,gpio-line";
-			label = "Line to spi mux, drive low to enable dmfw -> eeprom";
 			gpios = <&gpiob 0 GPIO_ACTIVE_LOW>;
 		};
 
+		/* Line to spi reset */
 		spi_reset {
 			compatible = "zephyr,gpio-line";
-			label = "Line to spi reset";
 			gpios = <&gpiod 5 GPIO_ACTIVE_LOW>;
 		};
 
@@ -76,9 +76,9 @@
 		};
 	};
 
+	/* Input from PCIe card edge triggering an asic reset */
 	preset_trigger {
 		compatible = "zephyr,gpio-line";
-		label = "Input from PCIe card edge triggering an asic reset";
 		gpios = <&gpioc 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	};
 

--- a/dts/bindings/misc/zephyr,gpio-line.yaml
+++ b/dts/bindings/misc/zephyr,gpio-line.yaml
@@ -9,9 +9,3 @@ properties:
   gpios:
     type: phandle-array
     required: true
-  label:
-    type: string
-    description: |
-      Human readable string describing the line. It can be used by an
-      application to identify this line or to retrieve its number/index
-      (i.e. child node number) on the parent device.

--- a/tests/lib/tenstorrent/jtag_bootrom/app.overlay
+++ b/tests/lib/tenstorrent/jtag_bootrom/app.overlay
@@ -18,32 +18,32 @@
 		port-write-cycles = <2>;
 	};
 
+	/* ASIC reset line */
 	mcureset {
 		compatible = "zephyr,gpio-line";
-		label = "ASIC reset line";
 		gpios = <&gpio0 5 GPIO_PULL_DOWN>;
 	};
 
+	/* Spi reset line */
 	spireset {
 		compatible = "zephyr,gpio-line";
-		label = "Spi reset line";
 		gpios = <&gpio0 6 GPIO_PULL_DOWN>;
 	};
 
+	/* Power good indicator */
 	pgood {
 		compatible = "zephyr,gpio-line";
-		label = "Power good indicator";
 		gpios = <&gpio0 8 GPIO_PULL_DOWN>;
 	};
 
+	/* Enable to select the arc jtag, disable to select rambus */
 	arc_rambus_jtag_mux_sel: arc_rambus_jtag_mux_enable {
-		label = "Enable to select the arc jtag, disable to select rambus";
 		compatible = "zephyr,gpio-line";
 		gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 	};
 
+	/* Enable to select the arc jtag, disable to select l2cpu */
 	arc_l2_jtag_mux_sel: arc_l2_jtag_mux_enable {
-		label = "Enable to select the arc jtag, disable to select l2cpu";
 		compatible = "zephyr,gpio-line";
 		gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 	};

--- a/tests/lib/tenstorrent/pgood/app.overlay
+++ b/tests/lib/tenstorrent/pgood/app.overlay
@@ -7,21 +7,21 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
+	/* Emulated ASIC reset line */
 	asic_reset {
 		compatible = "zephyr,gpio-line";
-		label = "Emulated ASIC reset line";
 		gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 	};
 
+	/* Emulated power good indicator */
 	pgood {
 		compatible = "zephyr,gpio-line";
-		label = "Emulated power good indicator";
 		gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
 	};
 
+	/* Emulated board fault LED */
 	board_fault_led {
 		compatible = "zephyr,gpio-line";
-		label = "Emulated board fault LED";
 		gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
 	};
 };


### PR DESCRIPTION
Use of the label property is discouraged for new device tree bindings. See [ZephyrProject, Intro to Syntax Structure](https://docs.zephyrproject.org/latest/build/dts/intro-syntax-structure.html#important-properties)

Removed label properties from various GPIO lines in the device tree source files and replace with comments. This includes lines for ASIC reset, SPI reset, power good indicators, thermal trip indicators, and others across multiple overlays and DTS files.

Also fix some dts linting errors.