### PR TITLE
boards: tenstorrent: glx2_dmc: enable uart5

### DIFF
--- a/boards/tenstorrent/tt_blackhole_glx2_dmc/tt_blackhole_glx2_dmc.dts
+++ b/boards/tenstorrent/tt_blackhole_glx2_dmc/tt_blackhole_glx2_dmc.dts
@@ -154,14 +154,12 @@
 	status = "okay";
 };
 
-/*
- *&uart5 {
- *	pinctrl-0 = <&uart5_tx_pc12 &uart5_rx_pd2>;
- *	pinctrl-names = "default";
- *	current-speed = <115200>;
- *	status = "okay";
- *};
- */
+&uart5 {
+	pinctrl-0 = <&uart5_tx_pc12 &uart5_rx_pd2>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
 
 &i3c1 {
 	pinctrl-0 = <&i3c1_scl_pb13 &i3c1_sda_pa1>;

--- a/west.yml
+++ b/west.yml
@@ -23,7 +23,7 @@ manifest:
     - name: zephyr
       remote: tenstorrent
       repo-path: zephyr-fork
-      revision: bbd8290c7bf6e135bacd803a5aae2b215d698f64
+      revision: 44bdb0d70ca0dc2dba73ab4694557717f715e981
       import:
         name-allowlist:
           - cmsis_6


### PR DESCRIPTION
Update the zephyr fork version to include stm32u3 UART5 dts node:
https://github.com/tenstorrent/zephyr-fork/tree/44bdb0d70ca0dc2dba73ab4694557717f715e981

Uncomment the uart5 node so Galaxy 2 DMC console uses UART5 on PC12/PD2 at 115200.