### PR TITLE
doc: release: 19.13: align notes with shipped 19.13.2

### DIFF
--- a/doc/release/migration-guide-19.13.md
+++ b/doc/release/migration-guide-19.13.md
@@ -1,7 +1,5 @@
-# 19.13.0
+# 19.13.2
 
 ## Migration Guide
 
-> This is a working draft for the up-coming 19.13.0 release.
-
-This document lists recommended and required changes for those migrating from the previous v19.12.0 firmware release to the new 19.13.0 firmware release.
+This document lists recommended and required changes for those migrating from the previous v19.12.0 firmware release to the new 19.13.2 firmware release.

--- a/doc/release/release-notes-19.13.md
+++ b/doc/release/release-notes-19.13.md
@@ -1,8 +1,16 @@
-# v19.13.0
+# v19.13.2
 
-> This is a working draft for the up-coming 19.13.0 release.
+We are pleased to announce the release of TT System Firmware version 19.13.2 🥳🎉.
 
-We are pleased to announce the release of TT System Firmware version 19.13.0 🥳🎉.
+This is a patch release on top of v19.13.1. It includes the following updates:
+- Added Blackhole per-instance GDDR soft-harvest support
+  - Selected GDDR channels can be harvested via a new fw_table field, also settable at runtime; boards that omit the field are unaffected
+
+
+# v19.13.1
+
+> Note: v19.13.0 was withdrawn and is superseded by v19.13.1. There are no
+> functional differences between the two; only the version numbers differ.
 
 Major enhancements with this release include:
 
@@ -62,4 +70,4 @@ An overview of required and recommended changes to make when migrating from the 
 
 The full ChangeLog from the previous v19.12.0 release can be found at the link below.
 
-https://github.com/tenstorrent/tt-system-firmware/compare/v19.12.0...v19.13.0
+https://github.com/tenstorrent/tt-system-firmware/compare/v19.12.0...v19.13.2


### PR DESCRIPTION
The 19.13 release shipped as v19.13.1, followed by the v19.13.2 patch release. The v19.13.0 tag could not be reused for a release: an immutable release was published for it and then deleted, and GitHub permanently reserves a tag name once an immutable release has existed for it.

Bring main's copy of the notes and migration guide in line with what shipped, matching `v19.13-branch`:

- Retitle the notes to v19.13.1 and record that v19.13.0 was withdrawn
- Drop the working-draft banner
- Add the v19.13.2 patch section covering Blackhole per-instance GDDR soft-harvest
- Retitle the migration guide for 19.13.2
- Point the Full ChangeLog compare link at v19.13.2
