### PR TITLE
.github: add CODEOWNERS for tt-system-firmware-codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tenstorrent/tt-system-firmware-codeowners


### PR DESCRIPTION
Request reviews from all members of tt-system-firmware-codeowners for all PRs to tt-system-firmware.

I believe this only pings based on CODEOWNERS in the target branch (i.e. doesn't work until this is in main):
- [Github docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-forks)