### PR TITLE
SYS-4922: Alternate flash MX25 & GD25

### DIFF
--- a/boards/tenstorrent/tt_blackhole/CMakeLists.txt
+++ b/boards/tenstorrent/tt_blackhole/CMakeLists.txt
@@ -7,6 +7,9 @@ endif()
 zephyr_library()
 if(CONFIG_MSPI AND CONFIG_FLASH)
   zephyr_library_sources(src/flash.c)
+  # flash.c reports the flash JEDEC ID through bh_arc telemetry
+  zephyr_library_include_directories_ifdef(CONFIG_TT_BH_ARC
+      ${ZEPHYR_TT_SYSTEM_FIRMWARE_MODULE_DIR}/lib/tenstorrent/bh_arc)
 endif()
 zephyr_library_sources_ifdef(CONFIG_UART_TT_VIRT src/vuart.c)
 

--- a/boards/tenstorrent/tt_blackhole/pre_dt_board.cmake
+++ b/boards/tenstorrent/tt_blackhole/pre_dt_board.cmake
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+# The galaxy SMC devicetrees deliberately place several flash chip
+# candidates at the same SPI bus position; the flash mux selects among
+# them at boot.
+if("${BOARD_QUALIFIERS}" MATCHES "/smc" AND "${BOARD_REVISION}" MATCHES "^galaxy(_revc)?$")
+  list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")
+endif()

--- a/boards/tenstorrent/tt_blackhole/src/flash.c
+++ b/boards/tenstorrent/tt_blackhole/src/flash.c
@@ -8,7 +8,6 @@
 #include <zephyr/drivers/flash.h>
 #include <zephyr/drivers/mspi.h>
 #include <zephyr/drivers/mspi/mspi_dw.h>
-#include <string.h>
 
 #define SPI_RX_TRAIN_ADDR   0x13FFC
 #define SPI_RX_TRAIN_DATA   0xa5a55a5a
@@ -16,6 +15,17 @@
 
 const struct device *mspi_dev = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(spi0));
 const struct device *flash = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(spi_flash));
+
+/*
+ * On boards with second-source flash support, spi_flash is a mux over
+ * per-chip candidate nodes; bus position and max frequency are common to
+ * all of them. On the other boards it is the flash chip node itself.
+ */
+#if DT_NODE_HAS_COMPAT(DT_NODELABEL(spi_flash), tenstorrent_flash_mux)
+#define FLASH_CHIP_NODE DT_PHANDLE_BY_IDX(DT_NODELABEL(spi_flash), flash_devices, 0)
+#else
+#define FLASH_CHIP_NODE DT_NODELABEL(spi_flash)
+#endif
 
 /* SPI operating modes, defined by blackhole bootrom */
 typedef enum {
@@ -63,12 +73,12 @@ static int flash_reset_init(void)
 		.cmd_length = 1,
 	};
 	struct mspi_dev_cfg mspi_dev_cfg = {
-		.freq = DT_PROP(DT_NODELABEL(spi_flash), mspi_max_frequency),
+		.freq = DT_PROP(FLASH_CHIP_NODE, mspi_max_frequency),
 		.endian = MSPI_XFER_BIG_ENDIAN,
 		.cmd_length = 1,
 	};
 	const struct mspi_dev_id mspi_dev_id = {
-		.dev_idx = DT_REG_ADDR(DT_NODELABEL(spi_flash)),
+		.dev_idx = DT_REG_ADDR(FLASH_CHIP_NODE),
 	};
 
 	if (!device_is_ready(mspi_dev)) {
@@ -221,6 +231,17 @@ static int flash_training_post_reclock(void)
 {
 	return flash_training_init();
 }
+
+BUILD_ASSERT(CONFIG_FLASH_INIT_PRIORITY > CONFIG_FLASH_RESET_PRIORITY,
+	     "The flash driver probes after the bootrom reset handoff");
+#ifdef CONFIG_FLASH_TT_MUX
+BUILD_ASSERT(CONFIG_FLASH_TT_MUX_INIT_PRIORITY < CONFIG_FLASH_TRAINING_PRIORITY,
+	     "Flash training reads through the selected flash configuration");
+#ifdef CONFIG_BH_FWTABLE
+BUILD_ASSERT(CONFIG_FLASH_TT_MUX_INIT_PRIORITY < CONFIG_BH_FWTABLE_INIT_PRIORITY,
+	     "bh_fwtable reads flash; the flash configuration must be selected first");
+#endif
+#endif
 
 SYS_INIT(flash_reset_init, POST_KERNEL, CONFIG_FLASH_RESET_PRIORITY);
 SYS_INIT(flash_training_pre_reclock, POST_KERNEL, CONFIG_FLASH_TRAINING_PRIORITY);

--- a/boards/tenstorrent/tt_blackhole/src/flash.c
+++ b/boards/tenstorrent/tt_blackhole/src/flash.c
@@ -8,6 +8,15 @@
 #include <zephyr/drivers/flash.h>
 #include <zephyr/drivers/mspi.h>
 #include <zephyr/drivers/mspi/mspi_dw.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/byteorder.h>
+
+/* MCUboot builds this file too, but without the telemetry library */
+#ifdef CONFIG_TT_BH_ARC
+#include "telemetry.h"
+#endif
+
+LOG_MODULE_REGISTER(tt_flash, CONFIG_FLASH_LOG_LEVEL);
 
 #define SPI_RX_TRAIN_ADDR   0x13FFC
 #define SPI_RX_TRAIN_DATA   0xa5a55a5a
@@ -169,6 +178,27 @@ static int flash_reset_init(void)
 	return 0;
 }
 
+#ifdef CONFIG_TT_BH_ARC
+static int flash_jedec_id_init(void)
+{
+	uint8_t id[3];
+	int rc;
+
+	if (!device_is_ready(flash)) {
+		return -ENODEV;
+	}
+
+	rc = flash_read_jedec_id(flash, id);
+	if (rc < 0) {
+		LOG_ERR("Flash JEDEC ID read failed (%d)", rc);
+		return rc;
+	}
+
+	UpdateTelemetryFlashJedecId(sys_get_be24(id));
+	return 0;
+}
+#endif
+
 static int flash_training_init(void)
 {
 	struct mspi_dw_timing_cfg timing_cfg;
@@ -244,5 +274,8 @@ BUILD_ASSERT(CONFIG_FLASH_TT_MUX_INIT_PRIORITY < CONFIG_BH_FWTABLE_INIT_PRIORITY
 #endif
 
 SYS_INIT(flash_reset_init, POST_KERNEL, CONFIG_FLASH_RESET_PRIORITY);
+#ifdef CONFIG_TT_BH_ARC
+SYS_INIT(flash_jedec_id_init, POST_KERNEL, CONFIG_FLASH_TRAINING_PRIORITY);
+#endif
 SYS_INIT(flash_training_pre_reclock, POST_KERNEL, CONFIG_FLASH_TRAINING_PRIORITY);
 SYS_INIT(flash_training_post_reclock, APPLICATION, CONFIG_FLASH_TRAINING_PRIORITY);

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_smc_flash_mux.dtsi
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_smc_flash_mux.dtsi
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Second-source flash support, for board revisions that fit parts other
+ * than the MT25Q. Replaces the spi_flash chip node with one candidate
+ * configuration per supported chip and a mux that selects among them at
+ * boot. Include from a board revision overlay, before any partition
+ * adjustments.
+ */
+
+/delete-node/ &spi_flash;
+
+/* Properties common to every flash candidate below. All describe the same
+ * physical chip on CS 0.
+ *
+ * Programming has experimentally been reliable up to 17 MHz, use 15 to be
+ * safe. Reading can operate at higher frequencies: reliable up to 50 MHz,
+ * use 40 to be safe.
+ */
+#define TT_SPI_FLASH_COMMON \
+	compatible = "jedec,mspi-nor"; \
+	reg = <0>; \
+	status = "okay"; \
+	size = <DT_SIZE_M(512)>; \
+	mspi-max-frequency = <DT_FREQ_M(15)>; \
+	read-frequency = <DT_FREQ_M(40)>; \
+	mspi-data-rate = "MSPI_DATA_RATE_SINGLE"; \
+	use-4byte-addressing; \
+	mspi-endian = "MSPI_BIG_ENDIAN"; \
+	transfer-timeout = <100>;
+
+&spi0 {
+	/* The flash candidates below are distinct devices for the same chip;
+	 * reconfigure the controller whenever a different one accesses it.
+	 */
+	software-multiperipheral;
+
+	/* One candidate configuration per supported flash chip. All probe
+	 * at boot; the driver's jedec-id check fails initialization for
+	 * every candidate but the one matching the fitted chip, and the
+	 * spi_flash mux then selects the first that succeeded.
+	 * flash_single_io omits jedec-id and so accepts any chip, as a slow
+	 * universal fallback that keeps an unrecognized chip readable and
+	 * reflashable.
+	 */
+	flash_mt25q: mt25q@0 {
+		TT_SPI_FLASH_COMMON
+		jedec-id = [20 bb 20]; /* Micron MT25QU512ABB */
+		mspi-io-mode = "MSPI_IO_MODE_QUAD_1_4_4";
+		quad-enable-requirements = "NONE";
+		read-command = <0xec>;
+		rx-dummy = <10>;
+		write-command = <0x3e>; /* 1-4-4 extended quad input page program */
+	};
+
+	flash_mx25u: mx25u@0 {
+		TT_SPI_FLASH_COMMON
+		jedec-id = [c2 25 3a]; /* Macronix MX25U51245G */
+		mspi-io-mode = "MSPI_IO_MODE_QUAD_1_4_4";
+		/* Quad commands are ignored unless the non-volatile QE bit
+		 * is set; it is written on first boot and only read
+		 * thereafter.
+		 */
+		quad-enable-requirements = "S1B6";
+		read-command = <0xec>;
+		/* Fixed 6 cycles between address and data: a mode byte in
+		 * the first 2, then 4 dummy cycles.
+		 */
+		rx-mode-cycles = <2>;
+		rx-dummy = <4>;
+		write-command = <0x3e>;
+	};
+
+	flash_gd25lf: gd25lf@0 {
+		TT_SPI_FLASH_COMMON
+		jedec-id = [c8 63 1a]; /* GigaDevice GD25LF512MF */
+		mspi-io-mode = "MSPI_IO_MODE_QUAD_1_4_4";
+		quad-enable-requirements = "NONE"; /* no QE bit */
+		read-command = <0xec>;
+		/* Factory-default read latency (DC=0 in SR3): a mode byte in
+		 * the first 2 cycles, then 4 dummy cycles. A chip whose
+		 * non-volatile DC bits were reconfigured for 8 or 10 cycles
+		 * is not supported.
+		 */
+		rx-mode-cycles = <2>;
+		rx-dummy = <4>;
+		/* No 3Eh (1-4-4) page program; use 34h (1-1-4). Only the
+		 * address phase is slower; page program time dominates.
+		 */
+		write-command = <0x34>;
+		write-io-mode = "MSPI_IO_MODE_QUAD_1_1_4";
+	};
+
+	flash_w25q: w25q@0 {
+		TT_SPI_FLASH_COMMON
+		jedec-id = [ef 60 20]; /* Winbond W25Q51RW-Q/-N, W25Q512NW-IQ/IN */
+		mspi-io-mode = "MSPI_IO_MODE_QUAD_1_4_4";
+		/* QE is non-volatile and factory-set on the supported
+		 * variants; the driver repairs a part that arrives with it
+		 * cleared.
+		 */
+		quad-enable-requirements = "S2B1v6";
+		read-command = <0xec>;
+		/* A mode byte in the first 2 cycles, then 4 dummy cycles */
+		rx-mode-cycles = <2>;
+		rx-dummy = <4>;
+		write-command = <0x34>; /* no 3Eh (1-4-4); 34h (1-1-4) */
+		write-io-mode = "MSPI_IO_MODE_QUAD_1_1_4";
+	};
+
+	flash_single_io: flash@0 {
+		TT_SPI_FLASH_COMMON
+		/* No jedec-id: accepts any chip. The driver defaults for
+		 * single-lane 4-byte addressing are universal commands: 0Ch
+		 * fast read with 8 dummy cycles, 12h page program.
+		 */
+		mspi-io-mode = "MSPI_IO_MODE_SINGLE";
+		quad-enable-requirements = "NONE";
+		rx-dummy = <8>;
+	};
+};
+
+/ {
+	/* Selects the first candidate that accepted the chip. Consumers
+	 * access the flash through this node.
+	 */
+	spi_flash: flash-mux {
+		compatible = "tenstorrent,flash-mux";
+		status = "okay";
+		flash-devices = <&flash_mt25q &flash_mx25u &flash_gd25lf
+				 &flash_w25q &flash_single_io>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		nv_flash: nv-flash@0 {
+			compatible = "soc-nv-flash";
+			reg = <0x0 DT_SIZE_M(512)>;
+			write-block-size = <1>;
+			erase-block-size = <4096>;
+		};
+	};
+};
+
+/* The base devicetree's partitions were deleted along with the spi_flash
+ * node they lived under; recreate them under the mux.
+ */
+&nv_flash {
+#include "tt_blackhole_fixed_partitions.dtsi"
+};

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_defconfig
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_defconfig
@@ -28,6 +28,8 @@ CONFIG_I2C_DW_CLOCK_SPEED=50
 # enable flash
 CONFIG_FLASH=y
 CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE=4096
+# flash.c reports the JEDEC ID of the detected flash chip in telemetry
+CONFIG_FLASH_JESD216_API=y
 
 # enable the bh_arc library
 CONFIG_TT_BH_ARC=y

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_galaxy.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_galaxy.overlay
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Galaxy boards fit second-source flash parts; include this before the
+ * partition adjustments below, as it recreates the partitions.
+ */
+#include "tt_blackhole_smc_flash_mux.dtsi"
+
 /delete-node/ &blupdate;
 /delete-node/ &dmfw;
 /delete-node/ &dmfwimg;

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_galaxy_revc.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_galaxy_revc.overlay
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Galaxy boards fit second-source flash parts; include this before the
+ * partition adjustments below, as it recreates the partitions.
+ */
+#include "tt_blackhole_smc_flash_mux.dtsi"
+
 /delete-node/ &blupdate;
 /delete-node/ &dmfw;
 /delete-node/ &dmfwimg;

--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -5,5 +5,6 @@ zephyr_library_amend()
 zephyr_library_include_directories("${ZEPHYR_BASE}/drivers/flash")
 
 # zephyr-keep-sorted-start
+zephyr_library_sources_ifdef(CONFIG_FLASH_TT_MUX flash_mux.c)
 zephyr_library_sources_ifdef(CONFIG_FLASH_TT_STM32_WRAPPER flash_stm32_wrapper.c)
 # zephyr-keep-sorted-stop

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -5,6 +5,29 @@ if FLASH
 
 menu "Flash drivers"
 
+config FLASH_TT_MUX
+	bool "Tenstorrent flash mux"
+	default y
+	depends on DT_HAS_TENSTORRENT_FLASH_MUX_ENABLED
+	help
+	  Support for the Tenstorrent flash mux driver. It selects among
+	  several candidate flash devices at init - typically alternative
+	  configurations of second-source chips on the same bus position -
+	  and forwards all flash API calls to the selected one.
+
+if FLASH_TT_MUX
+
+config FLASH_TT_MUX_INIT_PRIORITY
+	int "Tenstorrent flash mux init priority"
+	default 85
+	help
+	  Init priority of the flash mux. Must be greater than the init
+	  priority of the candidate flash devices, so that they have
+	  probed by the time the mux selects among them, and less than
+	  that of the first flash consumer.
+
+endif
+
 config FLASH_TT_STM32_WRAPPER
 	bool "Tenstorrent STM32 Flash Wrapper"
 	default y

--- a/drivers/flash/flash_mux.c
+++ b/drivers/flash/flash_mux.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+#define DT_DRV_COMPAT tenstorrent_flash_mux
+
+LOG_MODULE_REGISTER(flash_mux, CONFIG_FLASH_LOG_LEVEL);
+
+struct flash_mux_config {
+	const struct device *const *candidates;
+	size_t num_candidates;
+};
+
+struct flash_mux_data {
+	const struct device *active;
+};
+
+static const struct device *flash_mux_active(const struct device *dev)
+{
+	const struct flash_mux_data *data = dev->data;
+
+	return data->active;
+}
+
+static int flash_mux_read(const struct device *dev, off_t offset, void *data, size_t len)
+{
+	return flash_read(flash_mux_active(dev), offset, data, len);
+}
+
+static int flash_mux_write(const struct device *dev, off_t offset, const void *data, size_t len)
+{
+	return flash_write(flash_mux_active(dev), offset, data, len);
+}
+
+static int flash_mux_erase(const struct device *dev, off_t offset, size_t len)
+{
+	return flash_erase(flash_mux_active(dev), offset, len);
+}
+
+static const struct flash_parameters *flash_mux_get_parameters(const struct device *dev)
+{
+	return flash_get_parameters(flash_mux_active(dev));
+}
+
+static int flash_mux_get_size(const struct device *dev, uint64_t *size)
+{
+	return flash_get_size(flash_mux_active(dev), size);
+}
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+static void flash_mux_page_layout(const struct device *dev,
+				  const struct flash_pages_layout **layout, size_t *layout_size)
+{
+	const struct device *active = flash_mux_active(dev);
+	const struct flash_driver_api *api = active->api;
+
+	api->page_layout(active, layout, layout_size);
+}
+#endif
+
+#if defined(CONFIG_FLASH_JESD216_API)
+static int flash_mux_sfdp_read(const struct device *dev, off_t offset, void *data, size_t len)
+{
+	return flash_sfdp_read(flash_mux_active(dev), offset, data, len);
+}
+
+static int flash_mux_read_jedec_id(const struct device *dev, uint8_t *id)
+{
+	return flash_read_jedec_id(flash_mux_active(dev), id);
+}
+#endif
+
+#if defined(CONFIG_FLASH_EX_OP_ENABLED)
+static int flash_mux_ex_op(const struct device *dev, uint16_t code, const uintptr_t in, void *out)
+{
+	return flash_ex_op(flash_mux_active(dev), code, in, out);
+}
+#endif
+
+static int flash_mux_init(const struct device *dev)
+{
+	const struct flash_mux_config *config = dev->config;
+	struct flash_mux_data *data = dev->data;
+
+	for (size_t i = 0; i < config->num_candidates; i++) {
+		const struct device *candidate = config->candidates[i];
+
+		if (device_is_ready(candidate)) {
+			LOG_INF("Selected %s", candidate->name);
+			data->active = candidate;
+			return 0;
+		}
+	}
+
+	LOG_ERR("No flash candidate initialized");
+	return -ENODEV;
+}
+
+static DEVICE_API(flash, flash_mux_api) = {
+	.read = flash_mux_read,
+	.write = flash_mux_write,
+	.erase = flash_mux_erase,
+	.get_parameters = flash_mux_get_parameters,
+	.get_size = flash_mux_get_size,
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+	.page_layout = flash_mux_page_layout,
+#endif
+#if defined(CONFIG_FLASH_JESD216_API)
+	.sfdp_read = flash_mux_sfdp_read,
+	.read_jedec_id = flash_mux_read_jedec_id,
+#endif
+#if defined(CONFIG_FLASH_EX_OP_ENABLED)
+	.ex_op = flash_mux_ex_op,
+#endif
+};
+
+#define FLASH_MUX_CANDIDATE(node_id, prop, idx)                                                    \
+	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(node_id, prop, idx)),
+
+#define FLASH_MUX_DEFINE(inst)                                                                     \
+	static const struct device *const flash_mux_candidates_##inst[] = {                        \
+		DT_INST_FOREACH_PROP_ELEM(inst, flash_devices, FLASH_MUX_CANDIDATE)};              \
+	static const struct flash_mux_config flash_mux_config_##inst = {                           \
+		.candidates = flash_mux_candidates_##inst,                                         \
+		.num_candidates = ARRAY_SIZE(flash_mux_candidates_##inst),                         \
+	};                                                                                         \
+	static struct flash_mux_data flash_mux_data_##inst;                                        \
+	DEVICE_DT_INST_DEFINE(inst, flash_mux_init, NULL, &flash_mux_data_##inst,                  \
+			      &flash_mux_config_##inst, POST_KERNEL,                               \
+			      CONFIG_FLASH_TT_MUX_INIT_PRIORITY, &flash_mux_api);
+
+DT_INST_FOREACH_STATUS_OKAY(FLASH_MUX_DEFINE)

--- a/dts/bindings/mtd/tenstorrent,flash-mux.yaml
+++ b/dts/bindings/mtd/tenstorrent,flash-mux.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Runtime-selected flash configuration multiplexer.
+
+  Presents a single flash device backed by one of several candidate flash
+  devices. Typically the candidates describe the same physical flash chip
+  under different configurations - one jedec,mspi-nor node per supported
+  second-source part, distinguished by the jedec-id property, optionally
+  with a catch-all last entry that omits jedec-id. Every candidate probes
+  at its own init; the mux, initialized after them, selects the first
+  candidate that is ready and forwards all flash API calls to it.
+
+  Candidates sharing a bus position are distinct devices to the bus
+  controller, so give their bus the software-multiperipheral property:
+  the controller is then reconfigured whenever a different device
+  accesses it.
+
+compatible: "tenstorrent,flash-mux"
+
+include: base.yaml
+
+properties:
+  flash-devices:
+    type: phandles
+    required: true
+    description: |
+      Candidate flash devices in order of preference; the first one
+      ready when the mux initializes is selected.

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -175,6 +175,7 @@ static struct telemetry_table telemetry_table = {
 		[72] = {TAG_NOP_ON_DURATION, TELEM_OFFSET(TAG_NOP_ON_DURATION)},
 		[73] = {TAG_FW_CAPABILITIES_0, TELEM_OFFSET(TAG_FW_CAPABILITIES_0)},
 		[74] = {TAG_FW_ACTIVE_CONFIG_0, TELEM_OFFSET(TAG_FW_ACTIVE_CONFIG_0)},
+		[75] = {TAG_FLASH_JEDEC_ID, TELEM_OFFSET(TAG_FLASH_JEDEC_ID)},
 	},
 };
 /* clang-format on */
@@ -258,6 +259,14 @@ void UpdateTelemetryKernelThrottler(bool enabled, uint32_t stop_nops_freq)
 	active_config.bits.kernel_nops_at_aiclk_fmin = enabled ? 1U : 0U;
 	telemetry[TAG_FW_ACTIVE_CONFIG_0] = active_config.u32_all;
 	telemetry[TAG_KERNEL_THROTTLER] = (enabled ? 1U : 0U) | ((stop_nops_freq & 0xFFFFU) << 16U);
+}
+
+void UpdateTelemetryFlashJedecId(uint32_t jedec_id)
+{
+	/* Note that this is called before init_telemetry;
+	 * write_static_telemetry must not clear it.
+	 */
+	telemetry[TAG_FLASH_JEDEC_ID] = jedec_id;
 }
 
 void UpdateTelemetryGddrThermTrip(bool enabled)

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -486,12 +486,20 @@ typedef union {
  */
 #define TAG_FW_ACTIVE_CONFIG_0 79
 
+/** @brief JEDEC ID of the SPI flash.
+ *
+ * The three ID bytes returned by the RDID (9Fh) command, packed as
+ * 0x00MMTTCC: MM = manufacturer, TT = memory type, CC = capacity.
+ * 0 if the ID could not be read.
+ */
+#define TAG_FLASH_JEDEC_ID 80
+
 /** @} */ /* end of telemetry_tag group */
 
 /* Not a real tag, signifies the last tag in the list.
  * MUST be incremented if new tags are defined.
  */
-#define TAG_COUNT 80
+#define TAG_COUNT 81
 
 /* Telemetry tags are at offset `tag` in the telemetry buffer */
 #define TELEM_OFFSET(tag) (tag)
@@ -529,6 +537,8 @@ void UpdateTelemetryTdpLimit(uint32_t tdp_limit);
 void UpdateTelemetryThermTripCount(uint16_t therm_trip_count);
 void UpdateTelemetryHostAiclkLimit(uint32_t fmax);
 void UpdateTelemetryKernelThrottler(bool enabled, uint32_t stop_nops_freq);
+/** @brief Record the flash JEDEC ID in @ref TAG_FLASH_JEDEC_ID. */
+void UpdateTelemetryFlashJedecId(uint32_t jedec_id);
 /** @brief Update the GDDR thermal-trip active-config bit in @ref TAG_FW_ACTIVE_CONFIG_0. */
 void UpdateTelemetryGddrThermTrip(bool enabled);
 /** @brief Get the current active firmware feature bits from @ref TAG_FW_ACTIVE_CONFIG_0.

--- a/scripts/tooling/blackhole_recovery/data/common_flm/eeprom.c
+++ b/scripts/tooling/blackhole_recovery/data/common_flm/eeprom.c
@@ -241,6 +241,16 @@ static int eeprom_probe(struct spi_nor_config *cfg)
 				},
 		},
 		{
+			.jedec_id = 0x2060EF, /* JEDEC ID for W25Q51RW/W25Q512NW */
+			.config = {
+					.read_cmd = 0x13,
+					.pp_cmd = 0x12,
+					.se_cmd = 0x21,
+					.ce_cmd = 0xC7,
+					.addr_len = 4,
+				},
+		},
+		{
 			.jedec_id = 0x1A5B2C, /* JEDEC ID for MT35XU02GCBA */
 			.config = {
 					.read_cmd = 0x13,

--- a/scripts/tooling/blackhole_recovery/data/common_flm/eeprom.c
+++ b/scripts/tooling/blackhole_recovery/data/common_flm/eeprom.c
@@ -221,6 +221,16 @@ static int eeprom_probe(struct spi_nor_config *cfg)
 				},
 		},
 		{
+			.jedec_id = 0x3A25C2, /* JEDEC ID for MX25U51245G */
+			.config = {
+					.read_cmd = 0x13,
+					.pp_cmd = 0x12,
+					.se_cmd = 0x21,
+					.ce_cmd = 0xC7,
+					.addr_len = 4,
+				},
+		},
+		{
 			.jedec_id = 0x1A5B2C, /* JEDEC ID for MT35XU02GCBA */
 			.config = {
 					.read_cmd = 0x13,

--- a/scripts/tooling/blackhole_recovery/data/common_flm/eeprom.c
+++ b/scripts/tooling/blackhole_recovery/data/common_flm/eeprom.c
@@ -231,6 +231,16 @@ static int eeprom_probe(struct spi_nor_config *cfg)
 				},
 		},
 		{
+			.jedec_id = 0x1A63C8, /* JEDEC ID for GD25LF512MF */
+			.config = {
+					.read_cmd = 0x13,
+					.pp_cmd = 0x12,
+					.se_cmd = 0x21,
+					.ce_cmd = 0xC7,
+					.addr_len = 4,
+				},
+		},
+		{
 			.jedec_id = 0x1A5B2C, /* JEDEC ID for MT35XU02GCBA */
 			.config = {
 					.read_cmd = 0x13,

--- a/west.yml
+++ b/west.yml
@@ -23,7 +23,7 @@ manifest:
     - name: zephyr
       remote: tenstorrent
       repo-path: zephyr-fork
-      revision: 6006b4441942615d45e5531c0b08b053f241c77f
+      revision: 3d6af87a30854fa15ff64fe883e54a0bae469210
       import:
         name-allowlist:
           - cmsis_6


### PR DESCRIPTION
Add support for alternate flash devices MX25U51245GMI00 and GD25LF512MFFIR.

These are both quad-SPI parts that are fundamentally similar to MT25 with minor differences. One substantial difference is that the don't share a common quad-SPI write (page program) command. MT25 and MX25 support 3E/1-4-4 page program while MT25 and GD25 support 34/1-1-4 page program.

DMC uses SFDP because that provides enough information for its limited SPI interaction.

SMC detects the device using the JEDEC ID to program the device (MX25: enable quad mode) and override MSPI-NOR driver parameters (RX-delay and page program command) as needed.

The SMC bootrom has limited support for these devices and only boots them in single-SPI mode.