### PR TITLE
lib: bh_arc: source msgqueue info register from Devicetree

### DIFF
--- a/app/dmc/boards/dmc_common.dtsi
+++ b/app/dmc/boards/dmc_common.dtsi
@@ -58,6 +58,12 @@
 		status = "okay";
 	};
 
+	msgqueue_info: scratch-reg@8003042c {
+		compatible = "tenstorrent,scratch-reg";
+		reg = <0x8003042c 0x4>;
+		status = "okay";
+	};
+
 	chip0: chip0 {
 		compatible = "tenstorrent,bh-chip";
 

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc.dts
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc.dts
@@ -36,6 +36,12 @@
 		status = "okay";
 	};
 
+	msgqueue_info: scratch-reg@8003042c {
+		compatible = "tenstorrent,scratch-reg";
+		reg = <0x8003042c 0x4>;
+		status = "okay";
+	};
+
 	pinctrl: pinctrl {
 		compatible = "tenstorrent,bh-pinctrl";
 

--- a/dts/bindings/misc/tenstorrent,scratch-reg.yaml
+++ b/dts/bindings/misc/tenstorrent,scratch-reg.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Host-visible 32bit scratch register
+
+compatible: "tenstorrent,scratch-reg"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true

--- a/dts/vendor/tenstorrent/tt_grendel_smc.dtsi
+++ b/dts/vendor/tenstorrent/tt_grendel_smc.dtsi
@@ -333,5 +333,12 @@
 			channel-pairs = <32>;
 			#mbox-cells = <1>;
 		};
+
+		/* To be overridden by board */
+		msgqueue_info: scratch-reg@8003042c {
+			compatible = "tenstorrent,scratch-reg";
+			reg = <0x0 0x8003042c 0x0 0x4>;
+			status = "disabled";
+		};
 	};
 };

--- a/lib/tenstorrent/bh_arc/msgqueue.c
+++ b/lib/tenstorrent/bh_arc/msgqueue.c
@@ -19,7 +19,9 @@
 #include "status_reg.h"
 #include "reg.h"
 
-#define MSGQUEUE_IRQS_NODE DT_NODELABEL(msgqueue_irqs)
+#define MSGQUEUE_IRQS_NODE         DT_NODELABEL(msgqueue_irqs)
+#define MSGQUEUE_INFO_NODE         DT_NODELABEL(msgqueue_info)
+#define STATUS_MSG_Q_INFO_REG_ADDR (uintptr_t)DT_REG_ADDR(MSGQUEUE_INFO_NODE)
 
 #if DT_NODE_HAS_STATUS(MSGQUEUE_IRQS_NODE, okay)
 #define MSGQUEUE_IRQN(_name)     DT_IRQN_BY_NAME(MSGQUEUE_IRQS_NODE, _name)

--- a/lib/tenstorrent/bh_arc/status_reg.h
+++ b/lib/tenstorrent/bh_arc/status_reg.h
@@ -41,7 +41,7 @@
 #define STATUS_MSG_Q_STATUS_REG_ADDR         RESET_UNIT_SCRATCH_RAM_REG_ADDR(8)
 #define STATUS_MSG_Q_ERR_FLAGS_REG_ADDR      RESET_UNIT_SCRATCH_RAM_REG_ADDR(9)
 #define SPI_BUFFER_INFO_REG_ADDR             RESET_UNIT_SCRATCH_RAM_REG_ADDR(10)
-#define STATUS_MSG_Q_INFO_REG_ADDR           RESET_UNIT_SCRATCH_RAM_REG_ADDR(11)
+/* MSG_Q_INFO (formerly SCRATCH_RAM_11) is provided by DT msgqueue_info reg */
 /**
  * @ingroup telemetry
  * @brief Register address pointing to the telemetry data buffer.

--- a/tests/lib/tenstorrent/bh_arc/app.overlay
+++ b/tests/lib/tenstorrent/bh_arc/app.overlay
@@ -44,6 +44,12 @@
 		compatible = "tenstorrent,bh-watchdog";
 		status = "okay";
 	};
+
+	msgqueue_info: scratch-reg@8003042c {
+		compatible = "tenstorrent,scratch-reg";
+		reg = <0x8003042c 0x4>;
+		status = "okay";
+	};
 };
 
 &i2c0 {


### PR DESCRIPTION
## Overview
Move MSG_Q_INFO scratch word address out of the hardcoded Blackhole `status_reg.h` map and into `tenstorrent,scratch-reg` DT node.
Boards can supply different absolute addresses in their overlays.
native_sim and DMC emul overlays keep the BH ABI address so `msgqueue.c` still builds.

Addresses [SYS-4955](https://tenstorrent.atlassian.net/browse/SYS-4955)

## Tests
Smoke on p150a
Mimir smc build + emul test