### PR TITLE
scripts: ci: stability improvements

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,7 @@ jobs:
           echo "ci-boards=$(jq -c "[ .[][] | .board ]" .github/ci_boards.json)" | tee -a $GITHUB_OUTPUT
 
   ci-stats:
+    if: github.event_name == 'push'
     needs: [gen-config]
     strategy:
       matrix:
@@ -167,7 +168,7 @@ jobs:
 
   build:
     runs-on: ubuntu-22.04
-    needs: [ci-stats, gen-config]
+    needs: [gen-config]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -220,6 +221,23 @@ jobs:
           mv _build_sphinx/html/* deploy
           rm -rf _build_doxygen _build_sphinx
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs
+          path: tt-system-firmware/doc/deploy
+
+  build-ci-stats:
+    runs-on: ubuntu-22.04
+    needs: [build, ci-stats, gen-config]
+    if: github.event_name == 'push'
+    steps:
+      - name: Download docs
+        uses: actions/download-artifact@v4
+        with:
+          name: docs
+          path: deploy
+
       - name: Download CI Results
         uses: actions/download-artifact@v4
         with:
@@ -235,28 +253,20 @@ jobs:
 
           for board in ${CI_BOARD_REVS[@]}; do
             cp "ci-results/test-result-summaries ${board}/ci_stats.html" \
-              tt-system-firmware/doc/deploy/${board}_ci_stats.html
+              deploy/${board}_ci_stats.html
           done
 
       - name: Setup pages
-        if: github.event_name == 'push'
         uses: actions/configure-pages@v4
 
       - name: Upload pages artifact
-        if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: tt-system-firmware/doc/deploy
-
-      - name: Upload artifacts
-        if: github.event_name != 'push'
-        uses: actions/upload-artifact@v4
-        with:
-          path: tt-system-firmware/doc/deploy
+          path: deploy
 
   deploy:
     runs-on: ubuntu-22.04
-    needs: build
+    needs: build-ci-stats
     if: github.event_name == 'push'
     permissions:
       pages: write

--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -523,9 +523,6 @@ def test_arc_msg(arc_chip_dut, asic_id):
     assert response[0] == 21, "SMC did not respond to test message"
     assert response[1] == 0, "SMC response invalid"
     logger.info('SMC ping message response "%d"', response[0])
-    # Post code should have updated after first message
-    status = arc_chip.axi_read32(ARC_STATUS)
-    assert status == 0xC0DE003F, "SMC firmware has incorrect status"
 
 
 def test_dmc_msg(arc_chip_dut, asic_id):

--- a/scripts/ci/run-smoke.sh
+++ b/scripts/ci/run-smoke.sh
@@ -88,6 +88,7 @@ if [[ "$TEST_SET" == *"dmc"* ]]; then
 		--west-flash \
 		--device-serial-pty "$TT_Z_P_ROOT/scripts/dmc_rtt.py" \
 		--flash-before \
+		--device-flash-timeout 240 \
 		--tag smoke \
 		--alt-config-root "$TT_Z_P_ROOT/test-conf/samples" \
 		--alt-config-root "$TT_Z_P_ROOT/test-conf/tests" \
@@ -108,6 +109,7 @@ if [[ "$TEST_SET" == *"smc"* ]]; then
 		--device-serial-pty "$TT_Z_P_ROOT/scripts/dmc_rtt.py" \
 		--west-flash \
 		--flash-before \
+		--device-flash-timeout 240 \
 		-T "$TT_Z_P_ROOT/app" \
 		--outdir "$ZEPHYR_BASE/twister-dmc-e2e" \
 		"$@"


### PR DESCRIPTION
### Overview

Try increasing the flash timeout to see if we can address the spotty CI issues this way.

Change the msg test to not bother verifying the post code. The post code can be updated by internal mechanisms by the time the host checks the scratch register, so the assertion is not guaranteed by our SW behaviour.

Don't run the ci-stats job except on pushes to main (like when we publish docs) since the contents of the ci-stats are always the same per PR since they only take into account stats on main. (Future effort could be made to remove it if we think the newer CI dashboard replaces this.)

### tests
CI here

