### PR TITLE
drivers: bh_fwtable: expose eth_speed_override via ccfgovr

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -1976,6 +1976,81 @@ def test_ccfgovr_bh_mod(unlaunched_dut: DeviceAdapter, asic_id: int):
         )
 
 
+def test_ccfgovr_eth_speed_override(arc_chip_dut, asic_id, board_name):
+    """
+    Exercise the ETH link speed override that ccfgovr merges into
+    FwTable.eth_property_table.eth_speed_override.
+
+    There is no telemetry tag for the trained ETH speed, so instead of
+    reading it back this test drives the paths that would fail if the
+    override were mis-handled:
+
+    - `bh-mod` rejects a speed the ERISC firmware does not implement
+      before touching flash. This is the immediate-feedback story: the
+      user learns their value is wrong without waiting for a reset.
+    - Writing a supported speed and letting `bh-mod` reset the chip leaves
+      ARC coming back up. The reset is the end-to-end path through the
+      `FwTableOverride` encode, the SPI write, the ccfgovr merge into
+      `FwTable` (which sets `has_eth_speed_override`), and `LoadEthFwCfg`
+      consuming the field.
+    - `bh-mod res` clears the override.
+    """
+    bh_mod = shutil.which("bh-mod") or os.path.expanduser("~/bh-mod")
+    if not os.path.isfile(bh_mod):
+        pytest.skip("bh-mod not found (PATH or ~/bh-mod)")
+
+    ETH_SPEED_PATH = "eth_property_table.eth_speed_override"
+
+    # Re-assert the cmfwcfg speed. Every non-Galaxy board trains at 400G
+    # and Galaxy at 200G today, so this exercises the merge without asking
+    # the ETH FW to retrain at a different speed.
+    is_galaxy = board_name is not None and "galaxy" in board_name.lower()
+    speed = 200 if is_galaxy else 400
+
+    # A speed no ERISC firmware implements has to be refused before bh-mod
+    # touches the chip, so this leaves state alone.
+    reject = subprocess.run(
+        [bh_mod, "set", f"{ETH_SPEED_PATH}=137"],
+        capture_output=True,
+        check=False,
+    )
+    assert reject.returncode != 0, (
+        f"bh-mod set {ETH_SPEED_PATH}=137 should have been rejected; "
+        f"stdout={reject.stdout.decode(errors='replace')!r} "
+        f"stderr={reject.stderr.decode(errors='replace')!r}"
+    )
+
+    write = subprocess.run(
+        [bh_mod, "--reset-timeout=60s", "set", f"{ETH_SPEED_PATH}={speed}"],
+        capture_output=True,
+        check=False,
+    )
+    assert write.returncode == 0, (
+        f"bh-mod set {ETH_SPEED_PATH}={speed} failed, rc={write.returncode}; "
+        f"stdout={write.stdout.decode(errors='replace')!r} "
+        f"stderr={write.stderr.decode(errors='replace')!r}"
+    )
+    # ARC has to be back after bh-mod applied the override with a reset.
+    wait_arc_boot(asic_id, timeout=60)
+
+    # Clear the override so the SPI flash goes back to inheriting from cmfwcfg.
+    # Warn (don't fail) if this doesn't succeed, so a stale flash state can't
+    # flake later tests / CI runs.
+    restore = subprocess.run(
+        [bh_mod, "--reset-timeout=60s", "res", ETH_SPEED_PATH],
+        capture_output=True,
+        check=False,
+    )
+    if restore.returncode != 0:
+        logger.warning(
+            f"Failed to clear {ETH_SPEED_PATH} (rc={restore.returncode}); "
+            f"SPI flash may be left modified: "
+            f"{restore.stderr.decode(errors='replace')}"
+        )
+    else:
+        wait_arc_boot(asic_id, timeout=60)
+
+
 def test_heartbeat_telemetry(arc_chip_dut, asic_id):
     """
     Polls the heartbeat telemetry every 100ms and verifies that it's incrementing.

--- a/doc/release/release-notes-19.14.md
+++ b/doc/release/release-notes-19.14.md
@@ -27,6 +27,9 @@ Major enhancements with this release include:
 
 - Removed alternative SerDes firmware support from the SMC. The `altsdfw` and `altsdreg` flash partitions and their blobs have been dropped, as the required link speeds are now part of the default SerDes firmware image.
 
+### Persistent SPI Flash Parameters
+- Expose `eth_property_table.eth_speed_override` to `bh-mod`, valid speeds - `{0, 40, 100, 200, 330, 350, 370, 400}`. `0` is interpreted as a request to auto-train.
+
 ## Migration guide
 
 An overview of required and recommended changes to make when migrating from the previous v19.13.0 release can be found in [19.14 Migration Guide](https://github.com/tenstorrent/tt-system-firmware/tree/main/doc/release/migration-guide-19.14.md).

--- a/drivers/misc/bh_fwtable/bh_fwtable.c
+++ b/drivers/misc/bh_fwtable/bh_fwtable.c
@@ -409,6 +409,15 @@ void tt_bh_fwtable_apply_ccfgovr(const struct device *dev)
 				ovr.feature_enable.gddr_therm_trip_en;
 		}
 
+		if (ovr.has_eth_property_table && ovr.eth_property_table.has_eth_speed_override) {
+			LOG_INF("CCFGOVR override: eth_property_table.eth_speed_override = %u",
+				ovr.eth_property_table.eth_speed_override);
+			data->fw_table.eth_property_table.eth_speed_override =
+				ovr.eth_property_table.eth_speed_override;
+			data->fw_table.eth_property_table.has_eth_speed_override = true;
+			data->fw_table.has_eth_property_table = true;
+		}
+
 		return;
 	}
 

--- a/drivers/misc/bh_fwtable/spirom_protobufs/fw_table.proto
+++ b/drivers/misc/bh_fwtable/spirom_protobufs/fw_table.proto
@@ -93,7 +93,13 @@ message FwTable {
   message EthPropertyTable {
     uint32 eth_disable_mask = 1;
     bool eth_disable_mask_en = 2;
-    uint32 eth_speed_override = 3;
+    /*
+     * Link speed in Gbps. Optional so `has_eth_speed_override` distinguishes
+     * "table names no speed, use the ETH FW config image default (currently
+     * 400G, not 0)" from an explicit 0, which reaches ERISC as its
+     * auto-train sentinel.
+     */
+    optional uint32 eth_speed_override = 3;
   }
 
   message ProductSpecHarvesting {

--- a/drivers/misc/bh_fwtable/spirom_protobufs/fw_table_override.proto
+++ b/drivers/misc/bh_fwtable/spirom_protobufs/fw_table_override.proto
@@ -19,11 +19,12 @@ message FwTableOverride {
    * (FwTable field 1) is deliberately reserved here so tt-mod cannot forge
    * a bundle version.
    */
-  reserved 1, 4, 6, 7, 8, 9, 10;
+  reserved 1, 4, 6, 7, 8, 10;
 
   optional ChipLimits chip_limits = 2;
   optional FeatureEnable feature_enable = 3;
   optional DramTable dram_table = 5;
+  optional EthPropertyTable eth_property_table = 9;
 
   message ChipLimits {
 
@@ -46,5 +47,18 @@ message FwTableOverride {
     reserved 1, 2;
 
     optional uint32 soft_harvest_dram_mask = 3;
+  }
+
+  message EthPropertyTable {
+
+    reserved 1, 2;
+
+    /*
+     * Link speed in Gbps. The base fw table is `optional` too, so an
+     * explicit 0 survives the merge and reaches ERISC as its auto-train
+     * sentinel (which is not the image default; that ships as 400G).
+     * Distinct from `bh-mod res`, which clears the override entirely.
+     */
+    optional uint32 eth_speed_override = 3;
   }
 }

--- a/lib/tenstorrent/bh_arc/eth.c
+++ b/lib/tenstorrent/bh_arc/eth.c
@@ -329,15 +329,41 @@ int LoadEthFwCfg(uint32_t eth_inst, uint32_t ring, uint8_t *buf, uint32_t eth_en
 	/* Pass in eth_sel based on harvesting info and PCIe configuration */
 	fw_cfg_32b[0] = GetEthSel(eth_enabled);
 
-	/* Check if speed overrides exist, */
-	/* apply them if they are a valid speed setting (40G, 100G, 200G, 330G, 350G, 370G, 400G) */
-	uint32_t speed_override =
-		tt_bh_fwtable_get_fw_table(fwtable_dev)->eth_property_table.eth_speed_override;
+	/*
+	 * ETH link speed override, end-to-end
+	 * -----------------------------------
+	 *   +---------------------------------+-------------+------------------------+
+	 *   | how the fw table got here       | has_ / val  | fw_cfg_32b[1]          |
+	 *   +---------------------------------+-------------+------------------------+
+	 *   | non-Galaxy board, no override   | false / 0   | image default (400G)   |
+	 *   | Galaxy board, no override       | true  / 200 | 200G                   |
+	 *   | bh-mod set 0    (auto-train)    | true  / 0   | 0 -> ERISC auto-trains |
+	 *   | bh-mod set N    (N in allow)    | true  / N   | N                      |
+	 *   | bh-mod set N    (N not in allow)| (rejected by bh-mod, never reaches   |
+	 *   |                                 |  flash; user sees an error)          |
+	 *   | bh-mod res eth_speed_override   | reverts to the cmfwcfg row above     |
+	 *   | hand-edited cmfwcfg, unsupp. N  | true  / N   | image default + LOG_WRN|
+	 *   |   (defense-in-depth path)       |             |                        |
+	 *   +---------------------------------+-------------+------------------------+
+	 *
+	 * The has_ bit is what tells "explicit 0 for auto" from "table names no
+	 * speed, use the image default". Without it a merged 0 would look like a
+	 * table that names none, and bh-mod could not ask for auto-train.
+	 */
+	const FwTable *fw_table = tt_bh_fwtable_get_fw_table(fwtable_dev);
 
-	if (speed_override == 40 || speed_override == 100 || speed_override == 200 ||
-	    speed_override == 330 || speed_override == 350 || speed_override == 370 ||
-	    speed_override == 400) {
-		fw_cfg_32b[1] = speed_override;
+	if (fw_table->eth_property_table.has_eth_speed_override) {
+		uint32_t speed_override = fw_table->eth_property_table.eth_speed_override;
+
+		if (speed_override == 0 || speed_override == 40 || speed_override == 100 ||
+		    speed_override == 200 || speed_override == 330 || speed_override == 350 ||
+		    speed_override == 370 || speed_override == 400) {
+			fw_cfg_32b[1] = speed_override;
+		} else {
+			LOG_WRN("eth_speed_override %uG is not a speed the ETH FW implements; "
+				"leaving the ETH FW config image speed in place",
+				speed_override);
+		}
 	}
 
 	/* Pass in some board/chip specific data for ETH to use */

--- a/tests/drivers/fw_table/src/main.c
+++ b/tests/drivers/fw_table/src/main.c
@@ -46,6 +46,8 @@ static const struct device *const fwtable_dev = DEVICE_DT_GET(FWTABLE_NODE);
 #define FD_AREA_ERASE_SIZE 0x1000U
 
 #define DEFAULT_TDP_LIMIT 150U
+/* Stands in for a cmfwcfg that pins the link speed, as the Galaxy tables do. */
+#define DEFAULT_ETH_SPEED 200U
 
 static void write_fd(size_t slot, const char *tag, uint32_t spi_addr, uint32_t image_size)
 {
@@ -62,17 +64,11 @@ static void write_fd(size_t slot, const char *tag, uint32_t spi_addr, uint32_t i
 	zassert_equal(rc, 0, "flash_write of fd slot %zu failed with %d", slot, rc);
 }
 
-static size_t encode_tdp_limit_override(uint8_t *out, size_t out_size, uint32_t value)
+static size_t encode_override(const FwTableOverride *ovr, uint8_t *out, size_t out_size)
 {
-	FwTableOverride ovr = FwTableOverride_init_zero;
-
-	ovr.has_chip_limits = true;
-	ovr.chip_limits.has_tdp_limit = true;
-	ovr.chip_limits.tdp_limit = value;
-
 	pb_ostream_t stream = pb_ostream_from_buffer(out, out_size);
 
-	zassert_true(pb_encode_ex(&stream, FwTableOverride_fields, &ovr, PB_ENCODE_NULLTERMINATED),
+	zassert_true(pb_encode_ex(&stream, FwTableOverride_fields, ovr, PB_ENCODE_NULLTERMINATED),
 		     "pb_encode_ex failed: %s", PB_GET_ERROR(&stream));
 
 	size_t total = stream.bytes_written;
@@ -83,6 +79,17 @@ static size_t encode_tdp_limit_override(uint8_t *out, size_t out_size, uint32_t 
 		out[total++] = 0x00U;
 	}
 	return total;
+}
+
+static size_t encode_tdp_limit_override(uint8_t *out, size_t out_size, uint32_t value)
+{
+	FwTableOverride ovr = FwTableOverride_init_zero;
+
+	ovr.has_chip_limits = true;
+	ovr.chip_limits.has_tdp_limit = true;
+	ovr.chip_limits.tdp_limit = value;
+
+	return encode_override(&ovr, out, out_size);
 }
 
 static size_t encode_kernel_throttler_override(uint8_t *out, size_t out_size, bool enabled,
@@ -98,19 +105,18 @@ static size_t encode_kernel_throttler_override(uint8_t *out, size_t out_size, bo
 	ovr.chip_limits.has_kernel_throttler_stop_nops_freq = true;
 	ovr.chip_limits.kernel_throttler_stop_nops_freq = stop_freq;
 
-	pb_ostream_t stream = pb_ostream_from_buffer(out, out_size);
+	return encode_override(&ovr, out, out_size);
+}
 
-	zassert_true(pb_encode_ex(&stream, FwTableOverride_fields, &ovr, PB_ENCODE_NULLTERMINATED),
-		     "pb_encode_ex failed: %s", PB_GET_ERROR(&stream));
+static size_t encode_eth_speed_override(uint8_t *out, size_t out_size, uint32_t speed)
+{
+	FwTableOverride ovr = FwTableOverride_init_zero;
 
-	size_t total = stream.bytes_written;
+	ovr.has_eth_property_table = true;
+	ovr.eth_property_table.has_eth_speed_override = true;
+	ovr.eth_property_table.eth_speed_override = speed;
 
-	/* Pad to 4 byte alignment for ccfgovr header requirement */
-	while ((total % 4U) != 0U) {
-		zassert_true(total < out_size, "padded body overruns buffer");
-		out[total++] = 0x00U;
-	}
-	return total;
+	return encode_override(&ovr, out, out_size);
 }
 
 static size_t encode_gddr_therm_trip_override(uint8_t *out, size_t out_size, bool enabled)
@@ -121,19 +127,7 @@ static size_t encode_gddr_therm_trip_override(uint8_t *out, size_t out_size, boo
 	ovr.feature_enable.has_gddr_therm_trip_en = true;
 	ovr.feature_enable.gddr_therm_trip_en = enabled;
 
-	pb_ostream_t stream = pb_ostream_from_buffer(out, out_size);
-
-	zassert_true(pb_encode_ex(&stream, FwTableOverride_fields, &ovr, PB_ENCODE_NULLTERMINATED),
-		     "pb_encode_ex failed: %s", PB_GET_ERROR(&stream));
-
-	size_t total = stream.bytes_written;
-
-	/* Pad to 4 byte alignment for ccfgovr header requirement */
-	while ((total % 4U) != 0U) {
-		zassert_true(total < out_size, "padded body overruns buffer");
-		out[total++] = 0x00U;
-	}
-	return total;
+	return encode_override(&ovr, out, out_size);
 }
 
 static void write_bank(uint32_t addr, struct ccfgovr_bank_hdr *hdr, const uint8_t *body,
@@ -179,6 +173,8 @@ static void reset_fwtable(void)
 
 	memset(t, 0, sizeof(*t));
 	t->chip_limits.tdp_limit = DEFAULT_TDP_LIMIT;
+	t->eth_property_table.has_eth_speed_override = true;
+	t->eth_property_table.eth_speed_override = DEFAULT_ETH_SPEED;
 }
 
 /**
@@ -223,6 +219,9 @@ ZTEST(bh_fwtable_ccfgovr, test_happy_path_active_bank_applies)
 	tt_bh_fwtable_apply_ccfgovr(fwtable_dev);
 	zassert_equal(tt_bh_fwtable_get_fw_table(fwtable_dev)->chip_limits.tdp_limit, 175,
 		      "expected override to set tdp_limit=175");
+	zassert_equal(
+		tt_bh_fwtable_get_fw_table(fwtable_dev)->eth_property_table.eth_speed_override,
+		DEFAULT_ETH_SPEED, "fields absent from the override must keep their cmfwcfg value");
 }
 
 /**
@@ -259,6 +258,47 @@ ZTEST(bh_fwtable_ccfgovr, test_gddr_therm_trip_override_applies)
 	tt_bh_fwtable_apply_ccfgovr(fwtable_dev);
 	zassert_true(tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.gddr_therm_trip_en,
 		     "expected override to enable gddr_therm_trip_en");
+}
+
+/**
+ * @brief Test that the ETH training speed can be raised above the cmfwcfg value
+ */
+ZTEST(bh_fwtable_ccfgovr, test_eth_speed_override_applies)
+{
+	uint8_t body[16];
+	size_t body_len = encode_eth_speed_override(body, sizeof(body), 400U);
+	struct ccfgovr_bank_hdr hdr = {.magic = CCFGOVR_MAGIC, .seq = 2};
+
+	write_bank(BANK_A_ADDR, &hdr, body, body_len);
+
+	tt_bh_fwtable_apply_ccfgovr(fwtable_dev);
+	zassert_equal(
+		tt_bh_fwtable_get_fw_table(fwtable_dev)->eth_property_table.eth_speed_override,
+		400U, "expected override to set eth_speed_override=400");
+}
+
+/**
+ * @brief Test that a speed of 0 overrides the cmfwcfg speed and asks for auto-train
+ *
+ * Both the override and the base fw table are `optional`, so an explicit 0
+ * survives the merge with `has_eth_speed_override` set. `LoadEthFwCfg` writes
+ * 0 into the ETH FW config, which hands the speed choice back to ERISC.
+ */
+ZTEST(bh_fwtable_ccfgovr, test_eth_speed_override_of_zero_asks_for_auto_train)
+{
+	uint8_t body[16];
+	size_t body_len = encode_eth_speed_override(body, sizeof(body), 0U);
+	struct ccfgovr_bank_hdr hdr = {.magic = CCFGOVR_MAGIC, .seq = 2};
+
+	write_bank(BANK_A_ADDR, &hdr, body, body_len);
+
+	tt_bh_fwtable_apply_ccfgovr(fwtable_dev);
+	zassert_true(
+		tt_bh_fwtable_get_fw_table(fwtable_dev)->eth_property_table.has_eth_speed_override,
+		"expected the override to set has_eth_speed_override");
+	zassert_equal(
+		tt_bh_fwtable_get_fw_table(fwtable_dev)->eth_property_table.eth_speed_override, 0U,
+		"expected the override to set eth_speed_override=0 (auto)");
 }
 
 /**

--- a/tests/drivers/fw_table/src/main.c
+++ b/tests/drivers/fw_table/src/main.c
@@ -59,7 +59,7 @@ static void write_fd(size_t slot, const char *tag, uint32_t spi_addr, uint32_t i
 
 	int rc = flash_write(flash_dev, TT_BOOT_FS_FD_HEAD_ADDR + slot * sizeof(fd), &fd,
 			     sizeof(fd));
-	zassert_equal(rc, 0, "flash_write failed with %d", slot, rc);
+	zassert_equal(rc, 0, "flash_write of fd slot %zu failed with %d", slot, rc);
 }
 
 static size_t encode_tdp_limit_override(uint8_t *out, size_t out_size, uint32_t value)


### PR DESCRIPTION
The ETH training speed is pinned by cmfwcfg. Expose
eth_property_table.eth_speed_override in FwTableOverride.

An override of 0 is interpreted as letting the ETH firmware handle the
speed choice (which is whatever the default value is).

Tests: Smoke