### PR TITLE
ci: tt-kmd 2.10.0 -> 2.11.0-rc1

### DIFF
--- a/.github/ci_boards.json
+++ b/.github/ci_boards.json
@@ -3,7 +3,7 @@
     {
       "board": "n150",
       "supports_smoke": true,
-      "kmd_build": "2.10.0"
+      "kmd_build": "2.11.0-rc1"
     }
   ],
   "bh": [
@@ -14,7 +14,7 @@
       "metal-target": "blackhole",
       "arch-name": "blackhole",
       "metal-options": "--cap-add SYS_MODULE --device /dev/tenstorrent --user=root",
-      "kmd_build": "2.10.0"
+      "kmd_build": "2.11.0-rc1"
     },
     {
       "board": "p150a",
@@ -23,7 +23,7 @@
       "metal-target": "blackhole",
       "arch-name": "blackhole",
       "metal-options": "--cap-add SYS_MODULE --device /dev/tenstorrent --user=root",
-      "kmd_build": "2.10.0"
+      "kmd_build": "2.11.0-rc1"
     },
     {
       "board": "p300a",
@@ -32,7 +32,7 @@
       "metal-target": "blackhole_p300",
       "arch-name": "blackhole",
       "metal-options": "--cap-add SYS_MODULE --device /dev/tenstorrent --user=root",
-      "kmd_build": "2.10.0"
+      "kmd_build": "2.11.0-rc1"
     },
     {
       "board": "quietbox2",
@@ -40,7 +40,7 @@
       "metal-target": "blackhole_qb_ge",
       "arch-name": "blackhole",
       "metal-options": "--cap-add SYS_MODULE --device /dev/tenstorrent --user=root",
-      "kmd_build": "2.10.0"
+      "kmd_build": "2.11.0-rc1"
     },
     {
       "board": "loudbox",
@@ -48,7 +48,7 @@
       "metal-target": "blackhole_loudbox",
       "arch-name": "blackhole",
       "metal-options": "--cap-add SYS_MODULE --device /dev/tenstorrent --user=root",
-      "kmd_build": "2.10.0"
+      "kmd_build": "2.11.0-rc1"
     },
     {
       "board": "bh-galaxy",
@@ -56,7 +56,7 @@
       "metal-target": "blackhole_glx",
       "arch-name": "blackhole",
       "metal-options": "--cap-add SYS_MODULE --device /dev/tenstorrent --device /dev/ipmi0 --user=root",
-      "kmd_build": "2.10.0"
+      "kmd_build": "2.11.0-rc1"
     }
   ]
 }

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -62,6 +62,8 @@ jobs:
       image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
+        - /lib/modules:/lib/modules:ro
+        - /usr/src:/usr/src:ro
         - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/
       options: '--device /dev/tenstorrent --device /dev/bus/usb --device /dev/ipmi0 --privileged'
     steps:
@@ -139,6 +141,8 @@ jobs:
       image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
+        - /lib/modules:/lib/modules:ro
+        - /usr/src:/usr/src:ro
         - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/
       options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
     steps:
@@ -202,6 +206,8 @@ jobs:
       image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
+        - /lib/modules:/lib/modules:ro
+        - /usr/src:/usr/src:ro
         - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/
       options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
     steps:

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -6,7 +6,12 @@ on:
       - labeled
   schedule:
     - cron: "0 5 * * *"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      kmd_ref:
+        description: 'Optional tt-kmd tag, branch, or commit'
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -73,11 +78,16 @@ jobs:
         with:
           path: tt-system-firmware
 
+      - name: Set up tt-kmd
+        uses: ./tt-system-firmware/.github/workflows/setup-kmd
+        with:
+          kmd-version: ${{ matrix.config.kmd_build }}
+          kmd-ref: ${{ inputs.kmd_ref }}
+
       - name: Prepare Container
         uses: ./tt-system-firmware/.github/workflows/prepare-container
         with:
           app-path: tt-system-firmware
-          kmd-version: ${{ matrix.config.kmd_build }}
 
       - name: run-e2e-stress-test
         run: |
@@ -145,11 +155,16 @@ jobs:
         with:
           path: tt-system-firmware
 
+      - name: Set up tt-kmd
+        uses: ./tt-system-firmware/.github/workflows/setup-kmd
+        with:
+          kmd-version: 2.7.0
+          kmd-ref: ${{ inputs.kmd_ref }}
+
       - name: Prepare Container
         uses: ./tt-system-firmware/.github/workflows/prepare-container
         with:
           app-path: tt-system-firmware
-          kmd-version: 2.7.0
 
       - name: Install the package from PyPI
         run: |
@@ -201,11 +216,16 @@ jobs:
         with:
           path: tt-system-firmware
 
+      - name: Set up tt-kmd
+        uses: ./tt-system-firmware/.github/workflows/setup-kmd
+        with:
+          kmd-version: ${{ matrix.config.kmd_build }}
+          kmd-ref: ${{ inputs.kmd_ref }}
+
       - name: Prepare Container
         uses: ./tt-system-firmware/.github/workflows/prepare-container
         with:
           app-path: tt-system-firmware
-          kmd-version: ${{ matrix.config.kmd_build }}
 
       - name: Derive board properties
         id: board-map

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -72,6 +72,8 @@ jobs:
       image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
+        - /lib/modules:/lib/modules:ro
+        - /usr/src:/usr/src:ro
         - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/
       options: '--device /dev/tenstorrent --device /dev/bus/usb --device /dev/ipmi0 --privileged'
     steps:
@@ -165,6 +167,8 @@ jobs:
       image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
+        - /lib/modules:/lib/modules:ro
+        - /usr/src:/usr/src:ro
         - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/
       options: '--device /dev/tenstorrent --device /dev/bus/usb --device /dev/ipmi0 --privileged'
     steps:
@@ -283,6 +287,8 @@ jobs:
       image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
+        - /lib/modules:/lib/modules:ro
+        - /usr/src:/usr/src:ro
         - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/
       options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
     steps:

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -19,6 +19,11 @@ on:
     types:
       - checks_requested
   workflow_dispatch:
+    inputs:
+      kmd_ref:
+        description: 'Optional tt-kmd tag, branch, or commit'
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -83,11 +88,16 @@ jobs:
         with:
           path: tt-system-firmware
 
+      - name: Set up tt-kmd
+        uses: ./tt-system-firmware/.github/workflows/setup-kmd
+        with:
+          kmd-version: ${{ matrix.config.kmd_build }}
+          kmd-ref: ${{ inputs.kmd_ref }}
+
       - name: Prepare Container
         uses: ./tt-system-firmware/.github/workflows/prepare-container
         with:
           app-path: tt-system-firmware
-          kmd-version: ${{ matrix.config.kmd_build }}
 
       - name: run-dmc-tests
         run: |
@@ -171,11 +181,16 @@ jobs:
         with:
           path: tt-system-firmware
 
+      - name: Set up tt-kmd
+        uses: ./tt-system-firmware/.github/workflows/setup-kmd
+        with:
+          kmd-version: ${{ matrix.config.kmd_build }}
+          kmd-ref: ${{ inputs.kmd_ref }}
+
       - name: Prepare Container
         uses: ./tt-system-firmware/.github/workflows/prepare-container
         with:
           app-path: tt-system-firmware
-          kmd-version: ${{ matrix.config.kmd_build }}
 
       - name: Set ASIC ID
         shell: bash
@@ -284,11 +299,16 @@ jobs:
         with:
           path: tt-zephyr-platforms
 
+      - name: Set up tt-kmd
+        uses: ./tt-zephyr-platforms/.github/workflows/setup-kmd
+        with:
+          kmd-version: ${{ matrix.config.kmd_build }}
+          kmd-ref: ${{ inputs.kmd_ref }}
+
       - name: Prepare Container
         uses: ./tt-zephyr-platforms/.github/workflows/prepare-container
         with:
           app-path: tt-zephyr-platforms
-          kmd-version: ${{ matrix.config.kmd_build }}
 
       - name: Run WH E2E Tests
         working-directory: tt-zephyr-platforms

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -6,7 +6,12 @@ on:
       - labeled
   schedule:
     - cron: "0 6 * * *"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      kmd_ref:
+        description: 'Optional tt-kmd tag, branch, or commit'
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -64,14 +69,16 @@ jobs:
         shell: bash
         working-directory: ${{ env.HOME }}
     steps:
-      - name: Select tt-kmd
-        shell: bash
-        run: |
-          sudo apt update || true
-          sudo apt install -y kmod
-          sudo rmmod tenstorrent
-          sudo insmod /opt/tenstorrent/kmd-builds/${{ matrix.config.kmd_build }}/tenstorrent.ko
-          echo "tt-kmd version: $(cat /sys/module/tenstorrent/version)"
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          path: tt-system-firmware
+
+      - name: Set up tt-kmd
+        uses: ./tt-system-firmware/.github/workflows/setup-kmd
+        with:
+          kmd-version: ${{ matrix.config.kmd_build }}
+          kmd-ref: ${{ inputs.kmd_ref }}
 
       - name: Install ipmitool
         shell: bash

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -58,6 +58,8 @@ jobs:
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /dev/hugepages:/dev/hugepages
+        - /lib/modules:/lib/modules:ro
+        - /usr/src:/usr/src:ro
         - /opt/tenstorrent/hf-models/:/opt/tenstorrent/hf-models/
         - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/
       options: ${{ matrix.config.metal-options }}

--- a/.github/workflows/prepare-container/action.yml
+++ b/.github/workflows/prepare-container/action.yml
@@ -8,9 +8,6 @@ inputs:
   app-path:
     description: 'Path to the Zephyr application to build'
     required: true
-  kmd-version:
-    description: 'Version of tt-kmd to use'
-    required: true
 
 runs:
   using: composite
@@ -60,13 +57,6 @@ runs:
 
         echo "$HOME/.local/bin" >> $GITHUB_PATH
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-    - name: Select tt-kmd
-      shell: bash
-      run: |
-        apt update && apt install -y kmod
-        rmmod tenstorrent
-        insmod /opt/tenstorrent/kmd-builds/${{ inputs.kmd-version }}/tenstorrent.ko
 
     - name: Install ipmitool
       shell: bash

--- a/.github/workflows/publish-tensix-disable.yml
+++ b/.github/workflows/publish-tensix-disable.yml
@@ -72,6 +72,8 @@ jobs:
       image: ghcr.io/tenstorrent/tt-system-firmware/ci-image:v19.11.0
       volumes:
         - /dev/hugepages-1G:/dev/hugepages-1G
+        - /lib/modules:/lib/modules:ro
+        - /usr/src:/usr/src:ro
         - /opt/tenstorrent/kmd-builds/:/opt/tenstorrent/kmd-builds/
       options: '--device /dev/tenstorrent --device /dev/bus/usb --privileged'
     steps:

--- a/.github/workflows/publish-tensix-disable.yml
+++ b/.github/workflows/publish-tensix-disable.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: false
         type: boolean
+      kmd_ref:
+        description: 'Optional tt-kmd tag, branch, or commit'
+        required: false
+        type: string
 
 jobs:
   build_fw_artifact:
@@ -84,11 +88,16 @@ jobs:
         with:
           path: tt-system-firmware
 
+      - name: Set up tt-kmd
+        uses: ./tt-system-firmware/.github/workflows/setup-kmd
+        with:
+          kmd-version: ${{ matrix.config.kmd_build }}
+          kmd-ref: ${{ inputs.kmd_ref }}
+
       - name: Prepare Container
         uses: ./tt-system-firmware/.github/workflows/prepare-container
         with:
           app-path: tt-system-firmware
-          kmd-version: ${{ matrix.config.kmd_build }}
 
       - name: Download all the dists
         uses: actions/download-artifact@v6

--- a/.github/workflows/setup-kmd/action.yml
+++ b/.github/workflows/setup-kmd/action.yml
@@ -43,15 +43,20 @@ runs:
           build-essential \
           git \
           kmod \
-          util-linux \
-          "linux-headers-${kernel_release}"; then
-          echo "::error::Kernel headers for ${kernel_release} are unavailable from this container's package repositories."
+          util-linux; then
+          echo "::error::Unable to install the tt-kmd build dependencies."
           exit 1
         fi
 
         kernel_build_dir="/lib/modules/${kernel_release}/build"
         if [[ ! -d "$kernel_build_dir" ]]; then
-          echo "::error::Kernel build directory ${kernel_build_dir} does not exist after installing headers."
+          echo "::error::Host kernel build directory ${kernel_build_dir} is not mounted in the container."
+          exit 1
+        fi
+
+        module_symvers="${kernel_build_dir}/Module.symvers"
+        if [[ ! -f "$module_symvers" ]]; then
+          echo "::error::Host kernel symbol versions ${module_symvers} are unavailable."
           exit 1
         fi
 
@@ -70,7 +75,8 @@ runs:
         git -C "$source_dir" checkout --quiet --detach FETCH_HEAD
 
         kmd_commit="$(git -C "$source_dir" rev-parse HEAD)"
-        cache_root="/opt/tenstorrent/kmd-builds/${kernel_release}"
+        symvers_hash="$(sha256sum "$module_symvers" | awk '{print $1}')"
+        cache_root="/opt/tenstorrent/kmd-builds/${kernel_release}/${symvers_hash}"
         cache_dir="${cache_root}/${kmd_commit}"
         module_path="${cache_dir}/tenstorrent.ko"
         "${SUDO[@]}" mkdir -p "$cache_root"

--- a/.github/workflows/setup-kmd/action.yml
+++ b/.github/workflows/setup-kmd/action.yml
@@ -60,6 +60,38 @@ runs:
           exit 1
         fi
 
+        kernel_cc="$(
+          make -C "$kernel_build_dir" M=/tmp --no-print-directory -pn 2>/dev/null |
+            awk '$1 == "CC" && ($2 == "=" || $2 == ":=") && !found { print $3; found=1 }'
+        )"
+        if [[ -z "$kernel_cc" ]]; then
+          echo "::error::Unable to determine the compiler required by the host kernel build."
+          exit 1
+        fi
+
+        if ! command -v "$kernel_cc" >/dev/null 2>&1; then
+          case "$kernel_cc" in
+            gcc-[0-9]*|clang-[0-9]*)
+              compiler_package="$kernel_cc"
+              ;;
+            *-gcc-[0-9]*)
+              compiler_package="gcc-${kernel_cc##*-gcc-}"
+              ;;
+            *)
+              echo "::error::Host kernel requires unavailable compiler '${kernel_cc}', and its package cannot be inferred."
+              exit 1
+              ;;
+          esac
+
+          echo "Installing host kernel compiler ${compiler_package}"
+          if ! "${SUDO[@]}" env DEBIAN_FRONTEND=noninteractive \
+            apt-get install -y "$compiler_package"; then
+            echo "::error::Unable to install compiler package ${compiler_package} required by the host kernel."
+            exit 1
+          fi
+        fi
+        echo "Host kernel compiler: $kernel_cc"
+
         source_dir="$(mktemp -d)"
         cleanup() {
           rm -rf "$source_dir"

--- a/.github/workflows/setup-kmd/action.yml
+++ b/.github/workflows/setup-kmd/action.yml
@@ -1,0 +1,116 @@
+name: Build and Load tt-kmd
+description: Build tt-kmd for the running kernel and load it
+
+inputs:
+  kmd-version:
+    description: Plain tt-kmd version used to derive the default ttkmd-<version> tag
+    required: true
+  kmd-ref:
+    description: Optional tt-kmd git tag, branch, or commit overriding kmd-version
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Build and load tt-kmd
+      shell: bash
+      env:
+        KMD_VERSION: ${{ inputs.kmd-version }}
+        KMD_REF_OVERRIDE: ${{ inputs.kmd-ref }}
+      run: |
+        set -euo pipefail
+
+        kernel_release="$(uname -r)"
+        kmd_ref="${KMD_REF_OVERRIDE:-ttkmd-${KMD_VERSION}}"
+
+        if [[ "$EUID" -eq 0 ]]; then
+          SUDO=()
+        elif command -v sudo >/dev/null 2>&1; then
+          SUDO=(sudo)
+        else
+          echo "::error::Building and loading tt-kmd requires root or sudo."
+          exit 1
+        fi
+
+        if [[ ! "$kmd_ref" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]]; then
+          echo "::error::Invalid tt-kmd ref: $kmd_ref"
+          exit 1
+        fi
+
+        "${SUDO[@]}" apt-get update
+        if ! "${SUDO[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+          build-essential \
+          git \
+          kmod \
+          util-linux \
+          "linux-headers-${kernel_release}"; then
+          echo "::error::Kernel headers for ${kernel_release} are unavailable from this container's package repositories."
+          exit 1
+        fi
+
+        kernel_build_dir="/lib/modules/${kernel_release}/build"
+        if [[ ! -d "$kernel_build_dir" ]]; then
+          echo "::error::Kernel build directory ${kernel_build_dir} does not exist after installing headers."
+          exit 1
+        fi
+
+        source_dir="$(mktemp -d)"
+        cleanup() {
+          rm -rf "$source_dir"
+        }
+        trap cleanup EXIT
+
+        git init --quiet "$source_dir"
+        git -C "$source_dir" remote add origin https://github.com/tenstorrent/tt-kmd.git
+        if ! git -C "$source_dir" fetch --quiet --depth=1 origin "$kmd_ref"; then
+          echo "::error::Unable to fetch tt-kmd ref ${kmd_ref}."
+          exit 1
+        fi
+        git -C "$source_dir" checkout --quiet --detach FETCH_HEAD
+
+        kmd_commit="$(git -C "$source_dir" rev-parse HEAD)"
+        cache_root="/opt/tenstorrent/kmd-builds/${kernel_release}"
+        cache_dir="${cache_root}/${kmd_commit}"
+        module_path="${cache_dir}/tenstorrent.ko"
+        "${SUDO[@]}" mkdir -p "$cache_root"
+
+        # The cache and lock are on the host-mounted volume, so concurrent jobs
+        # on the same runner cannot publish or load a partially built module.
+        "${SUDO[@]}" touch "${cache_root}/.setup-kmd.lock"
+        "${SUDO[@]}" chmod a+rw "${cache_root}/.setup-kmd.lock"
+        exec 9>"${cache_root}/.setup-kmd.lock"
+        flock 9
+
+        if [[ ! -f "$module_path" ]]; then
+          echo "Building tt-kmd ${kmd_ref} (${kmd_commit}) for ${kernel_release}"
+          make -C "$source_dir" -j"$(nproc)"
+          "${SUDO[@]}" mkdir -p "$cache_dir"
+          temporary_module="${module_path}.tmp.$$"
+          "${SUDO[@]}" install -m 0644 \
+            "${source_dir}/tenstorrent.ko" "$temporary_module"
+          "${SUDO[@]}" mv "$temporary_module" "$module_path"
+        else
+          echo "Using cached tt-kmd ${kmd_commit} for ${kernel_release}"
+        fi
+
+        if [[ ! -f "$module_path" ]]; then
+          echo "::error::Expected built module ${module_path} does not exist."
+          exit 1
+        fi
+
+        module_vermagic="$(modinfo -F vermagic "$module_path")"
+        if [[ "$module_vermagic" != "${kernel_release} "* ]]; then
+          echo "::error::Module vermagic '${module_vermagic}' does not match running kernel '${kernel_release}'."
+          exit 1
+        fi
+
+        if [[ -d /sys/module/tenstorrent ]]; then
+          "${SUDO[@]}" rmmod tenstorrent
+        fi
+        "${SUDO[@]}" insmod "$module_path"
+
+        echo "tt-kmd ref: ${kmd_ref}"
+        echo "tt-kmd commit: ${kmd_commit}"
+        echo "tt-kmd version: $(cat /sys/module/tenstorrent/version)"
+        echo "tt-kmd vermagic: ${module_vermagic}"

--- a/.github/workflows/setup-kmd/action.yml
+++ b/.github/workflows/setup-kmd/action.yml
@@ -61,7 +61,7 @@ runs:
         fi
 
         kernel_cc="$(
-          make -C "$kernel_build_dir" M=/tmp --no-print-directory -pn 2>/dev/null |
+          { make -C "$kernel_build_dir" M=/tmp --no-print-directory -pn 2>/dev/null || true; } |
             awk '$1 == "CC" && ($2 == "=" || $2 == ":=") && !found { print $3; found=1 }'
         )"
         if [[ -z "$kernel_cc" ]]; then


### PR DESCRIPTION
This is just to trigger a CI run.

Edit: now it is to trigger CI runs and experiment with GitHub Actions-ifying the build/load of tenstorrent.ko upon which some of the tests rely.