### PR TITLE
tests: smc: allow one dirty reset failure in smoke

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -976,6 +976,7 @@ def test_dirty_reset():
     """
     total_tries = 10
     fail_count = 0
+    allowed_failures = 1
 
     for i in range(total_tries):
         logger.info(f"Iteration {i}:")
@@ -987,7 +988,9 @@ def test_dirty_reset():
             logger.info(f"dirty reset passed on iteration {i}")
 
     logger.info(f"dirty reset failed {fail_count}/{total_tries} times.")
-    assert fail_count == 0, "dirty reset failed a non-zero number of times."
+    assert fail_count <= allowed_failures, (
+        f"dirty reset failed {fail_count}/{total_tries} times (allowed {allowed_failures} failures)."
+    )
 
 
 def tensix_reset_sequence(arc_chip):


### PR DESCRIPTION
## Overview
Temporarily tolerate up to 1 of 10 dirty reset iterations failing to avoid CI holdups while reliability work continues.

We see failures on some p150a machines at a rate of ~1/200.

Ticket: [SYS-4937](https://tenstorrent.atlassian.net/browse/SYS-4937)

## Tests
Dirty reset smoke on p150a