### PR TITLE
github: ci: Galaxy flash fix 

### DIFF
--- a/.github/ci_boards.json
+++ b/.github/ci_boards.json
@@ -50,8 +50,9 @@
       "metal-options": "--cap-add SYS_MODULE --device /dev/tenstorrent --user=root",
       "kmd_build": "2.10.0"
     },
+
     {
-      "board": "bh-galaxy",
+      "board": "bh-galaxy-revc",
       "metal-image": "ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx:v0.74.0",
       "metal-target": "blackhole_glx",
       "arch-name": "blackhole",

--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -108,6 +108,7 @@ jobs:
         if: >-
           ${{ failure()
           && matrix.config.board != 'bh-galaxy'
+          && matrix.config.board != 'bh-galaxy-revc'
           && matrix.config.board != 'loudbox'
           && matrix.config.board != 'quietbox2' }}
         working-directory: tt-system-firmware

--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -345,6 +345,8 @@ def upgrade_from_version_test(
 ):
     if board_name is None:
         pytest.skip("Upgrade test requires --board set, skipping upgrade test")
+    if board_name == "bh-galaxy-revc":
+        pytest.skip("Upgrade test is not supported on Galaxy revc")
 
     RECOVERY_URL = "https://github.com/tenstorrent/tt-system-firmware/releases/download/v18.12.2/fw-pack-v18.12.2-recovery.tar.gz"
 

--- a/app/smc/pytest/e2e_stress.py
+++ b/app/smc/pytest/e2e_stress.py
@@ -42,7 +42,12 @@ SCRIPT_DIR = Path(os.path.dirname(os.path.abspath(__file__)))
 
 
 def _skip_boards() -> bool:
-    return os.getenv("BOARD") in ("bh-galaxy", "loudbox", "quietbox2")
+    return os.getenv("BOARD") in (
+        "bh-galaxy",
+        "bh-galaxy-revc",
+        "loudbox",
+        "quietbox2",
+    )
 
 
 # Constant memory addresses we can read from SMC
@@ -82,7 +87,7 @@ def tt_smi_reset():
 
 
 @pytest.mark.skipif(
-    "os.getenv('BOARD') in ('bh-galaxy', 'loudbox', 'quietbox2')",
+    "os.getenv('BOARD') in ('bh-galaxy', 'bh-galaxy-revc', 'loudbox', 'quietbox2')",
     reason="Galaxy lacks a DMC; Loudbox/Quietbox2 excluded from DMC-dependent stress tests",
 )
 def test_arc_watchdog(arc_chip_dut, asic_id):
@@ -112,7 +117,7 @@ def test_arc_watchdog(arc_chip_dut, asic_id):
 
 
 @pytest.mark.skipif(
-    "os.getenv('BOARD') in ('bh-galaxy', 'loudbox', 'quietbox2')",
+    "os.getenv('BOARD') in ('bh-galaxy', 'bh-galaxy-revc', 'loudbox', 'quietbox2')",
     reason="Galaxy lacks a DMC; Loudbox/Quietbox2 excluded from DMC-dependent stress tests",
 )
 def test_pcie_fw_load_time(arc_chip_dut, asic_id):
@@ -228,7 +233,7 @@ def test_smi_reset_with_eth(arc_chip_dut, asic_id):
 
 
 @pytest.mark.skipif(
-    "os.getenv('BOARD') in ('bh-galaxy', 'loudbox', 'quietbox2')",
+    "os.getenv('BOARD') in ('bh-galaxy', 'bh-galaxy-revc', 'loudbox', 'quietbox2')",
     reason="Galaxy lacks a DMC; Loudbox/Quietbox2 have no STLink for dirty reset",
 )
 def test_dirty_reset():
@@ -263,7 +268,7 @@ def test_dirty_reset():
 
 
 @pytest.mark.skipif(
-    "os.getenv('BOARD') in ('bh-galaxy', 'loudbox', 'quietbox2')",
+    "os.getenv('BOARD') in ('bh-galaxy', 'bh-galaxy-revc', 'loudbox', 'quietbox2')",
     reason="Galaxy lacks a DMC; Loudbox/Quietbox2 excluded from DMC-dependent stress tests",
 )
 def test_dmc_ping(arc_chip_dut, asic_id):
@@ -425,7 +430,7 @@ def test_power_state_toggle(arc_chip_dut, asic_id, board_name):
 
 
 @pytest.mark.skipif(
-    "os.getenv('BOARD') in ('bh-galaxy', 'loudbox', 'quietbox2')",
+    "os.getenv('BOARD') in ('bh-galaxy', 'bh-galaxy-revc', 'loudbox', 'quietbox2')",
     reason="Burnin not stable on Galaxy, Loudbox, or Quietbox2",
 )
 def test_power_virus(arc_chip_dut, asic_id):
@@ -521,7 +526,7 @@ def test_power_virus(arc_chip_dut, asic_id):
 
 
 @pytest.mark.skipif(
-    "os.getenv('BOARD') in ('bh-galaxy', 'loudbox', 'quietbox2')",
+    "os.getenv('BOARD') in ('bh-galaxy', 'bh-galaxy-revc', 'loudbox', 'quietbox2')",
     reason="Burnin not stable on Galaxy, Loudbox, or Quietbox2",
 )
 def test_tensix_reset_then_burnin(arc_chip_dut, asic_id):

--- a/app/smc/sample.yaml
+++ b/app/smc/sample.yaml
@@ -65,6 +65,7 @@ tests:
       - tt_blackhole@p300a/tt_blackhole/smc
       - tt_blackhole@p300c/tt_blackhole/smc
       - tt_blackhole@galaxy/tt_blackhole/smc
+      - tt_blackhole@galaxy_revc/tt_blackhole/smc
     harness: pytest
     sysbuild: true
     extra_args:

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_galaxy_revc.yaml
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_galaxy_revc.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: tt_blackhole@galaxy_revc/tt_blackhole/smc
+name: Tenstorrent Blackhole Galaxy Rev C (SMC)
+type: mcu
+arch: arc
+toolchain:
+  - zephyr
+  - cross-compile
+  - xtools
+  - arcmwdt
+supported:
+  - dma
+  - smp
+  - bh_glx
+testing:
+  ignore_tags:
+    - net
+    - bluetooth
+vendor: tenstorrent

--- a/scripts/rev2board.sh
+++ b/scripts/rev2board.sh
@@ -26,6 +26,8 @@ case "$1" in
   fi;;
   p100a|p150a|p150b|p150c|p300a|p300b|p300c|galaxy|galaxy_revc|orion_slt)
   BOARD="tt_blackhole@$1/tt_blackhole/$CLUSTER";;
+  bh-galaxy-revc)
+  BOARD="tt_blackhole@galaxy_revc/tt_blackhole/$CLUSTER";;
   bh-galaxy)
   BOARD="tt_blackhole@galaxy/tt_blackhole/$CLUSTER";;
   loudbox)


### PR DESCRIPTION
Target the galaxy revC runner, which should have the new label.

Tests will not work on the old one, as tt-flash will correctly determine the old galaxy FW bundle is not acceptable for the revC, and therefore tests will run on whatever was flashed before.

Remove the old board for now since we don't have a runner for it.

Can't run the upgrade-from-version test on the revc galaxy because the FW for that board didn't exist at the time.

### Tests:

stress here passed everything (except the upgrade test)