### PR TITLE
MK DMC: a shell on the USB-C port, alongside the UART one

### DIFF
--- a/app/dm_test_app/prj.conf
+++ b/app/dm_test_app/prj.conf
@@ -31,6 +31,34 @@ CONFIG_LOG_BUFFER_SIZE=32768
 # create build/zephyr/zephyr.lst
 CONFIG_OUTPUT_DISASSEMBLY=y
 
+# USB device: the board's USB-C port goes straight to the STM32 (PA11/PA12), so
+# expose it as a CDC ACM serial port and run a second shell on it. The UART shell
+# on uart4 (FTDI) is untouched -- both work at once, see usb_shell.c.
+#
+# INITIALIZE_AT_BOOT builds the whole USBD context (descriptors, configuration,
+# usbd_init + usbd_enable) around the first zephyr,cdc-acm-uart under
+# zephyr_udc0, so the app needs no USB setup code of its own.
+CONFIG_USB_DEVICE_STACK_NEXT=y
+CONFIG_USBD_CDC_ACM_CLASS=y
+CONFIG_CDC_ACM_SERIAL_INITIALIZE_AT_BOOT=y
+CONFIG_CDC_ACM_SERIAL_PRODUCT_STRING="MK DMC shell"
+CONFIG_CDC_ACM_SERIAL_MANUFACTURER_STRING="Tenstorrent"
+CONFIG_UART_LINE_CTRL=y
+
+# This app runs the whole log subsystem at DBG (below). Left there, USB
+# enumeration alone emits hundreds of lines per plug-in over the 115200 console,
+# which is slow enough to disturb the enumeration it is reporting on. Pin the USB
+# modules to warnings so real faults still show up.
+#
+# UDC_DRIVER matters as much as the other two: udc_stm32.c logs "DataIn ep 0x%02x"
+# at DBG on *every* IN transfer, and the console is uart4 -- which is also the
+# shell backend. Left at DBG, driving the USB shell sprays log lines into the
+# FTDI shell's replies, where a partial line ("ataIn ep 0x80") does not match the
+# host's log-line filter and lands inside a command's output instead.
+CONFIG_USBD_LOG_LEVEL_WRN=y
+CONFIG_USBD_CDC_ACM_LOG_LEVEL_WRN=y
+CONFIG_UDC_DRIVER_LOG_LEVEL_WRN=y
+
 # Shell configuration
 CONFIG_SHELL=y
 CONFIG_SHELL_BACKEND_SERIAL=y

--- a/app/dm_test_app/src/usb_shell.c
+++ b/app/dm_test_app/src/usb_shell.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * A second shell instance, on the USB CDC ACM port.
+ *
+ * Zephyr's serial shell backend is a single instance bound to the
+ * ``zephyr,shell-uart`` chosen node (subsys/shell/backends/shell_uart.c binds
+ * one SHELL_DEFINE to DT_CHOSEN(zephyr_shell_uart) and nothing else). Pointing
+ * that chosen node at the CDC ACM -- what the upstream ``cdc-acm-console``
+ * snippet does -- would therefore have *moved* the shell to USB and taken it off
+ * uart4, breaking every host tool that drives this DMC over the FTDI.
+ *
+ * So instead of moving it, this declares a second transport and shell against
+ * the same public SHELL_UART_DEFINE API. Both run at once: uart4 keeps its
+ * shell, and the USB-C port gets an equivalent one.
+ *
+ * The prompt is deliberately CONFIG_SHELL_PROMPT_UART, the same string the uart4
+ * shell uses: host tools find the end of a reply by matching the prompt, so the
+ * two transports have to be indistinguishable from the outside.
+ */
+
+#include <errno.h>
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/shell/shell_uart.h>
+
+#define USB_SHELL_NODE DT_NODELABEL(cdc_acm_uart0)
+
+#if DT_NODE_HAS_STATUS_OKAY(USB_SHELL_NODE)
+
+SHELL_UART_DEFINE(shell_transport_usb);
+SHELL_DEFINE(shell_usb, CONFIG_SHELL_PROMPT_UART, &shell_transport_usb,
+	     CONFIG_SHELL_BACKEND_SERIAL_LOG_MESSAGE_QUEUE_SIZE,
+	     CONFIG_SHELL_BACKEND_SERIAL_LOG_MESSAGE_QUEUE_TIMEOUT, SHELL_FLAG_OLF_CRLF);
+
+static int enable_shell_usb(void)
+{
+	const struct device *const dev = DEVICE_DT_GET(USB_SHELL_NODE);
+	static const struct shell_backend_config_flags cfg_flags =
+		SHELL_DEFAULT_BACKEND_CONFIG_FLAGS;
+
+	if (!device_is_ready(dev)) {
+		return -ENODEV;
+	}
+
+	/*
+	 * log_backend = false: the uart4 shell is already the log backend, and a
+	 * second one would duplicate every message. Logs stay on the FTDI, which
+	 * also keeps them somewhere readable while USB itself is being brought up.
+	 */
+	shell_init(&shell_usb, dev, cfg_flags, false, 0);
+
+	return 0;
+}
+
+/*
+ * Same priority the built-in backend uses. The CDC ACM UART device itself is
+ * created at PRE_KERNEL_1 (CONFIG_SERIAL_INIT_PRIORITY), so it is ready well
+ * before this runs; writes made before the host enumerates are simply dropped.
+ */
+SYS_INIT(enable_shell_usb, POST_KERNEL, CONFIG_SHELL_BACKEND_SERIAL_INIT_PRIORITY);
+
+#endif /* DT_NODE_HAS_STATUS_OKAY(USB_SHELL_NODE) */

--- a/boards/tenstorrent/tt_grendel_mk_bu_dmc/tt_grendel_mk_bu_dmc.dts
+++ b/boards/tenstorrent/tt_grendel_mk_bu_dmc/tt_grendel_mk_bu_dmc.dts
@@ -163,8 +163,22 @@
 	status = "okay";
 };
 
+/* USB-C device port straight to the STM32: PA11 = D-, PA12 = D+. The USB FS
+ * clock is HSI48 (see &clk_hsi48 above, and the SoC's ICLK_SEL); there is no
+ * HSE or LSE on this board, so HSI48 running on its factory trim is the only
+ * 48 MHz source -- which is exactly how upstream's nucleo_u385rg_q does it.
+ */
 zephyr_udc0: &usb {
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	pinctrl-names = "default";
 	status = "okay";
+
+	/* CDC ACM function, so the host sees a /dev/ttyACM* serial port. The
+	 * node label is what CONFIG_CDC_ACM_SERIAL_INITIALIZE_AT_BOOT looks for
+	 * (it registers the first CDC ACM instance under zephyr_udc0), and what
+	 * dm_test_app binds its second shell instance to.
+	 */
+	cdc_acm_uart0: cdc_acm_uart0 {
+		compatible = "zephyr,cdc-acm-uart";
+	};
 };


### PR DESCRIPTION
The MK's USB-C port goes straight to the STM32 (PA11 = D-, PA12 = D+), but nothing claimed it, so the only way into the DMC shell was uart4 out through an FT4232H. This exposes the port as CDC ACM and runs a shell on it, so the board needs one cable and no adapter to be driven.

The board already had the USB node enabled with the right pinctrl and clk_hsi48 on -- byte-identical to upstream's nucleo_u385rg_q, which is the same SoC -- so only a CDC ACM function node and the app's Kconfig were missing.

Both shells at once, rather than moving the shell
-------------------------------------------------
Upstream's cdc-acm-console snippet repoints chosen zephyr,shell-uart at the CDC ACM, which *moves* the shell to USB and takes it off uart4. That would have broken every host tool that drives this DMC over the FTDI, so it is not what this does. Zephyr's serial shell backend is a single instance bound to zephyr,shell-uart (subsys/shell/backends/shell_uart.c), so src/usb_shell.c declares a second transport and shell against the same public SHELL_UART_DEFINE API. chosen zephyr,shell-uart is untouched and uart4 keeps its shell.

The second instance uses CONFIG_SHELL_PROMPT_UART deliberately, so both transports present the same prompt: host tools find the end of a reply by matching it, and they should not have to care which wire they came in on. It is registered with log_backend = false, because uart4's shell is already the log backend and two would duplicate every message -- logs stay on the FTDI, which also keeps them readable while USB itself is being brought up.

Log levels are not incidental here
----------------------------------
dm_test_app runs the whole log subsystem at DBG. Left there, UDC_DRIVER alone sprays a line per IN transfer ("DataIn ep 0x%02x" in udc_stm32.c) into the uart4 console -- which is also the shell backend, so driving the USB shell corrupted replies on the FTDI one. A partial line ("ataIn ep 0x80") does not match the host's log-line filter and lands inside a command's output. USBD, USBD_CDC_ACM and UDC_DRIVER are therefore pinned to WRN; real faults still show up, and the image is 4.7 KB smaller for losing the DBG strings.

Hardware notes for anyone repeating this
----------------------------------------
VDDUSB is a separate supply on this part (3.0-3.6 V, "external independent power supply for USB transceivers" -- DS14861 3.8.1) and the USB FS block sits in that domain. Zephyr sets PWR_SVMCR.USV via LL_PWR_EnableVDDUSB(), but that only declares an external supply valid; it does not create one. With that rail down the PHY cannot drive the D+ pull-up and the host never sees a device.

BOOT0/PH3 must be LOW. High boots the system bootloader, which enumerates as an ST DFU device rather than this CDC ACM shell.

There is no CRS node in Zephyr's U3 DTS, so HSI48 runs on its factory trim rather than being trimmed against USB SOF. Same as the nucleo board, and it enumerates reliably here, but it is the first thing to suspect if it ever goes flaky across temperature.

Tested on MK board 3 (STM32U375RGT6): enumerates as a full-speed CDC ACM, 2fe3:0004 "MK DMC shell", bound to /dev/ttyACM1. Both shells were driven concurrently, each doing real I2C through its own session; a full functional sweep of every reachable component returned identical results over USB and UART, and round-trip latency is 5.4 ms against 6.0 ms over the FTDI.

CONFIG_CDC_ACM_SERIAL_VID/_PID are still Zephyr's defaults (2fe3:0004), which is why lsusb labels the board "NordicSemiconductor". That wants a Tenstorrent VID/PID before it goes anywhere near production.