### PR TITLE
lib: tenstorrent: bh_arc: process error logs for gddr therm trip

### DIFF
--- a/lib/tenstorrent/bh_arc/cat.c
+++ b/lib/tenstorrent/bh_arc/cat.c
@@ -23,6 +23,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/sensor/tenstorrent/pvt_tt_bh.h>
 #include <zephyr/logging/log.h>
+#include <zephyr/logging/log_ctrl.h>
 
 LOG_MODULE_REGISTER(cat);
 
@@ -290,6 +291,10 @@ static void gddr_therm_trip_work_handler(struct k_work *work)
 	int max_temp = MonitorGddrThermTrip(k_uptime_get(), GetTelemetryTag(TAG_MAX_GDDR_TEMP));
 
 	if (max_temp && GetActiveFeatures().gddr_therm_trip) {
+		/* Force log thread to process so the over-temp error above
+		 * reaches the host (KMD) before the therm trip resets the SMC.
+		 */
+		log_flush();
 		/* Notify DMC, then trigger therm trip after delay so DMC can read the message */
 		trip_pending = true;
 		ReportGddrThermTrip(max_temp >= gddr_therm_trip_critical_temp &&

--- a/lib/tenstorrent/bh_arc/tt_pcie_log.c
+++ b/lib/tenstorrent/bh_arc/tt_pcie_log.c
@@ -384,6 +384,12 @@ static void backend_process(const struct log_backend *const backend, union log_m
 	uint16_t total_size_u16 = (uint16_t)total_size;
 
 	memcpy(framed_log_buffer + entry_start_pos, &total_size_u16, sizeof(total_size_u16));
+
+	/* Push error-level logs to host immediately */
+	if (entry_header.log_level == LOG_LEVEL_ERR) {
+		flush_buffer_to_host();
+	}
+
 	k_mutex_unlock(&buffer_mutex);
 }
 


### PR DESCRIPTION
On logs with error-level, flush buffer to host immediately when processed.
Also force the log thread to to process queued logs on a gddr therm trip so that log can be captured by host before therm trip is triggered.

**Tests**:
- Local spot check on p150a system (dmesg captures log of therm trip before ASIC is gets tripped)

**Resolves**: SYS-4905