### PR TITLE
lib: tenstorrent: bh_arc: Use sys init instead of init.c

### DIFF
--- a/include/tenstorrent/msgqueue.h
+++ b/include/tenstorrent/msgqueue.h
@@ -1146,7 +1146,7 @@ int msgqueue_request_push(uint32_t msgqueue_id, const union request *request);
 int msgqueue_request_pop(uint32_t msgqueue_id, union request *request);
 int msgqueue_response_push(uint32_t msgqueue_id, const struct response *response);
 int msgqueue_response_pop(uint32_t msgqueue_id, struct response *response);
-void init_msgqueue(void);
+int init_msgqueue(void);
 
 #ifdef __cplusplus
 }

--- a/include/tenstorrent/sys_init_defines.h
+++ b/include/tenstorrent/sys_init_defines.h
@@ -34,7 +34,14 @@
 #define gddr_training_PRIO                    111
 #define CATInit_PRIO                          112
 #define publish_runtime_telemetry_PRIO        113
-#define bh_arc_init_end_PRIO                  114
+#define InitDVFS_PRIO                         114
+#define init_msgqueue_PRIO                    115
+#define init_telemetry_PRIO                   116
+#define init_fan_ctrl_PRIO                    117
+#define StartTelemetryTimer_PRIO              118
+#define StartDVFSTimer_PRIO                   119
+#define StartGddrThermTripMonitor_PRIO        120
+#define bh_arc_init_end_PRIO                  121
 
 #define SYS_INIT_APP(func) SYS_INIT(func, POST_KERNEL, func##_PRIO)
 

--- a/lib/tenstorrent/bh_arc/cat.c
+++ b/lib/tenstorrent/bh_arc/cat.c
@@ -317,7 +317,7 @@ static void gddr_therm_trip_timer_handler(struct k_timer *timer)
 
 static K_TIMER_DEFINE(gddr_therm_trip_timer, gddr_therm_trip_timer_handler, NULL);
 
-void StartGddrThermTripMonitor(void)
+int StartGddrThermTripMonitor(void)
 {
 	const FwTable *fw_table = tt_bh_fwtable_get_fw_table(fwtable_dev);
 
@@ -331,5 +331,8 @@ void StartGddrThermTripMonitor(void)
 
 	k_timer_start(&gddr_therm_trip_timer, K_MSEC(gddr_therm_trip_interval),
 		      K_MSEC(gddr_therm_trip_interval));
+
+	return 0;
 }
+SYS_INIT_APP(StartGddrThermTripMonitor);
 #endif

--- a/lib/tenstorrent/bh_arc/cat.h
+++ b/lib/tenstorrent/bh_arc/cat.h
@@ -13,7 +13,7 @@
 
 #define T_J_SHUTDOWN 110 /* BH Prod Spec 7.3 */
 
-void StartGddrThermTripMonitor(void);
+int StartGddrThermTripMonitor(void);
 
 /** @brief Evaluate the GDDR thermal-trip state machine for one sample against
  * the supplied thresholds.

--- a/lib/tenstorrent/bh_arc/dvfs.c
+++ b/lib/tenstorrent/bh_arc/dvfs.c
@@ -86,10 +86,20 @@ SYS_INIT_APP(InitDVFS);
 
 #define DVFS_MSEC 1
 
-void StartDVFSTimer(void)
+int StartDVFSTimer(void)
 {
+	if (!dvfs_enabled) {
+		return 0;
+	}
+
+	/* Split from InitDVFS because the work task has I2C conflicts with other
+	 * init functions. Zephyr's driver model would solve this.
+	 */
 	k_timer_start(&dvfs_timer, K_MSEC(DVFS_MSEC), K_MSEC(DVFS_MSEC));
+
+	return 0;
 }
+SYS_INIT_APP(StartDVFSTimer);
 
 #define DVFS_TICKS (CONFIG_SYS_CLOCK_TICKS_PER_SEC * DVFS_MSEC / MSEC_PER_SEC)
 

--- a/lib/tenstorrent/bh_arc/dvfs.c
+++ b/lib/tenstorrent/bh_arc/dvfs.c
@@ -5,10 +5,22 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/drivers/misc/bh_fwtable.h>
+#include <tenstorrent/sys_init_defines.h>
+
 #include "vf_curve.h"
 #include "throttler.h"
 #include "aiclk_ppm.h"
 #include "voltage.h"
+#include "init.h"
+#include "reg.h"
+#include "status_reg.h"
+
+LOG_MODULE_REGISTER(dvfs, CONFIG_TT_APP_LOG_LEVEL);
+
+static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
 
 bool dvfs_enabled;
 
@@ -41,14 +53,36 @@ static void dvfs_timer_handler(struct k_timer *timer)
 }
 static K_TIMER_DEFINE(dvfs_timer, dvfs_timer_handler, NULL);
 
-void InitDVFS(void)
+static int InitDVFS(void)
 {
+	if (IS_ENABLED(CONFIG_TT_BH_ARC_EMUL)) {
+		return 0;
+	}
+
+	if (!tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.aiclk_ppm_en) {
+		return 0;
+	}
+
+	uint32_t err0 = ReadReg(STATUS_ERROR_STATUS0_REG_ADDR);
+
+	if (err0 & BIT(INIT_STAGE_REGULATOR)) {
+		LOG_ERR("Not enabling AICLK PPM due to regulator init error");
+		return 0;
+	}
+
+	/* DVFS should get enabled if AICLK PPM or L2CPUCLK PPM is enabled.
+	 * We currently don't have plans to implement L2CPUCLK PPM,
+	 * so currently, dvfs_enable == aiclk_ppm_enable.
+	 */
 	InitVFCurve();
 	InitVoltagePPM();
 	InitArbMaxVoltage();
 	InitThrottlers();
 	dvfs_enabled = true;
+
+	return 0;
 }
+SYS_INIT_APP(InitDVFS);
 
 #define DVFS_MSEC 1
 

--- a/lib/tenstorrent/bh_arc/dvfs.h
+++ b/lib/tenstorrent/bh_arc/dvfs.h
@@ -10,7 +10,7 @@
 
 extern bool dvfs_enabled;
 
-void StartDVFSTimer(void);
+int StartDVFSTimer(void);
 void AdjustDVFSTimer(void);
 void DVFSChange(void);
 

--- a/lib/tenstorrent/bh_arc/dvfs.h
+++ b/lib/tenstorrent/bh_arc/dvfs.h
@@ -10,7 +10,6 @@
 
 extern bool dvfs_enabled;
 
-void InitDVFS(void);
 void StartDVFSTimer(void);
 void AdjustDVFSTimer(void);
 void DVFSChange(void);

--- a/lib/tenstorrent/bh_arc/fan_ctrl.c
+++ b/lib/tenstorrent/bh_arc/fan_ctrl.c
@@ -15,10 +15,12 @@
 
 #include <tenstorrent/msgqueue.h>
 #include <tenstorrent/smc_msg.h>
+#include <tenstorrent/sys_init_defines.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/misc/bh_fwtable.h>
+#include <zephyr/init.h>
 
 #ifdef CONFIG_ZTEST
 #define STATIC
@@ -143,8 +145,12 @@ static void fan_ctrl_timer_handler(struct k_timer *timer)
 }
 static K_TIMER_DEFINE(fan_ctrl_update_timer, fan_ctrl_timer_handler, NULL);
 
-void init_fan_ctrl(void)
+int init_fan_ctrl(void)
 {
+	if (!tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.fan_ctrl_en) {
+		return 0;
+	}
+
 	/* Get initial asic temp */
 	TelemetryInternalData telemetry_internal_data;
 
@@ -154,7 +160,10 @@ void init_fan_ctrl(void)
 	/* start a periodic timer that expires once every fan_ctrl_update_interval */
 	k_timer_start(&fan_ctrl_update_timer, K_MSEC(fan_ctrl_update_interval),
 		      K_MSEC(fan_ctrl_update_interval));
+
+	return 0;
 }
+SYS_INIT_APP(init_fan_ctrl);
 
 static uint8_t force_fan_speed(const union request *request, struct response *response)
 {

--- a/lib/tenstorrent/bh_arc/fan_ctrl.h
+++ b/lib/tenstorrent/bh_arc/fan_ctrl.h
@@ -8,7 +8,7 @@
 
 #include <stdint.h>
 
-void init_fan_ctrl(void);
+int init_fan_ctrl(void);
 uint32_t GetFanSpeed(void);
 uint16_t GetFanRPM(void);
 void SetFanRPM(uint16_t rpm);

--- a/lib/tenstorrent/bh_arc/init.c
+++ b/lib/tenstorrent/bh_arc/init.c
@@ -96,10 +96,6 @@ static int bh_arc_init_end(void)
 	SetPostCode(POST_CODE_SRC_CMFW, POST_CODE_ZEPHYR_INIT_DONE);
 	printk("Tenstorrent Blackhole CMFW %s\n", APP_VERSION_STRING);
 
-#ifdef CONFIG_TT_MSGQUEUE
-	init_msgqueue();
-#endif
-
 #ifdef CONFIG_BH_FWTABLE
 	init_telemetry(APPVERSION);
 	if (tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.fan_ctrl_en) {

--- a/lib/tenstorrent/bh_arc/init.c
+++ b/lib/tenstorrent/bh_arc/init.c
@@ -96,22 +96,6 @@ static int bh_arc_init_end(void)
 	SetPostCode(POST_CODE_SRC_CMFW, POST_CODE_ZEPHYR_INIT_DONE);
 	printk("Tenstorrent Blackhole CMFW %s\n", APP_VERSION_STRING);
 
-#if defined(CONFIG_BH_FWTABLE) && !defined(CONFIG_TT_BH_ARC_EMUL)
-	if (tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.aiclk_ppm_en) {
-		uint32_t err0 = ReadReg(STATUS_ERROR_STATUS0_REG_ADDR);
-
-		if (err0 & BIT(INIT_STAGE_REGULATOR)) {
-			LOG_ERR("Not enabling AICLK PPM due to regulator init error");
-		} else {
-			/* DVFS should get enabled if AICLK PPM or L2CPUCLK PPM is enabled
-			 * We currently don't have plans to implement L2CPUCLK PPM,
-			 * so currently, dvfs_enable == aiclk_ppm_enable
-			 */
-			InitDVFS();
-		}
-	}
-#endif
-
 #ifdef CONFIG_TT_MSGQUEUE
 	init_msgqueue();
 #endif

--- a/lib/tenstorrent/bh_arc/init.c
+++ b/lib/tenstorrent/bh_arc/init.c
@@ -97,13 +97,6 @@ static int bh_arc_init_end(void)
 	printk("Tenstorrent Blackhole CMFW %s\n", APP_VERSION_STRING);
 
 #ifdef CONFIG_BH_FWTABLE
-	/* These timers are split out from their init functions since their work tasks have
-	 * i2c conflicts with other init functions.
-	 *
-	 * Note: The above issue would be solved by using Zephyr's driver model.
-	 */
-	StartTelemetryTimer();
-
 #if !defined(CONFIG_TT_BH_ARC_EMUL)
 	if (dvfs_enabled) {
 		StartDVFSTimer();

--- a/lib/tenstorrent/bh_arc/init.c
+++ b/lib/tenstorrent/bh_arc/init.c
@@ -3,13 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "cat.h"
-#include "dvfs.h"
-#include "fan_ctrl.h"
 #include "init.h"
 #include "reg.h"
 #include "status_reg.h"
-#include "telemetry.h"
 #include "timer.h"
 #include "cm2dm_msg.h"
 #include <stdint.h>
@@ -21,22 +17,11 @@
 #define APP_VERSION_STRING "unknown"
 #endif
 
-#include <tenstorrent/msgqueue.h>
 #include <tenstorrent/post_code.h>
 #include <tenstorrent/sys_init_defines.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
-#include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
-#ifdef CONFIG_BH_FWTABLE
-#include <zephyr/drivers/misc/bh_fwtable.h>
-#endif
-
-LOG_MODULE_REGISTER(bh_arc_init, CONFIG_TT_APP_LOG_LEVEL);
-
-#ifdef CONFIG_BH_FWTABLE
-static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
-#endif
 
 #define FW_VERSION_SEMANTIC APPVERSION
 #define FW_VERSION_DATE     0x00000000

--- a/lib/tenstorrent/bh_arc/init.c
+++ b/lib/tenstorrent/bh_arc/init.c
@@ -97,10 +97,6 @@ static int bh_arc_init_end(void)
 	printk("Tenstorrent Blackhole CMFW %s\n", APP_VERSION_STRING);
 
 #ifdef CONFIG_BH_FWTABLE
-	if (tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.fan_ctrl_en) {
-		init_fan_ctrl();
-	}
-
 	/* These timers are split out from their init functions since their work tasks have
 	 * i2c conflicts with other init functions.
 	 *

--- a/lib/tenstorrent/bh_arc/init.c
+++ b/lib/tenstorrent/bh_arc/init.c
@@ -96,9 +96,6 @@ static int bh_arc_init_end(void)
 	SetPostCode(POST_CODE_SRC_CMFW, POST_CODE_ZEPHYR_INIT_DONE);
 	printk("Tenstorrent Blackhole CMFW %s\n", APP_VERSION_STRING);
 
-#ifdef CONFIG_BH_FWTABLE
-	StartGddrThermTripMonitor();
-#endif
 	Dm2CmReadyRequest();
 	return 0;
 }

--- a/lib/tenstorrent/bh_arc/init.c
+++ b/lib/tenstorrent/bh_arc/init.c
@@ -97,11 +97,6 @@ static int bh_arc_init_end(void)
 	printk("Tenstorrent Blackhole CMFW %s\n", APP_VERSION_STRING);
 
 #ifdef CONFIG_BH_FWTABLE
-#if !defined(CONFIG_TT_BH_ARC_EMUL)
-	if (dvfs_enabled) {
-		StartDVFSTimer();
-	}
-#endif
 	StartGddrThermTripMonitor();
 #endif
 	Dm2CmReadyRequest();

--- a/lib/tenstorrent/bh_arc/init.c
+++ b/lib/tenstorrent/bh_arc/init.c
@@ -97,7 +97,6 @@ static int bh_arc_init_end(void)
 	printk("Tenstorrent Blackhole CMFW %s\n", APP_VERSION_STRING);
 
 #ifdef CONFIG_BH_FWTABLE
-	init_telemetry(APPVERSION);
 	if (tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.fan_ctrl_en) {
 		init_fan_ctrl();
 	}

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -650,16 +650,20 @@ int init_telemetry(void)
 }
 SYS_INIT_APP(init_telemetry);
 
-void StartTelemetryTimer(void)
+int StartTelemetryTimer(void)
 {
 	/* Start the timer to update the dynamic telemetry values
 	 * Duration (time interval before the timer expires for the first time) and
 	 * Period (time interval between all timer expirations after the first one)
-	 * are both set to telem_update_interval
+	 * are both set to telem_update_interval.
+	 *
+	 * Split from init_telemetry because the work task has I2C conflicts with
+	 * other init functions. Zephyr's driver model would solve this.
 	 */
 	k_timer_start(&telem_update_timer, K_MSEC(telem_update_interval),
 		      K_MSEC(telem_update_interval));
 	telem_timer_started = true;
+	return 0;
 }
 
 uint8_t TelemetrySetUpdateInterval(uint32_t interval_ms)
@@ -690,4 +694,5 @@ uint8_t TelemetrySetUpdateInterval(uint32_t interval_ms)
 	LOG_INF("telemetry update interval set to %d ms", telem_update_interval);
 	return 0;
 }
+SYS_INIT_APP(StartTelemetryTimer);
 #endif /* CONFIG_BH_FWTABLE */

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -42,11 +42,18 @@
 
 #include <tenstorrent/post_code.h>
 #include <tenstorrent/smbus_target.h>
+#include <tenstorrent/sys_init_defines.h>
 #include <zephyr/drivers/misc/bh_fwtable.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/clock_control/clock_control_tt_bh.h>
 #include <zephyr/drivers/clock_control.h>
+#include <zephyr/init.h>
+#if defined(HAS_APP_VERSION)
+#include <zephyr/app_version.h>
+#else
+#define APPVERSION 0x00000000
+#endif
 #endif
 
 LOG_MODULE_REGISTER(telemetry, CONFIG_TT_APP_LOG_LEVEL);
@@ -629,16 +636,19 @@ static void telemetry_timer_handler(struct k_timer *timer)
 static K_WORK_DEFINE(telem_update_worker, telemetry_work_handler);
 static K_TIMER_DEFINE(telem_update_timer, telemetry_timer_handler, NULL);
 
-void init_telemetry(uint32_t app_version)
+int init_telemetry(void)
 {
-	write_static_telemetry(app_version);
+	write_static_telemetry(APPVERSION);
 	/* fill the dynamic values once before starting timed updates */
 	update_telemetry();
 
 	/* Publish the telemetry data pointer for readers in Scratch RAM */
 	WriteReg(TELEMETRY_DATA_REG_ADDR, (uint32_t)&telemetry[0]);
 	WriteReg(TELEMETRY_TABLE_REG_ADDR, (uint32_t)&telemetry_table);
+
+	return 0;
 }
+SYS_INIT_APP(init_telemetry);
 
 void StartTelemetryTimer(void)
 {

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -517,7 +517,7 @@ typedef union {
 /** @brief Longest accepted telemetry update interval in milliseconds. */
 #define TELEM_UPDATE_INTERVAL_MAX_MS 1000
 
-void init_telemetry(uint32_t app_version);
+int init_telemetry(void);
 uint32_t ConvertFloatToTelemetry(float value);
 float ConvertTelemetryToFloat(int32_t value);
 void StartTelemetryTimer(void);

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -520,7 +520,7 @@ typedef union {
 int init_telemetry(void);
 uint32_t ConvertFloatToTelemetry(float value);
 float ConvertTelemetryToFloat(int32_t value);
-void StartTelemetryTimer(void);
+int StartTelemetryTimer(void);
 
 /** @brief Set the periodic telemetry update interval.
  * @param interval_ms 0 restores @ref TELEM_UPDATE_INTERVAL_DEFAULT_MS, otherwise the interval in

--- a/lib/tenstorrent/fw_common/msgqueue.c
+++ b/lib/tenstorrent/fw_common/msgqueue.c
@@ -365,7 +365,6 @@ static void prepare_msg_queue(void)
 	WriteReg(STATUS_MSG_Q_INFO_REG_ADDR, (uintptr_t)message_queue_info);
 }
 
-#ifndef MSG_QUEUE_TEST
 static int register_interrupt_handlers(void)
 {
 	STRUCT_SECTION_FOREACH(msgqueue_handler, item) {
@@ -375,7 +374,6 @@ static int register_interrupt_handlers(void)
 }
 
 SYS_INIT_APP(register_interrupt_handlers);
-#endif
 
 #if MSGQUEUE_HAS_IRQS || MSGQUEUE_HAS_MBOX
 static void msgqueue_work_handler(struct k_work *work)
@@ -543,7 +541,7 @@ static void init_msgqueue_mbox_irq(void)
 }
 #endif /* MSGQUEUE_HAS_MBOX */
 
-void init_msgqueue(void)
+int init_msgqueue(void)
 {
 	prepare_msg_queue();
 
@@ -553,4 +551,8 @@ void init_msgqueue(void)
 #if MSGQUEUE_HAS_MBOX
 	init_msgqueue_mbox_irq();
 #endif
+
+	return 0;
 }
+
+SYS_INIT_APP(init_msgqueue);


### PR DESCRIPTION
Adresses [SYS-5030](https://tenstorrent.atlassian.net/browse/SYS-5030)

## Overview
Moves the following `bh_arc` inits out of `init.c` and uses Zephyr `SYS_INIT` instead (order preserved):
- DVFS
- msgqueue
- telemetry
- fan_cntrl
- Telemetry timer start
- DVFS timer start
- GDDR therm trip monitor

After all this, `init.c::bh_arc_init_end` is still called to perform:
- Post `POST_CODE_ZEPHYR_INIT_DONE`
- printk version
- `Dm2CmReadyRequest`

Only functional difference is that post code and printk used to happen before all the rest. I actually think it makes much more sense to do them after.

## Tests
Last time we did something like this we ran into dirty reset test failures. With recent fixes to host side of dirty reset that should be fixed.

Smoke on p150a
Stress dirty reset on p150a (0/1000 failures)
stress "super dirty reset" (remove the 0.5s sleep between resets) 0/1000 failures

TODO: Stress this on gh-03 since it fails the dirty reset in CI.