### PR TITLE
scripts: tooling: blackhole_recovery: bind-mount host /dev

### DIFF
--- a/scripts/tooling/blackhole_recovery/recover-blackhole.sh
+++ b/scripts/tooling/blackhole_recovery/recover-blackhole.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-IMAGE_TAG=${IMAGE_TAG:-"v18.12.2"}
+IMAGE_TAG=${IMAGE_TAG:-"v19.5.0"}
 
 # Tags v19.6.0 and earlier were published as ghcr.io/tenstorrent/tt-zephyr-platforms/recovery-image
 # with scripts under /tt-zephyr-platforms; newer releases replace "tt-zephyr-platforms"
@@ -55,7 +55,10 @@ fi
 docker pull $IMAGE_URL:$IMAGE_TAG
 
 echo "Launching docker container to recover blackhole device..."
-docker run --device /dev/bus/usb --privileged \
+# Bind mount /dev so the container tracks hotplug events. Docker otherwise gives
+# the container a private /dev populated at startup, so a card that enumerates
+# during recovery never appears at /dev/tenstorrent/<n> inside the container.
+docker run --device /dev/bus/usb --privileged -v /dev:/dev \
     --rm $IMAGE_URL:$IMAGE_TAG \
     python3 "/${FIRMWARE_REPO}/scripts/tooling/blackhole_recovery/recover-blackhole.py" \
     /recovery.tar.gz $NAME_ARG $SERIAL_ARG $FORCE_ARG $@

--- a/scripts/tooling/blackhole_recovery/recover-wormhole.sh
+++ b/scripts/tooling/blackhole_recovery/recover-wormhole.sh
@@ -41,7 +41,10 @@ fi
 docker pull $IMAGE_URL:$IMAGE_TAG
 
 echo "Launching docker container to recover wormhole device..."
-docker run --device /dev/bus/usb --privileged \
+# Bind mount /dev so the container tracks hotplug events. Docker otherwise gives
+# the container a private /dev populated at startup, so a card that enumerates
+# during recovery never appears at /dev/tenstorrent/<n> inside the container.
+docker run --device /dev/bus/usb --privileged -v /dev:/dev \
     --rm $IMAGE_URL:$IMAGE_TAG \
     python3 /tt-system-firmware/scripts/tooling/blackhole_recovery/recover-wormhole.py \
     /firmware.fwbundle $TYPE_ARG $SERIAL_ARG $FORCE_ARG $@


### PR DESCRIPTION
Addresses [SYS-5031](https://tenstorrent.atlassian.net/browse/SYS-5031)

## Overview
`recover-blackhole.sh` sometimes exits with an error of "card not found on bus", but when you lspci yourself the card is there. 

This happens because the docker container which runs `recover-blackhole.py` has a tempfs _copy_ of /dev, which means that if `/tenstorrent/dev/0` doesn't exist on invocation, it will never exist in the docker's filesystem (and vice versa, if it exists on invocation, then it will persist even if it gets removed on host /dev).

To recreate:
```
# 1) Remove card from PCIe
>> dev=$(lspci -D -d 1e52: | awk 'NR==1{print $1}') && echo 1 | sudo tee "/sys/bus/pci/devices/${dev}/remove"

# 2) Check that it's gone in /dev/tenstorrent/0
>> ls /dev/tenstorrent/0
ls: cannot access '/dev/tenstorrent/0': No such file or directory

# 3) Recover
>> sudo ./scripts/tooling/blackhole_recovery/recover-blackhole.sh p150a --force
...
Card 0 not found on bus
...
RuntimeError: Card did not recover successfully, try a reboot?

#4) Card is in fact on the bus
>> lspci -d 1e52:
01:00.0 Processing accelerators: Device 1e52:b140
```

Fix by bind-mounting the host /dev so hotplug device nodes are visible. Also bump the default blackhole recovery image to v19.5.0 (poll for card on bus with timeout instead of checking once).

## Test
```
# Steps 1, 2 above

# 3) Recover
>> sudo ./scripts/tooling/blackhole_recovery/recover-blackhole.sh p150a --force
...
Waiting 20 seconds for DMFW to update...
Card 0 not found on bus
Card 0 not found on bus
Card 0 not found on bus
Card recovered successfully

#4) Card works
tt-smi --use_luwen
```