### PR TITLE
lib: bh_arc: add characterization msg to set telemetry interval

### DIFF
--- a/include/tenstorrent/msgqueue.h
+++ b/include/tenstorrent/msgqueue.h
@@ -810,6 +810,20 @@ struct char_gddr_therm_trip_enabled_submsg {
 	uint32_t enabled;
 };
 
+/** @brief Submessage for setting the periodic telemetry update interval
+ * @details Payload is a single uint32_t with two interpretations:
+ * - Value == 0: Restore the default update interval
+ * - Any other value: Set the update interval to this value in milliseconds, subject to the
+ *   bounds enforced by the handler
+ *
+ * The new interval takes effect on the next expiry of the telemetry timer and is reflected
+ * in the @ref TAG_UPDATE_TELEM_SPEED telemetry tag.
+ */
+struct char_telemetry_interval_submsg {
+	/** @brief 0 to restore the default, or the update interval in ms */
+	uint32_t interval_ms;
+};
+
 /** @brief Union of all possible characterization submessage payloads */
 union characterisation_submsg_data {
 	/** @brief Set host-requested minimum frequency floor */
@@ -820,6 +834,8 @@ union characterisation_submsg_data {
 	struct char_throttle_stop_freq_submsg throttler_stop_freq;
 	/** @brief Enable/disable GDDR thermal-trip action */
 	struct char_gddr_therm_trip_enabled_submsg gddr_therm_trip_enabled;
+	/** @brief Set the periodic telemetry update interval */
+	struct char_telemetry_interval_submsg telemetry_interval;
 	/* add to this union to define more sub-message payloads */
 	/** @brief Generic fallback for raw access */
 	uint8_t raw_data[4];

--- a/include/tenstorrent/smc_msg.h
+++ b/include/tenstorrent/smc_msg.h
@@ -180,6 +180,8 @@ enum char_submsg_ids {
 	TT_SUB_MSG_SET_KERNEL_THROTTLER_STOP_NOPS_FREQ = 0x3,
 	/** @brief Enable/disable GDDR thermal-trip action on over-temperature */
 	TT_SUB_MSG_SET_GDDR_THERM_TRIP_ENABLED = 0x4,
+	/** @brief Set the periodic telemetry update interval */
+	TT_SUB_MSG_SET_TELEMETRY_UPDATE_INTERVAL = 0x5,
 };
 
 /** @} */

--- a/lib/tenstorrent/bh_arc/aiclk_ppm.c
+++ b/lib/tenstorrent/bh_arc/aiclk_ppm.c
@@ -542,6 +542,12 @@ static uint8_t characterisation_handler(const union request *request, struct res
 		return CatSetGddrThermTripEnabled(
 			request->characterisation_msg.submsg_data.gddr_therm_trip_enabled.enabled);
 
+#ifdef CONFIG_BH_FWTABLE
+	case TT_SUB_MSG_SET_TELEMETRY_UPDATE_INTERVAL:
+		return TelemetrySetUpdateInterval(
+			request->characterisation_msg.submsg_data.telemetry_interval.interval_ms);
+#endif
+
 	default:
 		LOG_WRN("Unknown characterization submessage ID: 0x%02x",
 			request->characterisation_msg.submsg_ID);

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -302,7 +302,11 @@ static const struct device *const smbus_target_dev =
 
 static struct k_timer telem_update_timer;
 static struct k_work telem_update_worker;
-static int telem_update_interval = 100;
+static int telem_update_interval = TELEM_UPDATE_INTERVAL_DEFAULT_MS;
+/* Set once StartTelemetryTimer() has run. Guards against a host interval change arriving
+ * between init_telemetry() and StartTelemetryTimer() and starting the timer early.
+ */
+static bool telem_timer_started;
 
 static void UpdateEthTelemetry(void)
 {
@@ -631,5 +635,35 @@ void StartTelemetryTimer(void)
 	 */
 	k_timer_start(&telem_update_timer, K_MSEC(telem_update_interval),
 		      K_MSEC(telem_update_interval));
+	telem_timer_started = true;
+}
+
+uint8_t TelemetrySetUpdateInterval(uint32_t interval_ms)
+{
+	if (interval_ms == 0) {
+		interval_ms = TELEM_UPDATE_INTERVAL_DEFAULT_MS;
+	} else if (interval_ms < TELEM_UPDATE_INTERVAL_MIN_MS ||
+		   interval_ms > TELEM_UPDATE_INTERVAL_MAX_MS) {
+		LOG_WRN("telemetry update interval %u ms rejected, must be 0 (restore default of "
+			"%d ms) or within [%d, %d] ms",
+			interval_ms, TELEM_UPDATE_INTERVAL_DEFAULT_MS, TELEM_UPDATE_INTERVAL_MIN_MS,
+			TELEM_UPDATE_INTERVAL_MAX_MS);
+		return 1;
+	}
+
+	telem_update_interval = interval_ms;
+	/* Report the new rate to readers of the telemetry table. */
+	telemetry[TAG_UPDATE_TELEM_SPEED] = telem_update_interval;
+
+	/* Restart the timer so the new period takes effect immediately. Before
+	 * StartTelemetryTimer() runs it will pick the value up on its own.
+	 */
+	if (telem_timer_started) {
+		k_timer_start(&telem_update_timer, K_MSEC(telem_update_interval),
+			      K_MSEC(telem_update_interval));
+	}
+
+	LOG_INF("telemetry update interval set to %d ms", telem_update_interval);
+	return 0;
 }
 #endif /* CONFIG_BH_FWTABLE */

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -496,10 +496,32 @@ typedef union {
 /* Telemetry tags are at offset `tag` in the telemetry buffer */
 #define TELEM_OFFSET(tag) (tag)
 
+/** @brief Default periodic telemetry update interval in milliseconds. */
+#define TELEM_UPDATE_INTERVAL_DEFAULT_MS 100
+
+/** @brief Shortest accepted telemetry update interval in milliseconds.
+ *
+ * The telemetry pass shares the system work queue with the 1 ms DVFS loop, so the interval is
+ * floored well above 1 ms to keep telemetry from crowding out frequency and voltage control.
+ */
+#define TELEM_UPDATE_INTERVAL_MIN_MS 10
+
+/** @brief Longest accepted telemetry update interval in milliseconds. */
+#define TELEM_UPDATE_INTERVAL_MAX_MS 1000
+
 void init_telemetry(uint32_t app_version);
 uint32_t ConvertFloatToTelemetry(float value);
 float ConvertTelemetryToFloat(int32_t value);
 void StartTelemetryTimer(void);
+
+/** @brief Set the periodic telemetry update interval.
+ * @param interval_ms 0 restores @ref TELEM_UPDATE_INTERVAL_DEFAULT_MS, otherwise the interval in
+ *                    milliseconds, which must be within
+ *                    [@ref TELEM_UPDATE_INTERVAL_MIN_MS, @ref TELEM_UPDATE_INTERVAL_MAX_MS].
+ * @retval 0 on success.
+ * @retval 1 if @p interval_ms is out of range; the interval is left unchanged.
+ */
+uint8_t TelemetrySetUpdateInterval(uint32_t interval_ms);
 void UpdateDmFwVersion(uint32_t bl_version, uint32_t app_version);
 void UpdateTelemetryNocTranslation(bool translation_enabled);
 void UpdateTelemetryBoardPowerLimit(uint32_t power_limit);

--- a/tests/lib/tenstorrent/bh_arc/src/msgqueue.c
+++ b/tests/lib/tenstorrent/bh_arc/src/msgqueue.c
@@ -24,6 +24,7 @@
 #include "aiclk_ppm.h"
 
 #include "reg_mock.h"
+#include "telemetry.h"
 #include "voltage.h"
 
 /* Custom fake for ReadReg to simulate timer progression */
@@ -878,6 +879,69 @@ ZTEST(msgqueue, test_msg_type_ping_dm)
 	/* Send ACK for the legacy message */
 	ack_smbus_message(&legacy_msg);
 	/* Note the DM PING SMBUS message is not simulated in this test */
+}
+
+/* Send TT_SUB_MSG_SET_TELEMETRY_UPDATE_INTERVAL with the given payload. */
+static void push_set_telem_interval(uint32_t interval_ms)
+{
+	memset(&req, 0, sizeof(req));
+	memset(&rsp, 0, sizeof(rsp));
+	req.characterisation_msg.command_code = TT_SMC_MSG_CHARACTERISATION;
+	req.characterisation_msg.submsg_ID = TT_SUB_MSG_SET_TELEMETRY_UPDATE_INTERVAL;
+	req.characterisation_msg.submsg_data.telemetry_interval.interval_ms = interval_ms;
+}
+
+/* The interval the firmware is running at, as published to the host. */
+static uint32_t get_telem_interval(void)
+{
+	return GetTelemetryTag(TAG_UPDATE_TELEM_SPEED);
+}
+
+ZTEST(msgqueue, test_msg_type_set_telemetry_interval)
+{
+	/* A value inside the accepted range takes effect and is reported back. */
+	push_set_telem_interval(50);
+	push_msg_success("Valid telemetry interval should be accepted");
+	zassert_equal(get_telem_interval(), 50,
+		      "TAG_UPDATE_TELEM_SPEED should report the new interval");
+
+	/* Both bounds are inclusive. */
+	push_set_telem_interval(TELEM_UPDATE_INTERVAL_MIN_MS);
+	push_msg_success("Minimum interval should be accepted");
+	zassert_equal(get_telem_interval(), TELEM_UPDATE_INTERVAL_MIN_MS);
+
+	push_set_telem_interval(TELEM_UPDATE_INTERVAL_MAX_MS);
+	push_msg_success("Maximum interval should be accepted");
+	zassert_equal(get_telem_interval(), TELEM_UPDATE_INTERVAL_MAX_MS);
+
+	/* 0 restores the compiled-in default. */
+	push_set_telem_interval(0);
+	push_msg_success("Restore default should be accepted");
+	zassert_equal(get_telem_interval(), TELEM_UPDATE_INTERVAL_DEFAULT_MS,
+		      "Interval should return to the default");
+}
+
+ZTEST(msgqueue, test_msg_type_set_telemetry_interval_invalid)
+{
+	/* Establish a known non-default interval to detect any clobbering below. */
+	push_set_telem_interval(200);
+	push_msg_success();
+	zassert_equal(get_telem_interval(), 200);
+
+	/* Out-of-range values are rejected and must leave the running interval untouched. */
+	push_set_telem_interval(TELEM_UPDATE_INTERVAL_MIN_MS - 1);
+	push_msg_failure("Interval below the minimum should be rejected");
+	zassert_equal(get_telem_interval(), 200,
+		      "A rejected interval must not change the running interval");
+
+	push_set_telem_interval(TELEM_UPDATE_INTERVAL_MAX_MS + 1);
+	push_msg_failure("Interval above the maximum should be rejected");
+	zassert_equal(get_telem_interval(), 200,
+		      "A rejected interval must not change the running interval");
+
+	/* Leave the default in place for any test that runs after this one. */
+	push_set_telem_interval(0);
+	push_msg_success();
 }
 
 ZTEST_SUITE(msgqueue, NULL, NULL, test_setup, NULL, NULL);


### PR DESCRIPTION
Add TT_SUB_MSG_SET_TELEMETRY_UPDATE_INTERVAL (0x5) under TT_SMC_MSG_CHARACTERISATION so the host can change the periodic telemetry update interval at runtime. The new interval restarts the telemetry timer immediately and is published in TAG_UPDATE_TELEM_SPEED. A payload of 0 restores the default.

The accepted range is hardcoded in telemetry.h as
TELEM_UPDATE_INTERVAL_MIN_MS (10) to TELEM_UPDATE_INTERVAL_MAX_MS (1000), with a default of 100 ms. Values outside that range are rejected with a warning naming the bounds and leave the running interval unchanged.

Tested with twister on native_sim, including two new cases in tests/lib/tenstorrent/bh_arc/src/msgqueue.c covering valid values, both range boundaries, restore-to-default, and rejection of out-of-range values without clobbering the current interval. Verified on hardware via 'tt msg 0x5c6 <ms>