### PR TITLE
drivers: mbox_tt_grendel: allocate enough mbox cbs

### DIFF
--- a/drivers/mbox/mbox_tt_grendel.c
+++ b/drivers/mbox/mbox_tt_grendel.c
@@ -313,8 +313,9 @@ static void tt_grendel_mbox_isr(const struct device *dev, mbox_channel_id_t chan
 	};                                                                                         \
                                                                                                    \
 	static mbox_callback_t                                                                     \
-		tt_grendel_mbox_callbacks_##inst[DT_INST_PROP(inst, channel_pairs)];               \
-	static void *tt_grendel_mbox_callback_user_data_##inst[DT_INST_PROP(inst, channel_pairs)]; \
+		tt_grendel_mbox_callbacks_##inst[DT_INST_PROP(inst, channel_pairs) * 2];           \
+	static void                                                                                \
+		*tt_grendel_mbox_callback_user_data_##inst[DT_INST_PROP(inst, channel_pairs) * 2]; \
                                                                                                    \
 	static struct tt_grendel_mbox_data tt_grendel_mbox_data_##inst = {                         \
 		.callbacks = tt_grendel_mbox_callbacks_##inst,                                     \


### PR DESCRIPTION
### Overview

Callbacks are registered based on channel_id. Channel ID from ISR is `(channel * 2) + 1`. So (e.g.) if channel_pairs = 4 then channel 3 will map to channel 7; Which is out of range of 4 channels which DT_INST_PROP allocates.

### Tests:

mbox test