### PR TITLE
lib: tenstorrent: fw_common: Add mbox support for msgqueue

### DIFF
--- a/boards/tenstorrent/tt_mmk/tt_mmk_tt_keraunos_smc.dts
+++ b/boards/tenstorrent/tt_mmk/tt_mmk_tt_keraunos_smc.dts
@@ -48,3 +48,12 @@
 		reg = <0x0 0x88fc 0x1fe8fa15>;
 	};
 };
+
+&{/soc} {
+	/* Cold Scratch 3 */
+	msgqueue_info: scratch-reg@c000280c {
+		compatible = "tenstorrent,scratch-reg";
+		reg = <0x0 0xc000280c 0x0 0x4>;
+		status = "okay";
+	};
+};

--- a/boards/tenstorrent/tt_mmk/tt_mmk_tt_keraunos_smc.dts
+++ b/boards/tenstorrent/tt_mmk/tt_mmk_tt_keraunos_smc.dts
@@ -27,6 +27,13 @@
 		zephyr,console = &vuart0;
 		zephyr,shell-uart = &vuart0;
 	};
+
+	msgqueue_mbox: msgqueue_mbox {
+		compatible = "tenstorrent,msgqueue-mbox";
+		mboxes = <&mbox0 1>;
+		mbox-names = "doorbell";
+		status = "okay";
+	};
 };
 
 &i3c1 {

--- a/boards/tenstorrent/tt_mmk/tt_mmk_tt_mimir_smc.dts
+++ b/boards/tenstorrent/tt_mmk/tt_mmk_tt_mimir_smc.dts
@@ -26,6 +26,13 @@
 		zephyr,console = &vuart0;
 		zephyr,shell-uart = &vuart0;
 	};
+
+	msgqueue_mbox: msgqueue_mbox {
+		compatible = "tenstorrent,msgqueue-mbox";
+		mboxes = <&mbox0 1>;
+		mbox-names = "doorbell";
+		status = "okay";
+	};
 };
 
 &i3c1 {

--- a/boards/tenstorrent/tt_mmk/tt_mmk_tt_mimir_smc.dts
+++ b/boards/tenstorrent/tt_mmk/tt_mmk_tt_mimir_smc.dts
@@ -41,3 +41,12 @@
 	i3c-scl-hz = <1000000>;
 	i2c-scl-hz = <400000>;
 };
+
+&{/soc} {
+	/* Cold Scratch 3 */
+	msgqueue_info: scratch-reg@c000280c {
+		compatible = "tenstorrent,scratch-reg";
+		reg = <0x0 0xc000280c 0x0 0x4>;
+		status = "okay";
+	};
+};

--- a/dts/bindings/misc/tenstorrent,msgqueue-mbox.yaml
+++ b/dts/bindings/misc/tenstorrent,msgqueue-mbox.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Tenstorrent message queue mbox doorbell channel.
+
+  Links a Grendel mbox controller channel to the portable SMC message
+  queue as its inbound IRQ/doorbell. Presence of a node with this
+  compatible (status okay) selects the mbox IRQ backend in msgqueue
+  instead of Blackhole MSI/arc_misc.
+
+compatible: "tenstorrent,msgqueue-mbox"
+
+include: base.yaml
+
+properties:
+  mboxes:
+    required: true
+
+  mbox-names:
+    required: true

--- a/dts/vendor/tenstorrent/tt_grendel_smc.dtsi
+++ b/dts/vendor/tenstorrent/tt_grendel_smc.dtsi
@@ -333,12 +333,5 @@
 			channel-pairs = <32>;
 			#mbox-cells = <1>;
 		};
-
-		/* To be overridden by board */
-		msgqueue_info: scratch-reg@8003042c {
-			compatible = "tenstorrent,scratch-reg";
-			reg = <0x0 0x8003042c 0x0 0x4>;
-			status = "disabled";
-		};
 	};
 };

--- a/lib/tenstorrent/fw_common/Kconfig
+++ b/lib/tenstorrent/fw_common/Kconfig
@@ -20,8 +20,11 @@ config TT_FW_COMMON_EMUL
 config TT_MSGQUEUE
 	bool "Enable host message queue"
 	default y
+	select MBOX if DT_HAS_TENSTORRENT_MSGQUEUE_MBOX_ENABLED
 	help
 	  Enable the portable SMC host message queue implementation.
+	  When a tenstorrent,msgqueue-mbox node is present, the mbox
+	  IRQ doorbell backend is used instead of Blackhole MSI.
 
 config TT_MSGQUEUE_NUM_MSG_CODES
 	int "Number of message codes"

--- a/lib/tenstorrent/fw_common/msgqueue.c
+++ b/lib/tenstorrent/fw_common/msgqueue.c
@@ -24,6 +24,10 @@
 /* IRQ stack (msgqueue_irqs + arc_misc_cntl + msi_catcher) is one feature. */
 #define MSGQUEUE_HAS_IRQS DT_HAS_COMPAT_STATUS_OKAY(tenstorrent_msgqueue_irqs)
 
+/* Mbox doorbell backend when a tenstorrent,msgqueue-mbox node is okay. */
+#define MSGQUEUE_HAS_MBOX  DT_HAS_COMPAT_STATUS_OKAY(tenstorrent_msgqueue_mbox)
+#define MSGQUEUE_MBOX_NODE DT_NODELABEL(msgqueue_mbox)
+
 #if MSGQUEUE_HAS_IRQS
 #define MSGQUEUE_IRQS_NODE           DT_NODELABEL(msgqueue_irqs)
 #define ARC_MISC_CNTL_NODE           DT_NODELABEL(arc_misc_cntl)
@@ -39,6 +43,12 @@
 #define STATUS_BOOT_STATUS0_REG_ADDR 0x80030408
 #endif
 
+#if MSGQUEUE_HAS_MBOX
+#include <zephyr/drivers/mbox.h>
+#define MSGQUEUE_MBOX_CTLR    DT_MBOX_CTLR_BY_NAME(MSGQUEUE_MBOX_NODE, doorbell)
+#define MSGQUEUE_MBOX_CHANNEL DT_MBOX_CHANNEL_BY_NAME(MSGQUEUE_MBOX_NODE, doorbell)
+#endif
+
 #define MSGHANDLER_COMPAT_MASK 0x1
 
 #define MSG_ERROR_REPLY 0xff
@@ -46,11 +56,19 @@
 BUILD_ASSERT(sizeof(union request) <= (sizeof(uint32_t) * REQUEST_MSG_LEN));
 BUILD_ASSERT(DT_NODE_HAS_STATUS(MSGQUEUE_INFO_NODE, okay),
 	     "TT_MSGQUEUE requires msgqueue_info status okay");
+BUILD_ASSERT(!(MSGQUEUE_HAS_MBOX && MSGQUEUE_HAS_IRQS),
+	     "msgqueue_mbox and msgqueue_irqs are mutually exclusive");
 #if MSGQUEUE_HAS_IRQS
 BUILD_ASSERT(DT_NODE_HAS_STATUS(ARC_MISC_CNTL_NODE, okay),
 	     "msgqueue_irqs requires arc_misc_cntl status okay");
 BUILD_ASSERT(DT_NODE_HAS_STATUS(MSI_CATCHER_NODE, okay),
 	     "msgqueue_irqs requires msi_catcher status okay");
+#endif
+#if MSGQUEUE_HAS_MBOX
+BUILD_ASSERT(DT_NODE_EXISTS(MSGQUEUE_MBOX_NODE),
+	     "msgqueue_mbox nodelabel required for mbox channel lookup");
+BUILD_ASSERT(DT_NODE_HAS_STATUS(MSGQUEUE_MBOX_CTLR, okay),
+	     "msgqueue_mbox requires mbox controller status okay");
 #endif
 
 /* Describes a single message queue. */
@@ -359,6 +377,16 @@ static int register_interrupt_handlers(void)
 SYS_INIT_APP(register_interrupt_handlers);
 #endif
 
+#if MSGQUEUE_HAS_IRQS || MSGQUEUE_HAS_MBOX
+static void msgqueue_work_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+	process_message_queues();
+}
+
+static K_WORK_DEFINE(msgqueue_work, msgqueue_work_handler);
+#endif
+
 #if MSGQUEUE_HAS_IRQS
 typedef struct {
 	uint32_t run: 4;
@@ -409,13 +437,6 @@ static void clear_msg_irq(void)
 	arc_misc_cntl.f.irq0_trig = 0;
 	WriteReg(ARC_MISC_CNTL_REG_ADDR, arc_misc_cntl.val);
 }
-
-static void msgqueue_work_handler(struct k_work *work)
-{
-	process_message_queues();
-}
-
-static K_WORK_DEFINE(msgqueue_work, msgqueue_work_handler);
 
 static void msgqueue_interrupt_handler(void *arg)
 {
@@ -491,11 +512,45 @@ static void init_msgqueue_irqs(void)
 }
 #endif /* MSGQUEUE_HAS_IRQS */
 
+#if MSGQUEUE_HAS_MBOX
+static void msgqueue_mbox_callback(const struct device *dev, mbox_channel_id_t channel_id,
+				   void *user_data, struct mbox_msg *msg)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(channel_id);
+	ARG_UNUSED(user_data);
+	/* Driver already drained READ_DATA; payload is doorbell-only. */
+	ARG_UNUSED(msg);
+
+	k_work_submit(&msgqueue_work);
+}
+
+static void init_msgqueue_mbox_irq(void)
+{
+	const struct device *mbox_dev = DEVICE_DT_GET(MSGQUEUE_MBOX_CTLR);
+	int ret;
+
+	if (!device_is_ready(mbox_dev)) {
+		return;
+	}
+
+	ret = mbox_register_callback(mbox_dev, MSGQUEUE_MBOX_CHANNEL, msgqueue_mbox_callback, NULL);
+	if (ret != 0) {
+		return;
+	}
+
+	(void)mbox_set_enabled(mbox_dev, MSGQUEUE_MBOX_CHANNEL, true);
+}
+#endif /* MSGQUEUE_HAS_MBOX */
+
 void init_msgqueue(void)
 {
 	prepare_msg_queue();
 
 #if MSGQUEUE_HAS_IRQS
 	init_msgqueue_irqs();
+#endif
+#if MSGQUEUE_HAS_MBOX
+	init_msgqueue_mbox_irq();
 #endif
 }


### PR DESCRIPTION
## Overview
Use mbox IRQs instead of MSI IRQs for message handling.

Add msgqueue_mbox nodes to dts, which inform compilation of mbox IRQ vs MSI IRQ.

## Tests
Emul test app `hello_msgqueue` runs sucesfully, receives message from mbox self write.
Test app: https://github.com/projkovTT/tt-system-firmware/blob/hello_msgqueue/app/hello_msgqueue/src/main.c