### PR TITLE
tests: drivers: tt_smc_remoteproc: add mmk support

### DIFF
--- a/boards/tenstorrent/tt_mmk/tt_mmk_tt_keraunos_smc.dts
+++ b/boards/tenstorrent/tt_mmk/tt_mmk_tt_keraunos_smc.dts
@@ -31,13 +31,13 @@
 
 &i3c1 {
 	status = "okay";
-	input-clock-frequency = <1500000000>;
+	input-clock-frequency = <200000000>;
 	i3c-scl-hz = <1000000>;
 	i2c-scl-hz = <400000>;
 
-	remoteproc: remoteproc@88fc1fe8fa15 {
+	remoteproc: remoteproc@0a7c0013f001 {
 		compatible = "tenstorrent,smc-remoteproc";
-		/* No static address, PID of 0x88fc1fe8fa15 */
-		reg = <0x0 0x88fc 0x1fe8fa15>;
+		/* No static address, PID of 0x0a7c0013f001 */
+		reg = <0x0 0x0a7c 0x0013f001>;
 	};
 };

--- a/tests/drivers/tt_smc_remoteproc/boards/tt_mimir_tt_mimir_smc.overlay
+++ b/tests/drivers/tt_smc_remoteproc/boards/tt_mimir_tt_mimir_smc.overlay
@@ -12,7 +12,7 @@
 	status = "okay";
 	input-clock-frequency = <DT_FREQ_M(150)>;
 	i3c-scl-hz = <DT_FREQ_M(12)>; /* 12 MHz I3C SCL frequency */
-	i2c-scl-hz = <DT_FREQ_K(300)>; /* 400 kHz I2C SCL frequency */
+	i2c-scl-hz = <DT_FREQ_K(300)>; /* 300 kHz I2C SCL frequency */
 
 	remoteproc: remoteproc@88fc1fe8fa15 {
 		/* GPIO 61 is boot gpio */

--- a/tests/drivers/tt_smc_remoteproc/boards/tt_mmk_tt_keraunos_smc.overlay
+++ b/tests/drivers/tt_smc_remoteproc/boards/tt_mmk_tt_keraunos_smc.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <freq.h>
+
+&i3c1 {
+	i3c-scl-hz = <DT_FREQ_M(12)>;  /* 12 MHz I3C SCL frequency */
+};

--- a/tests/drivers/tt_smc_remoteproc/remote_smc_app/boards/tt_mmk_tt_mimir_smc.overlay
+++ b/tests/drivers/tt_smc_remoteproc/remote_smc_app/boards/tt_mmk_tt_mimir_smc.overlay
@@ -1,0 +1,10 @@
+#include <freq.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+
+/*
+ * Move RAM to start at 0xc0066400 for secondary SMCs, as this is the first load
+ * address the bootrom supports.
+ */
+&ram0 {
+	reg = <0x0 0xc0066400 0x0 0xf4c00>;
+};

--- a/tests/drivers/tt_smc_remoteproc/remote_smc_app/src/main.c
+++ b/tests/drivers/tt_smc_remoteproc/remote_smc_app/src/main.c
@@ -5,11 +5,12 @@
  */
 
 #include <stdio.h>
+#include <zephyr/autoconf.h>
 #include <soc.h>
 
 int main(void)
 {
-	printf("Secondary BL1 is running!\n");
+	printf("Secondary BL1 is running on " CONFIG_BOARD_TARGET "!\n");
 
 	test_pass();
 	return 0;

--- a/tests/drivers/tt_smc_remoteproc/sysbuild.cmake
+++ b/tests/drivers/tt_smc_remoteproc/sysbuild.cmake
@@ -1,9 +1,13 @@
 # Copyrigtht (c) 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
+# The remote SMC image always targets the mimir SoC.
+set(REMOTE_SMC_APP_BOARD ${BOARD}/tt_mimir/smc)
+
 ExternalZephyrProject_Add(
     APPLICATION remote_smc_app
     SOURCE_DIR  ${APP_DIR}/remote_smc_app
+    BOARD       ${REMOTE_SMC_APP_BOARD}
     BUILD_ONLY 1
 )
 

--- a/tests/drivers/tt_smc_remoteproc/testcase.yaml
+++ b/tests/drivers/tt_smc_remoteproc/testcase.yaml
@@ -6,4 +6,5 @@ tests:
     tags: smoke
     platform_allow:
       - tt_mimir/tt_mimir/smc
+      - tt_mmk/tt_keraunos/smc
     sysbuild: true


### PR DESCRIPTION
### Overview
Add mmk support for tt_smc_remoteproc test.
Keraunos is controller and M is the target.

### Tests

This test in tt-sim. Think it should work in emul though remains to be seen, @alexapostolu is looking into what's there.
Build:

`west build --sysbuild -p -d build_test -b tt_mmk/tt_keraunos/smc ./tests/drivers/tt_smc_remoteproc/`

Keraunos:
```
*** Booting Zephyr OS build bbd8290c7bf6 ***
Running TESTSUITE tt_smc_remoteproc
===================================================================
START - test_boot
Primary BL1 is running!
[00:00:00.102,806] <dbg> occp.occp_write_data: Sending OCCP WRITE_DATA command: addr=0xc0067000, length=16116
[00:00:07.606,697] <dbg> occp.occp_write_data: OCCP WRITE_DATA command complete
[00:00:07.618,845] <dbg> occp.occp_execute_image: Sending OCCP EXECUTE_IMAGE command: addr=0xc0067000, cpu=0
[00:00:07.636,665] <dbg> occp.occp_execute_image: OCCP EXECUTE_IMAGE command complete
Primary BL1 is alive!
```

(I have local mods to keep the number of prints down which I'm _thinking_ we put in main, but IDK.)

Mimir:
```
*** Booting Zephyr OS build bbd8290c7bf6 ***
Secondary BL1 is running on tt_mmk/tt_mimir/smc!
```
This test does not compile as is. We are still waiting on the sival drop.