### PR TITLE
lib: bh_arc: move SetPostCode out of fw_common

### DIFF
--- a/lib/tenstorrent/bh_arc/CMakeLists.txt
+++ b/lib/tenstorrent/bh_arc/CMakeLists.txt
@@ -33,6 +33,7 @@ zephyr_library_sources(
   pcie.c
   pcie_msi.c
   pll.c
+  post_code.c
   reset.c
   smbus_target.c
   spi_eeprom.c

--- a/lib/tenstorrent/bh_arc/Kconfig
+++ b/lib/tenstorrent/bh_arc/Kconfig
@@ -16,6 +16,12 @@ config TT_BH_ARC
 	help
 	  This option enables the Blackhole ARC firmware library.
 
+config TT_POST_CODE
+	bool
+	default y if BOARD_TT_BLACKHOLE
+	help
+	  Enables writing firmware post codes to the status scratch register.
+
 if TT_BH_ARC
 
 config TT_BH_ARC_EMUL

--- a/lib/tenstorrent/bh_arc/post_code.c
+++ b/lib/tenstorrent/bh_arc/post_code.c
@@ -5,15 +5,9 @@
  */
 
 #include <stdint.h>
-
 #include <tenstorrent/post_code.h>
-
 #include "reg.h"
-
-#if defined(CONFIG_TT_POST_CODE)
-/* Provided by the selected SoC (tt_blackhole today; tt_grendel later). */
 #include "status_reg.h"
-#endif
 
 void SetPostCode(uint8_t fw_id, uint16_t post_code)
 {

--- a/lib/tenstorrent/fw_common/CMakeLists.txt
+++ b/lib/tenstorrent/fw_common/CMakeLists.txt
@@ -1,14 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
-# Shared with bh_arc and other consumers of ReadReg/WriteReg/SetPostCode.
+# Shared with bh_arc and other consumers of ReadReg/WriteReg.
 zephyr_include_directories(.)
 
-# SoC-owned status_reg.h (Blackhole today; Grendel can add its own map later).
-zephyr_library_include_directories_ifdef(CONFIG_TT_POST_CODE
-  ${ZEPHYR_CURRENT_MODULE_DIR}/soc/tenstorrent/tt_blackhole/include)
-
-zephyr_library_sources(post_code.c)
 zephyr_library_sources_ifdef(CONFIG_TT_MSGQUEUE msgqueue.c)
 zephyr_library_sources_ifdef(CONFIG_TT_FW_COMMON_EMUL reg_stub.c)
 

--- a/lib/tenstorrent/fw_common/Kconfig
+++ b/lib/tenstorrent/fw_common/Kconfig
@@ -17,12 +17,6 @@ config TT_FW_COMMON_EMUL
 	  host/native builds. Selected by TT_BH_ARC_EMUL when Blackhole
 	  ARC emulation is enabled.
 
-config TT_POST_CODE
-	bool
-	default y if BOARD_TT_BLACKHOLE
-	help
-	  Enables writing firmware post codes to the status scratch register.
-
 config TT_MSGQUEUE
 	bool "Enable host message queue"
 	default y


### PR DESCRIPTION
## Overview
Keep Blackhole and Grendel post-code writers as separate sources instead of one fw_common file gated by TT_POST_CODE. Grendel already owns its writer under the SoC tree.

`include/tenstorrent/post_code.h` links to:
`lib/tenstorrent/bh_arc/post_code.c` (Blackhole build)
`soc/tenstorrent/tt_grendel/tt_grendel_smc/post_code.c` (Grendel build)

## Tests
p150a sysbuild and smoke
Native sim build
My custom hello_msgqueue app build