### PR TITLE
ci: collect openocd.log in hardware test artifacts

### DIFF
--- a/.github/workflows/hardware-long.yml
+++ b/.github/workflows/hardware-long.yml
@@ -91,6 +91,7 @@ jobs:
           include-hidden-files: true
           path: |
             zephyr/twister-*e2e*/**/device.log
+            zephyr/twister-*e2e*/**/openocd.log
             zephyr/twister-*e2e*/**/handler.log
             zephyr/twister-*e2e*/**/twister_harness.log
             zephyr/twister-*e2e*/**/zephyr.dts

--- a/.github/workflows/hardware-smoke.yml
+++ b/.github/workflows/hardware-smoke.yml
@@ -108,6 +108,7 @@ jobs:
             zephyr/twister-dmc-smoke/**/zephyr.elf
             zephyr/twister-dmc-smoke/**/*.lst
             zephyr/twister-dmc-smoke/**/device.log
+            zephyr/twister-dmc-smoke/**/openocd.log
             zephyr/twister-dmc-smoke/twister.log
             zephyr/twister-dmc-smoke/twister.json
 
@@ -130,6 +131,7 @@ jobs:
             zephyr/twister-smc-smoke/**/zephyr.elf
             zephyr/twister-smc-smoke/**/*.lst
             zephyr/twister-smc-smoke/**/device.log
+            zephyr/twister-smc-smoke/**/openocd.log
             zephyr/twister-smc-smoke/twister.log
             zephyr/twister-smc-smoke/twister.json
 
@@ -242,6 +244,7 @@ jobs:
             zephyr/twister-*e2e*/**/zephyr.elf
             zephyr/twister-*e2e*/**/*.lst
             zephyr/twister-*e2e*/**/device.log
+            zephyr/twister-*e2e*/**/openocd.log
             zephyr/twister-*e2e*/twister.log
             zephyr/twister-*e2e*/twister.json
             zephyr/twister-*e2e*/**/update.fwbundle


### PR DESCRIPTION
## Overview

Add openocd logs to CI test artifacts to help debug cases like https://github.com/tenstorrent/tt-system-firmware/actions/runs/32261303535/job/96094991553

West's OpenOCD runner writes the real flash error to openocd.log, not stderr. Twister still reports any nonzero flash exit as "Timeout during flashing", so those logs are the only way to tell a probe/init failure from a hang. device.log only has the OpenOCD banner.

## Tests
Checked `openocd.log`s from artifacts on this PR's CI.

