### PR TITLE
doc: release: 19.15: add draft release notes

### DIFF
--- a/doc/release/migration-guide-19.15.md
+++ b/doc/release/migration-guide-19.15.md
@@ -1,0 +1,5 @@
+# 19.15.0
+
+## Migration Guide
+
+This document lists recommended and required changes for those migrating from the previous v19.14.0 firmware release to the new 19.15.0 firmware release.

--- a/doc/release/release-notes-19.15.md
+++ b/doc/release/release-notes-19.15.md
@@ -1,0 +1,21 @@
+# v19.15.0
+
+> This is a working draft for the up-coming 19.15.0 release.
+
+We are pleased to announce the release of TT System Firmware version 19.15.0 🥳🎉.
+
+Major enhancements with this release include:
+
+## What's Changed
+
+## Blackhole
+
+## Migration guide
+
+An overview of required and recommended changes to make when migrating from the previous v19.14.0 release can be found in [19.15 Migration Guide](https://github.com/tenstorrent/tt-system-firmware/tree/main/doc/release/migration-guide-19.15.md).
+
+## Full ChangeLog
+
+The full ChangeLog from the previous v19.14.0 release can be found at the link below.
+
+https://github.com/tenstorrent/tt-system-firmware/compare/v19.14.0...v19.15.0


### PR DESCRIPTION
Start the 19.15.0 notes and migration guide on main so they can be filled in before the release tag.