### PR TITLE
kmd_ci: fix gcc13 not found errors

### DIFF
--- a/scripts/ci/build-and-load-kmd.sh
+++ b/scripts/ci/build-and-load-kmd.sh
@@ -52,10 +52,12 @@ if [ ! -e "/lib/modules/${KVER}/build" ]; then
 	exit 1
 fi
 
-# Ubuntu's kernel headers invoke the exact gcc the kernel was built with, which
-# is often older than the container's default (e.g. a jammy-built kernel needs
-# gcc-12 while the noble CI image ships gcc-13). Without it the module build
-# dies with "gcc-N: not found".
+# Ubuntu's kernel headers invoke the exact gcc the kernel was built with, so
+# without it the module build dies with "gcc-N: not found". That version is not
+# always in the container's archive: jammy stops at gcc-12, but a host kernel
+# built with gcc-13 asks for gcc-13, which only the toolchain PPA carries. A
+# module's vermagic does not record the compiler, so if the exact version cannot
+# be had, building with another gcc still yields a loadable module.
 KERNEL_CC="${KMD_CC:-}"
 if [ -z "$KERNEL_CC" ]; then
 	CC_VERSION_TEXT="$(sed -n 's/^CONFIG_CC_VERSION_TEXT="\(.*\)"$/\1/p' \
@@ -64,14 +66,47 @@ if [ -z "$KERNEL_CC" ]; then
 		| grep -oE 'gcc-[0-9]+' | head -n1 || true)"
 fi
 
-if [ -n "$KERNEL_CC" ] && ! command -v "$KERNEL_CC" >/dev/null 2>&1; then
+# Set empty to skip the PPA fallback.
+TOOLCHAIN_PPA="${KMD_TOOLCHAIN_PPA-ppa:ubuntu-toolchain-r/test}"
+
+have_cc() {
+	command -v "$1" >/dev/null 2>&1
+}
+
+newest_installed_gcc() {
+	printf '%s\n' /usr/bin/gcc-[0-9]* \
+		| grep -oE 'gcc-[0-9]+$' \
+		| sort -t- -k2,2n \
+		| tail -n1
+}
+
+if [ -n "$KERNEL_CC" ] && ! have_cc "$KERNEL_CC"; then
 	echo "Kernel was built with ${KERNEL_CC}; installing it to match"
-	if ! "${SUDO[@]}" apt-get install -y --no-install-recommends "$KERNEL_CC"; then
-		echo "Cannot build KMD: kernel requires ${KERNEL_CC}," \
-			"which is unavailable in this image." >&2
-		echo "Install it in the CI image, or set KMD_CC to a compiler that is present." >&2
+	"${SUDO[@]}" apt-get install -y --no-install-recommends "$KERNEL_CC" || true
+fi
+
+if [ -n "$KERNEL_CC" ] && ! have_cc "$KERNEL_CC" && [ -n "$TOOLCHAIN_PPA" ]; then
+	echo "${KERNEL_CC} is not in this image's archive; trying ${TOOLCHAIN_PPA}"
+	if "${SUDO[@]}" apt-get install -y --no-install-recommends \
+		software-properties-common; then
+		"${SUDO[@]}" add-apt-repository -y "$TOOLCHAIN_PPA" || true
+		"${SUDO[@]}" apt-get install -y --no-install-recommends "$KERNEL_CC" || true
+	fi
+fi
+
+if [ -n "$KERNEL_CC" ] && ! have_cc "$KERNEL_CC"; then
+	FALLBACK_CC="$(newest_installed_gcc || true)"
+	if [ -z "$FALLBACK_CC" ] && have_cc gcc; then
+		FALLBACK_CC="gcc"
+	fi
+	if [ -z "$FALLBACK_CC" ]; then
+		echo "Cannot build KMD: ${KERNEL_CC} is unavailable and no other gcc" \
+			"is installed." >&2
+		echo "Set KMD_CC to a compiler that is present in this image." >&2
 		exit 1
 	fi
+	echo "${KERNEL_CC} is unavailable; falling back to ${FALLBACK_CC}"
+	KERNEL_CC="$FALLBACK_CC"
 fi
 
 BUILD_DIR="$(mktemp -d)"


### PR DESCRIPTION
Fix gcc13 not found errors in KMD loading CI script.

Tests:
- Script worked on a system that previously had gcc13 errors