### PR TITLE
app: smc: return fail count from power_state_toggle helper

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -1356,7 +1356,7 @@ def power_state_toggle_test(arc_chip_dut, asic_id, board_name):
     Galaxy, loudbox, and quietbox2 skip TDP validation and always return 0.
     """
     expected_power_delta = 80
-    settling_time = 0.5
+    settling_time = 0.7
     arc_chip = pyluwen.detect_chips()[asic_id]
     skip_tdp = _skip_boards(board_name)
 

--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -1351,11 +1351,9 @@ def test_pvt_comprehensive(arc_chip_dut, asic_id):
 
 def power_state_toggle_test(arc_chip_dut, asic_id, board_name):
     """
-    Test toggling between high and low power states and verify TDP delta.
-
-    Toggles between high and low power states and verifies that the TDP
-    difference between the two states is greater than 80W.
-    For galaxy, loudbox, and quietbox2, only tests power state setting without TDP validation.
+    Validates that toggling between high and low power states results in expected TDP delta
+    Returns 0 on success, 1 if TDP delta is <= 80W.
+    Galaxy, loudbox, and quietbox2 skip TDP validation and always return 0.
     """
     expected_power_delta = 80
     settling_time = 0.5
@@ -1388,10 +1386,11 @@ def power_state_toggle_test(arc_chip_dut, asic_id, board_name):
         power_delta = high_power - low_power
         logger.info(f"Power delta: {power_delta}W")
 
-        # Verify delta is greater than expected
-        assert power_delta > expected_power_delta, (
-            f"Power delta ({power_delta}W) is not greater than {expected_power_delta}W"
-        )
+        if power_delta <= expected_power_delta:
+            logger.error(
+                f"Power delta ({power_delta}W) is not greater than {expected_power_delta}W"
+            )
+            return 1
 
     return 0
 


### PR DESCRIPTION
## Overview
Asserting inside the shared helper aborted e2e_stress on the first TDP miss, so iteration logging and remaining tries never ran. Return 1 on failure to match the other PVT helpers.

Note that this means stress will keep running the iterations until it finishes them all, then logs how many failed at the end.

We're seeing some stress failures on this test eg. https://github.com/tenstorrent/tt-system-firmware/actions/runs/32619569485/job/97145557649 and it would be nice to have better logs.

Also updated settling time from 0.5s to 0.7s per state change (so 1.4s per iteration, ~50% longer). Might help with the failures.

## Test
Stress power state toggle p150a