### PR TITLE
lib: bh_arc: add DVFS counters to characterize telemetry interval

### DIFF
--- a/include/tenstorrent/msgqueue.h
+++ b/include/tenstorrent/msgqueue.h
@@ -76,6 +76,35 @@ enum counter_cmd {
 enum counter_bank {
 	/** @brief Throttler counters indexed by @ref aiclk_arb_max */
 	COUNTER_BANK_THROTTLERS,
+	/** @brief DVFS loop counters indexed by @ref dvfs_counter_index */
+	COUNTER_BANK_DVFS,
+};
+
+/** @brief Counter indices within @ref COUNTER_BANK_DVFS */
+enum dvfs_counter_index {
+	/** @brief DVFS timer ticks that expired while the previous pass was still queued.
+	 *
+	 * Such a tick is coalesced into the pending one rather than running on its own, so the
+	 * DVFS loop skips a cycle. A non-zero value means something is occupying the system work
+	 * queue long enough to delay frequency and voltage control.
+	 */
+	DVFS_COUNTER_DROPPED_TICKS,
+	/** @brief Longest gap between consecutive DVFS passes, in microseconds.
+	 *
+	 * Measured start-to-start across DVFSChange() calls, so it is the interval the DVFS PID
+	 * controllers actually ran at. They assume 1000 us; a larger value means a cycle was
+	 * delayed or skipped. A maximum since the last clear, not an average.
+	 */
+	DVFS_COUNTER_MAX_PERIOD_US,
+	/** @brief Longest duration of a single DVFS pass, in microseconds.
+	 *
+	 * Time spent inside DVFSChange(). Under throttling each pass reprograms the PLL and the
+	 * voltage regulator, so this grows; as it approaches the 1000 us period the loop starts
+	 * delaying its own next cycle. Also a maximum since the last clear.
+	 */
+	DVFS_COUNTER_MAX_PASS_US,
+	/** @brief Number of counters in this bank */
+	DVFS_COUNTER_COUNT,
 };
 
 /** @brief Host request for generic counter operations
@@ -814,7 +843,7 @@ struct char_gddr_therm_trip_enabled_submsg {
  * @details Payload is a single uint32_t with two interpretations:
  * - Value == 0: Restore the default update interval
  * - Any other value: Set the update interval to this value in milliseconds, subject to the
- *   bounds enforced by the handler
+ *   minimum enforced by the handler
  *
  * The new interval takes effect on the next expiry of the telemetry timer and is reflected
  * in the @ref TAG_UPDATE_TELEM_SPEED telemetry tag.

--- a/lib/tenstorrent/bh_arc/counter.c
+++ b/lib/tenstorrent/bh_arc/counter.c
@@ -5,6 +5,7 @@
  */
 
 #include "aiclk_ppm.h"
+#include "dvfs.h"
 
 #include <tenstorrent/smc_msg.h>
 #include <tenstorrent/msgqueue.h>
@@ -14,6 +15,8 @@ static uint8_t counter_handler(const union request *request, struct response *re
 	switch (request->counter.counter_bank) {
 	case COUNTER_BANK_THROTTLERS:
 		return throttler_counter_handler(request, response);
+	case COUNTER_BANK_DVFS:
+		return dvfs_counter_handler(request, response);
 	default:
 		return 1;
 	}

--- a/lib/tenstorrent/bh_arc/dvfs.c
+++ b/lib/tenstorrent/bh_arc/dvfs.c
@@ -8,6 +8,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/misc/bh_fwtable.h>
+#include <tenstorrent/msgqueue.h>
 #include <tenstorrent/sys_init_defines.h>
 
 #include "vf_curve.h"
@@ -23,6 +24,32 @@ LOG_MODULE_REGISTER(dvfs, CONFIG_TT_APP_LOG_LEVEL);
 static const struct device *const fwtable_dev = DEVICE_DT_GET(DT_NODELABEL(fwtable));
 
 bool dvfs_enabled;
+
+/* DVFS timer ticks that expired while the previous pass was still queued. Incremented from the
+ * timer ISR and read/cleared from the message-handler thread, so it must be atomic: a plain
+ * read-modify-write could drop a clear that lands between the ISR's load and store.
+ */
+static atomic_t dvfs_dropped_ticks;
+
+/* Worst-case DVFS pass spacing and duration since the last clear, in microseconds. Updated only
+ * from the work handler, but cleared from whichever thread services the counter message, so the
+ * maxima are published atomically.
+ */
+static atomic_t dvfs_max_period_us;
+static atomic_t dvfs_max_pass_us;
+
+/* Raise *target to value if value is larger. Retries on contention with a concurrent clear. */
+static void atomic_max_u32(atomic_t *target, uint32_t value)
+{
+	atomic_val_t old = atomic_get(target);
+
+	while (value > (uint32_t)old) {
+		if (atomic_cas(target, old, (atomic_val_t)value)) {
+			break;
+		}
+		old = atomic_get(target);
+	}
+}
 
 void DVFSChange(void)
 {
@@ -43,13 +70,34 @@ void DVFSChange(void)
 
 static void dvfs_work_handler(struct k_work *work)
 {
+	static uint32_t prev_start_cyc;
+	static bool have_prev;
+	uint32_t start_cyc = k_cycle_get_32();
+
+	/* Unsigned subtraction stays correct across the 32-bit cycle counter wrap, since one
+	 * period or pass is tiny relative to the counter's range.
+	 */
+	if (have_prev) {
+		atomic_max_u32(&dvfs_max_period_us,
+			       k_cyc_to_us_floor32(start_cyc - prev_start_cyc));
+	}
+	prev_start_cyc = start_cyc;
+	have_prev = true;
+
 	DVFSChange();
+
+	atomic_max_u32(&dvfs_max_pass_us, k_cyc_to_us_floor32(k_cycle_get_32() - start_cyc));
 }
 static K_WORK_DEFINE(dvfs_worker, dvfs_work_handler);
 
 static void dvfs_timer_handler(struct k_timer *timer)
 {
-	k_work_submit(&dvfs_worker);
+	/* 0 means the work item was already queued, so this tick is folded into the pending one
+	 * and the DVFS loop skips a cycle.
+	 */
+	if (k_work_submit(&dvfs_worker) == 0) {
+		atomic_inc(&dvfs_dropped_ticks);
+	}
 }
 static K_TIMER_DEFINE(dvfs_timer, dvfs_timer_handler, NULL);
 
@@ -129,4 +177,41 @@ void AdjustDVFSTimer(void)
 			k_timer_start(&dvfs_timer, delay, K_MSEC(DVFS_MSEC));
 		}
 	}
+}
+
+/* Indexed by @ref dvfs_counter_index so GET and CLEAR need no per-counter switch. */
+static atomic_t *const dvfs_counters[DVFS_COUNTER_COUNT] = {
+	[DVFS_COUNTER_DROPPED_TICKS] = &dvfs_dropped_ticks,
+	[DVFS_COUNTER_MAX_PERIOD_US] = &dvfs_max_period_us,
+	[DVFS_COUNTER_MAX_PASS_US] = &dvfs_max_pass_us,
+};
+
+uint8_t dvfs_counter_handler(const union request *request, struct response *response)
+{
+	switch (request->counter.command) {
+	case COUNTER_CMD_GET:
+		if (request->counter.bank_index >= DVFS_COUNTER_COUNT) {
+			return 1;
+		}
+		/* This bank tracks neither overflow nor freeze, so both status fields read 0. */
+		response->data[1] = 0;
+		response->data[2] =
+			(uint32_t)atomic_get(dvfs_counters[request->counter.bank_index]);
+		break;
+	case COUNTER_CMD_CLEAR:
+		for (uint32_t i = 0; i < DVFS_COUNTER_COUNT; i++) {
+			if (request->counter.mask & BIT(i)) {
+				atomic_clear(dvfs_counters[i]);
+			}
+		}
+		break;
+	case COUNTER_CMD_FREEZE:
+	default:
+		/* FREEZE is rejected rather than ignored: these counters must keep running for a
+		 * measurement window to mean anything
+		 */
+		return 1;
+	}
+
+	return 0;
 }

--- a/lib/tenstorrent/bh_arc/dvfs.h
+++ b/lib/tenstorrent/bh_arc/dvfs.h
@@ -14,4 +14,8 @@ int StartDVFSTimer(void);
 void AdjustDVFSTimer(void);
 void DVFSChange(void);
 
+struct response;
+union request;
+uint8_t dvfs_counter_handler(const union request *request, struct response *response);
+
 #endif

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -670,12 +670,11 @@ uint8_t TelemetrySetUpdateInterval(uint32_t interval_ms)
 {
 	if (interval_ms == 0) {
 		interval_ms = TELEM_UPDATE_INTERVAL_DEFAULT_MS;
-	} else if (interval_ms < TELEM_UPDATE_INTERVAL_MIN_MS ||
-		   interval_ms > TELEM_UPDATE_INTERVAL_MAX_MS) {
+	} else if (interval_ms < TELEM_UPDATE_INTERVAL_MIN_MS) {
 		LOG_WRN("telemetry update interval %u ms rejected, must be 0 (restore default of "
-			"%d ms) or within [%d, %d] ms",
-			interval_ms, TELEM_UPDATE_INTERVAL_DEFAULT_MS, TELEM_UPDATE_INTERVAL_MIN_MS,
-			TELEM_UPDATE_INTERVAL_MAX_MS);
+			"%d ms) or at least %d ms",
+			interval_ms, TELEM_UPDATE_INTERVAL_DEFAULT_MS,
+			TELEM_UPDATE_INTERVAL_MIN_MS);
 		return 1;
 	}
 

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -509,13 +509,11 @@ typedef union {
 
 /** @brief Shortest accepted telemetry update interval in milliseconds.
  *
- * The telemetry pass shares the system work queue with the 1 ms DVFS loop, so the interval is
- * floored well above 1 ms to keep telemetry from crowding out frequency and voltage control.
+ * The telemetry pass shares the system work queue with the 1 ms DVFS loop, so a short interval
+ * eats into the time available for frequency and voltage control. The floor is kept at 1 ms so
+ * that characterization runs can sweep the whole range.
  */
-#define TELEM_UPDATE_INTERVAL_MIN_MS 10
-
-/** @brief Longest accepted telemetry update interval in milliseconds. */
-#define TELEM_UPDATE_INTERVAL_MAX_MS 1000
+#define TELEM_UPDATE_INTERVAL_MIN_MS 1
 
 int init_telemetry(void);
 uint32_t ConvertFloatToTelemetry(float value);
@@ -524,10 +522,10 @@ int StartTelemetryTimer(void);
 
 /** @brief Set the periodic telemetry update interval.
  * @param interval_ms 0 restores @ref TELEM_UPDATE_INTERVAL_DEFAULT_MS, otherwise the interval in
- *                    milliseconds, which must be within
- *                    [@ref TELEM_UPDATE_INTERVAL_MIN_MS, @ref TELEM_UPDATE_INTERVAL_MAX_MS].
+ *                    milliseconds, which must be at least
+ *                    @ref TELEM_UPDATE_INTERVAL_MIN_MS. There is no upper bound.
  * @retval 0 on success.
- * @retval 1 if @p interval_ms is out of range; the interval is left unchanged.
+ * @retval 1 if @p interval_ms is below the minimum; the interval is left unchanged.
  */
 uint8_t TelemetrySetUpdateInterval(uint32_t interval_ms);
 void UpdateDmFwVersion(uint32_t bl_version, uint32_t app_version);

--- a/lib/tenstorrent/bh_arc/tt_shell.c
+++ b/lib/tenstorrent/bh_arc/tt_shell.c
@@ -13,6 +13,7 @@
 #include <tenstorrent/bh_power.h>
 #ifdef CONFIG_TT_MSGQUEUE
 #include <tenstorrent/msgqueue.h>
+#include <tenstorrent/smc_msg.h>
 #endif
 
 #include "telemetry.h"
@@ -207,6 +208,89 @@ static int msg_handler(const struct shell *sh, size_t argc, char **argv)
 
 	return 0;
 }
+
+/* Exchange one counter request and leave the reply in *response. */
+static int counter_msg_exchange(const struct shell *sh, uint8_t command, uint32_t bank,
+				uint32_t index_or_mask, struct response *response)
+{
+	union request request = {0};
+	int ret;
+
+	request.counter.command_code = TT_SMC_MSG_COUNTER;
+	request.counter.command = command;
+	request.counter.counter_bank = bank;
+	if (command == COUNTER_CMD_GET) {
+		request.counter.bank_index = index_or_mask;
+	} else {
+		request.counter.mask = index_or_mask;
+	}
+
+	ret = msgqueue_request_push(0, &request);
+	if (ret != 0) {
+		shell_error(sh, "Failed to queue request (%d)", ret);
+		return ret;
+	}
+
+	process_message_queues();
+
+	ret = msgqueue_response_pop(0, response);
+	if (ret != 0) {
+		shell_error(sh, "Failed to read response (%d)", ret);
+		return ret;
+	}
+
+	if (response->data[0] != 0) {
+		shell_error(sh, "Counter request rejected (status %u)", response->data[0]);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/* Print one counter as a plain decimal value, rather than the full response dump of `tt msg`. */
+static int counter_get_handler(const struct shell *sh, size_t argc, char **argv)
+{
+	struct response response = {0};
+	uint32_t bank, index;
+	int ret;
+
+	ARG_UNUSED(argc);
+
+	if (parse_u32_arg(argv[1], &bank) != 0 || parse_u32_arg(argv[2], &index) != 0) {
+		shell_error(sh, "Invalid u32 value");
+		return -EINVAL;
+	}
+
+	ret = counter_msg_exchange(sh, COUNTER_CMD_GET, bank, index, &response);
+	if (ret != 0) {
+		return ret;
+	}
+
+	shell_print(sh, "%u", response.data[2]);
+
+	return 0;
+}
+
+static int counter_clear_handler(const struct shell *sh, size_t argc, char **argv)
+{
+	struct response response = {0};
+	uint32_t bank, mask;
+	int ret;
+
+	ARG_UNUSED(argc);
+
+	if (parse_u32_arg(argv[1], &bank) != 0 || parse_u32_arg(argv[2], &mask) != 0) {
+		shell_error(sh, "Invalid u32 value");
+		return -EINVAL;
+	}
+
+	ret = counter_msg_exchange(sh, COUNTER_CMD_CLEAR, bank, mask, &response);
+	if (ret != 0) {
+		return ret;
+	}
+
+	return 0;
+}
 #endif
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
@@ -217,6 +301,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(telem, NULL, "<Telemetry Index> [|x|f|d]", telem_handler, 2, 1),
 #ifdef CONFIG_TT_MSGQUEUE
 	SHELL_CMD_ARG(msg, NULL, "<cmd> [data1 ... data7]", msg_handler, 2, 7),
+	SHELL_CMD_ARG(counter, NULL, "<bank> <index>", counter_get_handler, 3, 0),
+	SHELL_CMD_ARG(counter_clr, NULL, "<bank> <mask>", counter_clear_handler, 3, 0),
 #endif
 	SHELL_SUBCMD_SET_END);
 

--- a/tests/lib/tenstorrent/bh_arc/src/msgqueue.c
+++ b/tests/lib/tenstorrent/bh_arc/src/msgqueue.c
@@ -1017,14 +1017,10 @@ ZTEST(msgqueue, test_msg_type_set_telemetry_interval)
 	zassert_equal(get_telem_interval(), 50,
 		      "TAG_UPDATE_TELEM_SPEED should report the new interval");
 
-	/* Both bounds are inclusive. */
+	/* The minimum is inclusive. There is no upper bound. */
 	push_set_telem_interval(TELEM_UPDATE_INTERVAL_MIN_MS);
 	push_msg_success("Minimum interval should be accepted");
 	zassert_equal(get_telem_interval(), TELEM_UPDATE_INTERVAL_MIN_MS);
-
-	push_set_telem_interval(TELEM_UPDATE_INTERVAL_MAX_MS);
-	push_msg_success("Maximum interval should be accepted");
-	zassert_equal(get_telem_interval(), TELEM_UPDATE_INTERVAL_MAX_MS);
 
 	/* 0 restores the compiled-in default. */
 	push_set_telem_interval(0);
@@ -1033,6 +1029,10 @@ ZTEST(msgqueue, test_msg_type_set_telemetry_interval)
 		      "Interval should return to the default");
 }
 
+/* Rejection is only reachable when the minimum is above 1: at a minimum of 1 the only smaller
+ * value is 0, which is the restore-default request rather than an out-of-range one.
+ */
+#if TELEM_UPDATE_INTERVAL_MIN_MS > 1
 ZTEST(msgqueue, test_msg_type_set_telemetry_interval_invalid)
 {
 	/* Establish a known non-default interval to detect any clobbering below. */
@@ -1040,14 +1040,8 @@ ZTEST(msgqueue, test_msg_type_set_telemetry_interval_invalid)
 	push_msg_success();
 	zassert_equal(get_telem_interval(), 200);
 
-	/* Out-of-range values are rejected and must leave the running interval untouched. */
 	push_set_telem_interval(TELEM_UPDATE_INTERVAL_MIN_MS - 1);
 	push_msg_failure("Interval below the minimum should be rejected");
-	zassert_equal(get_telem_interval(), 200,
-		      "A rejected interval must not change the running interval");
-
-	push_set_telem_interval(TELEM_UPDATE_INTERVAL_MAX_MS + 1);
-	push_msg_failure("Interval above the maximum should be rejected");
 	zassert_equal(get_telem_interval(), 200,
 		      "A rejected interval must not change the running interval");
 
@@ -1055,5 +1049,6 @@ ZTEST(msgqueue, test_msg_type_set_telemetry_interval_invalid)
 	push_set_telem_interval(0);
 	push_msg_success();
 }
+#endif
 
 ZTEST_SUITE(msgqueue, NULL, NULL, test_setup, NULL, NULL);


### PR DESCRIPTION
The telemetry pass shares the system work queue with the 1 ms DVFS loop, so shortening the telemetry update interval eats into the time available for frequency and voltage control. This adds the instrumentation needed to find how short that interval can safely get.

Three values are exposed through a new DVFS counter bank (COUNTER_BANK_DVFS under TT_SMC_MSG_COUNTER): 
1. ticks dropped because the previous pass was still queued
2. the longest gap between passes
3. the longest pass duration. 

The interval itself is now settable at runtime via TT_SUB_MSG_SET_TELEMETRY_UPDATE_INTERVAL (0x5), so a sweep needs no reflash. 'tt counter' and 'tt counter_clr' print a single decimal value rather than the full response dump.

Tested with twister on native_sim (83/83 passing) for the interval message, and manually on a p150b through tt-fw-terminal: setting intervals with 'tt msg 0x5c6 <ms>', reading them back with 'tt telem 5', and clearing and reading the counters across runs.