### PR TITLE
Flash variable interlock

### DIFF
--- a/app/smc/sysbuild.cmake
+++ b/app/smc/sysbuild.cmake
@@ -183,6 +183,33 @@ add_custom_target(
     DEPENDS ${OUTPUT_FILE}
 )
 
+# Describes the hardware this image is compatible with, beyond the board type
+# that selects it, for the flashing tool to check before it writes SPI
+set(OUTPUT_COMPAT_VARIABLES ${CMAKE_BINARY_DIR}/compat-variables.json)
+set(COMPAT_VARIABLES_SCHEMA ${APP_DIR}/../../scripts/schemas/compat-variables-schema.json)
+
+add_custom_command(
+    OUTPUT ${OUTPUT_COMPAT_VARIABLES}
+    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${PYTHON_DEVICETREE_SRC}:$ENV{PYTHONPATH}
+      python3 ${GEN_SCRIPT}
+      generate_compat_variables
+      --dts-file ${DTS_FILE}
+      --bindings-dirs ${APP_DIR}/../../../zephyr/dts/bindings/ ${APP_DIR}/../../dts/bindings/
+      --output-file ${OUTPUT_COMPAT_VARIABLES}
+    DEPENDS
+      ${DTS_FILE}
+      ${GEN_SCRIPT}
+      # The generator validates its output against the schema, so a change to
+      # the schema has to regenerate and revalidate
+      ${COMPAT_VARIABLES_SCHEMA}
+    VERBATIM
+)
+
+add_custom_target(
+    generate_compat_variables ALL
+    DEPENDS ${OUTPUT_COMPAT_VARIABLES}
+)
+
 if(PROD_NAME MATCHES "^P300")
   foreach(side left right)
     string(TOUPPER ${side} side_upper)
@@ -195,6 +222,7 @@ if(PROD_NAME MATCHES "^P300")
       ${OUTPUT_BOOTFS_${side_upper}}
       ${OUTPUT_FWBUNDLE_${side_upper}}
       ${PROD_NAME}_${side}
+      ${OUTPUT_COMPAT_VARIABLES}
       ${BOOTFS_DEPS}
     )
     add_custom_target(fwbundle-${side} ALL DEPENDS ${OUTPUT_FWBUNDLE_${side_upper}})
@@ -216,6 +244,7 @@ else()
     ${OUTPUT_BOOTFS}
     ${OUTPUT_FWBUNDLE}
     ${PROD_NAME}
+    ${OUTPUT_COMPAT_VARIABLES}
     ${BOOTFS_DEPS}
   )
 endif()

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc.dts
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc.dts
@@ -116,6 +116,13 @@
 		reg = <0>;
 		status = "okay";
 		size = <DT_SIZE_M(512)>;
+
+		/* Micron MT25QU512ABB only.
+		 * Boards with any other part replace this node with a flash_mux node.
+		 * See tt_blackhole_smc_flash_mux.dtsi.
+		 */
+		jedec-id = [20 bb 20];
+
 		/* Programming has experimentally been reliable up to 17 MHz, use 15 to be safe */
 		mspi-max-frequency = <DT_FREQ_M(15)>;
 		/* Reading can operate at higher frequencies.

--- a/cmake/bootfs_util.cmake
+++ b/cmake/bootfs_util.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-function(add_bootfs_and_fwbundle bundle_version bootfs_yaml output_bootfs output_fwbundle prod_name)
+function(add_bootfs_and_fwbundle bundle_version bootfs_yaml output_bootfs output_fwbundle prod_name compat_variables)
   # Remaining arguments are bootfs_deps
   set(bootfs_deps ${ARGN})
 
@@ -22,7 +22,8 @@ function(add_bootfs_and_fwbundle bundle_version bootfs_yaml output_bootfs output
     ${APP_DIR}/../../scripts/tt_fwbundle.py create
     -v "${bundle_version}"
     -o ${output_fwbundle}
+    --compat-variables ${compat_variables}
     ${prod_name}
     ${output_bootfs}
-    DEPENDS ${output_bootfs})
+    DEPENDS ${output_bootfs} ${compat_variables})
 endfunction()

--- a/doc/services/board_variables/index.rst
+++ b/doc/services/board_variables/index.rst
@@ -1,0 +1,152 @@
+Board Variables
+===============
+
+A firmware image is compatible with a board by virtue of two things: the board
+type, which selects the image out of a firmware bundle, and the board
+variables, which are hardware attributes that vary between boards of the same
+type.
+
+Board variables are numbered from 0, independently of board type and ASIC, in
+:file:`include/tenstorrent/board_variables.h`. A number is never reused. The
+first is the SPI flash JEDEC ID, which matters because one image can drive
+several second-source flash parts while an older image speaks only the Micron
+MT25QU512ABB command set. Writing an MT25-only image to a board carrying
+another part leaves an image that cannot read itself back at the next boot.
+
+Interlock flow
+--------------
+1. Each board image lists which board variables it knows and what values it
+   supports for each. This is included in the fwbundle.
+2. tt-flash reads fwbundle info and checks the variables. If any check fails,
+   it reports an error.
+3. tt-flash requests flash unlock and includes the list of variables it
+   checked. FW confirms that all required variables have been checked,
+   and fails unlock if any were not.
+
+.. mermaid::
+
+   sequenceDiagram
+       autonumber
+       participant TF as tt-flash
+       participant FB as fwbundle
+       participant TM as SMC telemetry
+       participant FW as SMC firmware
+
+       TF->>TM: read board ID
+       TM-->>TF: board type and revision
+       TF->>FB: read BOARD-REV/compat-variables.json
+       FB-->>TF: the variables this image constrains,<br/>where to read each one, and what it permits
+
+       loop each constrained variable
+           TF->>TM: read the variable's telemetry tag
+           alt tag reported
+               TM-->>TF: value
+           else tag absent
+               TM-->>TF: not reported
+               Note right of TF: firmware older than the variable, so this is<br/>an "original design" board. Variable left out of the checked list, but not rejected.
+           end
+       end
+
+       alt a value is outside what the image supports
+           Note right of TF: Stop, naming the variable and<br/>what the image supports.
+       else every value read is supported
+           TF->>FW: FLASH_UNLOCK, with the bitmap of<br/>variables it verified
+           Note left of FW: required = the variables that matter on<br/>this board.
+           alt a required variable is missing from the bitmap
+               FW-->>TF: error, plus the required bitmap
+               Note right of TF: name the variables it must check.<br/>Nothing is written
+           else every required variable is verified
+               FW-->>TF: ok, plus the required bitmap
+               Note left of FW: flash unlocked, ready to write
+               TF->>FW: WRITE_EEPROM
+           end
+       end
+
+The FW bundle
+-------------
+
+Each image in a firmware bundle carries a ``compat-variables.json`` beside its
+image, describing the hardware it is compatible with: the variables it
+constrains, how to read each one from the board, and the values it permits.
+Values are unsigned 32-bit integers, written as a JSON integer or a ``"0x..."``
+string.
+
+.. code-block:: json
+
+   {
+     "version": 1,
+     "variables": [
+       {
+         "name": "SPI EEPROM",
+         "number": 0,
+         "formatter": "hex",
+         "source": { "type": "telemetry", "tag": 80 },
+         "constraints": [ { "in": ["0x20bb20", "0xc2253a", "0xc8631a", "0xef6020"] } ]
+       }
+     ]
+   }
+
+``number``
+   The board variable number. This is the bit index in the unlock message.
+
+``name``
+   A free-form display string, printed verbatim in messages. Not an identifier.
+
+``formatter``
+   Optional. Names how to render the value and the constraint values in
+   messages. A consumer renders as hex if this is absent *or* if it names a
+   formatter the consumer does not recognize, so a new formatter never breaks
+   an older tool. Defined so far: ``hex``, ``semver``.
+
+``source``
+   Optional. How to read the value from the board; the only method defined so
+   far is ``{"type": "telemetry", "tag": <int>}``. Unlike ``formatter``, an
+   unrecognized ``source`` fails closed: the consumer must treat the variable
+   as unverified rather than guess, because it affects correctness rather than
+   presentation.
+
+``constraints``
+   A list of comparisons, every one of which must hold. Each entry names
+   exactly one of ``eq``, ``ne``, ``lt``, ``le``, ``gt``, ``ge``, ``in``,
+   ``not_in``, so an operator may appear more than once. An empty list places
+   no restriction.
+
+The file is generated at build time from the devicetree by
+``tt_boot_fs.py generate_compat_variables``, so the flash mux candidate list
+stays the single source of truth, and validated against
+:file:`scripts/schemas/compat-variables-schema.json`.
+
+The generator currently only supports SPI EEPROM JEDEC ID. It scans devicetree
+files and checks the jedec-id of SPI entries. It has special-case code to
+comprehend the flash_mux device and the standard SPI generic fallback.
+
+The tt-flash checks
+-------------------
+
+After identifying the board ID & board version, tt-flash will check for
+compat-variables.json in the board subdirectory. It performs the checks
+as documented above. Currently it understands how to use Blackhole-style
+telemetry to get a 32-bit value for a variable. If any check fails, it
+refuses to load the firmware with an error message.
+
+There is an important exception: If a board variable's telemetry value is not
+present, tt-flash will attempt to unlock and flash without this variable in
+the list of checked variables. This addresses the case of an original design
+board and old firmware from before the variable was introduced. We assume that
+original designs will always be supported.
+
+The firmware-side flash unlock
+------------------------------
+
+The running firmware is the final authority on which board variables must be
+checked. It refuses to unlock the flash for a tool that does not confirm that
+it checked every required variable.
+
+``TT_SMC_MSG_FLASH_UNLOCK`` carries a bitmap of the board variables the host
+verified against the image it is about to write. An error is reported if any
+required variable is not listed. Otherwise the flash is unlocked.
+
+The unlock persists until ``TT_SMC_MSG_FLASH_LOCK`` or until a flash unlock
+message with ``num_variable_words != 0``. There is a special exception to
+ignore redundant unlocks with ``num_variable_words == 0`` because luwen's
+``spi_write`` unlocks and relocks each time it is called.

--- a/doc/services/index.rst
+++ b/doc/services/index.rst
@@ -7,6 +7,7 @@ Firmware Services
    :maxdepth: 1
 
    binary_descriptors/index.rst
+   board_variables/index.rst
    kmd_logging/index.rst
    tracing/index.rst
    telemetry/index.rst

--- a/include/tenstorrent/board_variables.h
+++ b/include/tenstorrent/board_variables.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file board_variables.h
+ * @brief Board variable numbering
+ */
+
+#ifndef TT_BOARD_VARIABLES_H_
+#define TT_BOARD_VARIABLES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup board_variables Board variables
+ * @brief Hardware attributes a flashing tool must verify before writing SPI
+ *
+ * A board variable is a numbered hardware attribute that, together with the
+ * board type, determines whether a firmware image is compatible with the
+ * board it is about to be written to. Numbering is common to all board types
+ * and ASICs and starts at 0; a number is never reused.
+ *
+ * SPI writers declare the variables they verified by setting bits in
+ * flash_unlock_rqst.verified_variables. Firmware refuses to unlock the flash
+ * if the host did not verify every variable that matters on this board.
+ *
+ * @{
+ */
+
+/** @brief JEDEC ID of the SPI flash, as reported by @ref TAG_FLASH_JEDEC_ID.
+ *
+ * Old images only support Micron MT25QU512ABB. Writing that to a second-
+ * source board would cause it to fail to boot, even to recovery.
+ */
+#define BOARD_VAR_SPI_JEDEC_ID 0
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TT_BOARD_VARIABLES_H_ */

--- a/include/tenstorrent/msgqueue.h
+++ b/include/tenstorrent/msgqueue.h
@@ -881,14 +881,30 @@ struct toggle_tensix_reset_rqst {
 /** @brief Host request to unlock flash for writing
  * @details Messages of this type are processed by @ref flash_unlock_handler.
  *
- * This is a command-only request with no additional arguments.
+ * A flash writer declares which board variables it verified against the
+ * image it is about to write. The reply reports the variables this board
+ * requires in data[1..7], whether or not the request was accepted.
  */
 struct flash_unlock_rqst {
 	/** @brief The command code corresponding to @ref TT_SMC_MSG_FLASH_UNLOCK */
 	uint8_t command_code;
 
-	/** @brief Three bytes of padding */
-	uint8_t pad[3];
+	/** @brief Number of valid words in @ref verified_variables
+	 *
+	 * Zero for hosts that predate board variables.
+	 */
+	uint8_t num_variable_words: 3;
+	uint8_t /* unused */: 5;
+
+	/** @brief Two bytes of padding */
+	uint8_t pad[2];
+
+	/** @brief Board variables the flash writer has verified against the
+	 * image it is about to write
+	 *
+	 * One bit is allocated per board variable.
+	 */
+	uint32_t verified_variables[1];
 };
 
 /** @brief Host request to set watchdog timeout

--- a/lib/tenstorrent/bh_arc/spi_eeprom.c
+++ b/lib/tenstorrent/bh_arc/spi_eeprom.c
@@ -6,11 +6,13 @@
 
 #include "reg.h"
 #include "status_reg.h"
+#include "telemetry.h"
 #include "util.h"
 
 #include <stdbool.h>
 #include <string.h>
 
+#include <tenstorrent/board_variables.h>
 #include <tenstorrent/smc_msg.h>
 #include <tenstorrent/msgqueue.h>
 #include <tenstorrent/sys_init_defines.h>
@@ -235,7 +237,8 @@ static uint8_t confirm_flashed_spi_handler(const union request *request, struct 
 /**
  * @brief Locks flash memory to prevent writes
  * @details Sets the global flash_locked flag to true, blocking all subsequent
- *          flash write operations until unlocked
+ *          flash write operations until unlocked. The host must prove board
+ *          compatibility again before the next unlock.
  */
 static uint8_t flash_lock_handler(const union request *request, struct response *response)
 {
@@ -243,14 +246,79 @@ static uint8_t flash_lock_handler(const union request *request, struct response 
 	return 0;
 }
 
+/* Micron MT25QU512ABB, packed as telemetry reports it: 0x00MMTTCC. (Not the
+ * same encoding as the bootrom SPI_DEVICE_ID register.)
+ */
+#define FLASH_JEDEC_ID_MT25QU512ABB 0x20BB20
+
+/** @brief FLASH_UNLOCK exit code: the host did not verify every required
+ * board variable. The required set is reported in response->data[1].
+ */
+#define FLASH_UNLOCK_ERR_MISSING_VARIABLES 1
+
+/**
+ * @brief The board variables a host must verify before this board may be flashed
+ * @details See board_variables.h. Requiring a variable makes the board
+ *          unflashable by any tool that does not know how to check it, so a
+ *          variable is only required where getting it wrong would produce an
+ *          unbootable image.
+ */
+static uint32_t required_board_variables(void)
+{
+	uint32_t required = 0;
+
+	/* Exempt MT25 boards from the SPI flash check to allow old tt-flash
+	 * & FW to succeed.
+	 */
+	if (GetTelemetryFlashJedecId() != FLASH_JEDEC_ID_MT25QU512ABB) {
+		required |= BIT(BOARD_VAR_SPI_JEDEC_ID);
+	}
+
+	return required;
+}
+
 /**
  * @brief Unlocks flash memory to allow writes
- * @details Clears the global flash_locked flag, enabling flash write operations
+ * @details Clears the global flash_locked flag, enabling flash write
+ *          operations, but only once the host has declared that it verified
+ *          every board variable this board requires.
+ *
+ *          An image is compatible with a board if its board type matches
+ *          (always verified by SPI writers) and the board variable checks
+ *          pass. A host that does not know a variable exists cannot have
+ *          checked it, so it is refused rather than allowed to write an
+ *          image that the board cannot boot.
+ *
+ *          We also need a special exception for tt-flash + luwen. luwen
+ *          unlocks & relocks (with no variable verification bits) in every
+ *          call to spi_flash, failing if the unlock fails. Thus, if already
+ *          unlocked, we ignore a no-bit unlock.
+ *
+ *          The requirement is reported in response->data[1] on success and
+ *          failure alike, so that a rejected host can name what it must
+ *          check.
  */
 static uint8_t flash_unlock_handler(const union request *request, struct response *response)
 {
-	flash_locked = false;
-	return 0;
+	uint32_t required = required_board_variables();
+	uint32_t verified = 0;
+
+	response->data[1] = required;
+
+	if (!flash_locked && request->flash_unlock.num_variable_words == 0) {
+		/* luwen spi_flash special case: tt-flash already did the real unlock */
+		return 0;
+	}
+
+	if (request->flash_unlock.num_variable_words >= 1) {
+		verified = request->flash_unlock.verified_variables[0];
+	}
+
+	bool flash_constraints_satisfied = ((required & ~verified) == 0);
+
+	flash_locked = !flash_constraints_satisfied;
+
+	return flash_constraints_satisfied ? 0 : FLASH_UNLOCK_ERR_MISSING_VARIABLES;
 }
 
 REGISTER_MESSAGE(TT_SMC_MSG_READ_EEPROM, read_eeprom_handler);

--- a/lib/tenstorrent/bh_arc/telemetry.c
+++ b/lib/tenstorrent/bh_arc/telemetry.c
@@ -269,6 +269,11 @@ void UpdateTelemetryFlashJedecId(uint32_t jedec_id)
 	telemetry[TAG_FLASH_JEDEC_ID] = jedec_id;
 }
 
+uint32_t GetTelemetryFlashJedecId(void)
+{
+	return telemetry[TAG_FLASH_JEDEC_ID];
+}
+
 void UpdateTelemetryGddrThermTrip(bool enabled)
 {
 	telemetry_feature_flags_0_t active_config = {

--- a/lib/tenstorrent/bh_arc/telemetry.h
+++ b/lib/tenstorrent/bh_arc/telemetry.h
@@ -539,6 +539,8 @@ void UpdateTelemetryHostAiclkLimit(uint32_t fmax);
 void UpdateTelemetryKernelThrottler(bool enabled, uint32_t stop_nops_freq);
 /** @brief Record the flash JEDEC ID in @ref TAG_FLASH_JEDEC_ID. */
 void UpdateTelemetryFlashJedecId(uint32_t jedec_id);
+/** @brief Get the flash JEDEC ID from @ref TAG_FLASH_JEDEC_ID, 0 if it was never read. */
+uint32_t GetTelemetryFlashJedecId(void);
 /** @brief Update the GDDR thermal-trip active-config bit in @ref TAG_FW_ACTIVE_CONFIG_0. */
 void UpdateTelemetryGddrThermTrip(bool enabled);
 /** @brief Get the current active firmware feature bits from @ref TAG_FW_ACTIVE_CONFIG_0.

--- a/scripts/schemas/compat-variables-schema.json
+++ b/scripts/schemas/compat-variables-schema.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Board variable compatibility",
+  "description": "The hardware a firmware image is compatible with, beyond the board type that selects it out of a bundle. Compatibility is decided by the board type and by the board variables described here, which are numbered in include/tenstorrent/board_variables.h.",
+  "type": "object",
+  "required": [
+    "version",
+    "variables"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "description": "Format version. This schema describes version 1; a file that declares anything else needs the schema that goes with it.",
+      "const": 1
+    },
+    "variables": {
+      "description": "The board variables this image constrains. A variable it says nothing about is one it makes no claim over.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/variable"
+      }
+    }
+  },
+  "$defs": {
+    "value": {
+      "description": "A board variable value: an unsigned 32 bit integer, written either as a JSON integer or as a \"0x...\" string. Eight hex digits is 0xffffffff, so the pattern bounds the string form to the same range as the integer form.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4294967295
+        },
+        {
+          "type": "string",
+          "pattern": "^0[xX][0-9a-fA-F]{1,8}$"
+        }
+      ]
+    },
+    "variable": {
+      "type": "object",
+      "required": [
+        "name",
+        "number",
+        "constraints"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "A display string, printed verbatim in messages. Not an identifier: consumers must not match on it.",
+          "type": "string",
+          "minLength": 1
+        },
+        "number": {
+          "description": "The board variable number, as assigned in include/tenstorrent/board_variables.h. Bit N of the FLASH_UNLOCK verified-variables mask. The only field with wire significance. The mask is at most seven 32 bit words, because the request is eight words and the first carries the command code and the word count, so 223 is the highest number a host can ever report as verified.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 223
+        },
+        "formatter": {
+          "description": "How to render the value and the constraint values in messages. A consumer renders as hex when this is absent, and must also fall back to hex rather than fail when it does not recognise the name, so that a newer file never breaks an older tool. These are the names defined for version 1.",
+          "enum": [
+            "hex",
+            "semver"
+          ]
+        },
+        "source": {
+          "$ref": "#/$defs/source"
+        },
+        "constraints": {
+          "description": "The values the variable may take for the image to be compatible. Every entry must hold. An empty list places no restriction, meaning any value will do. Each entry names exactly one comparison, so an operator may appear more than once.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/constraint"
+          }
+        }
+      }
+    },
+    "source": {
+      "description": "How to read the variable's value from the board. Omitted when it cannot be read. A consumer that does not recognise the type must treat the variable as unverified rather than guess: unlike a formatter, this affects correctness rather than presentation.",
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "description": "The retrieval method. Only telemetry is defined for version 1.",
+          "enum": [
+            "telemetry"
+          ]
+        },
+        "tag": {
+          "description": "For type telemetry, the telemetry tag holding the value.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 65535
+        }
+      },
+      "allOf": [
+        {
+          "comment": "A telemetry source without a tag names nothing to read.",
+          "if": {
+            "properties": {
+              "type": {
+                "const": "telemetry"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "required": [
+              "tag"
+            ]
+          }
+        }
+      ]
+    },
+    "constraint": {
+      "description": "One comparison against the variable's value.",
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "eq": {
+          "$ref": "#/$defs/value"
+        },
+        "ne": {
+          "$ref": "#/$defs/value"
+        },
+        "lt": {
+          "$ref": "#/$defs/value"
+        },
+        "le": {
+          "$ref": "#/$defs/value"
+        },
+        "gt": {
+          "$ref": "#/$defs/value"
+        },
+        "ge": {
+          "$ref": "#/$defs/value"
+        },
+        "in": {
+          "$ref": "#/$defs/values"
+        },
+        "not_in": {
+          "$ref": "#/$defs/values"
+        }
+      }
+    },
+    "values": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/value"
+      }
+    }
+  }
+}

--- a/scripts/tt_boot_fs.py
+++ b/scripts/tt_boot_fs.py
@@ -9,6 +9,7 @@ import base64
 import ctypes
 from dataclasses import dataclass
 import io
+import jsonschema
 import logging
 import os
 from pathlib import Path
@@ -44,6 +45,27 @@ IMAGE_ADDR = 0x14000
 SCHEMA_PATH = (
     Path(__file__).parents[1] / "scripts" / "schemas" / "tt-boot-fs-schema.yml"
 )
+
+COMPAT_VARIABLES_SCHEMA_PATH = (
+    Path(__file__).parents[1] / "scripts" / "schemas" / "compat-variables-schema.json"
+)
+
+COMPAT_VARIABLES_VERSION = 1
+
+# Board variable numbers, as assigned in include/tenstorrent/board_variables.h
+BOARD_VAR_SPI_JEDEC_ID = 0
+
+# The properties of each board variable that do not depend on the board: the
+# display name a flashing tool prints, how it renders the value, and where it
+# reads the value from. Only the permitted values are per-image.
+BOARD_VARIABLES = {
+    BOARD_VAR_SPI_JEDEC_ID: {
+        "name": "SPI EEPROM",
+        "formatter": "hex",
+        # TAG_FLASH_JEDEC_ID, packed as 0x00MMTTCC
+        "source": {"type": "telemetry", "tag": 80},
+    },
+}
 
 ROOT = Path(__file__).parents[1]
 
@@ -1039,12 +1061,9 @@ def _generate_bootfs_yaml(
     _logger.debug(f"\nGenerated YAML Content: {args.output_file}\n{yaml_str}")
 
 
-def invoke_generate_bootfs_yaml(args):
+def _load_edt(dts_file: str, bindings_dirs: list[str]):
     """
-    Generates a boot filesystem YAML file from the partitions node in the
-    Zephyr devicetree at build time.
-
-    See parse_args() for a descriptive list of arguments.
+    Loads the Zephyr devicetree, which needs edtlib from the Zephyr tree.
     """
 
     sys.path.insert(
@@ -1060,10 +1079,21 @@ def invoke_generate_bootfs_yaml(args):
     )
     from devicetree import edtlib
 
+    return edtlib.EDT(dts_file, bindings_dirs)
+
+
+def invoke_generate_bootfs_yaml(args):
+    """
+    Generates a boot filesystem YAML file from the partitions node in the
+    Zephyr devicetree at build time.
+
+    See parse_args() for a descriptive list of arguments.
+    """
+
     if args.verbose:
         logging.basicConfig(format="%(message)s", level=logging.DEBUG)
 
-    edt = edtlib.EDT(args.dts_file, args.bindings_dirs)
+    edt = _load_edt(args.dts_file, args.bindings_dirs)
 
     partitions_nodes = edt.compat2nodes.get("tenstorrent,tt-boot-fs")
     partitions_node = partitions_nodes[0]
@@ -1091,6 +1121,110 @@ def invoke_generate_bootfs_yaml(args):
             args.board.upper(),
             args.output_file,
         )
+
+    return os.EX_OK
+
+
+def _flash_candidate_nodes(edt) -> list:
+    """
+    The flash configurations the firmware image can drive.
+
+    A board that may be built with more than one flash part selects between
+    them at runtime with a flash mux, whose candidates are exactly the parts
+    the image supports. Any other board drives a single flash node.
+    """
+
+    flash_node = edt.label2node.get("spi_flash")
+    if flash_node is None:
+        return []
+
+    if "tenstorrent,flash-mux" in flash_node.compats:
+        return list(flash_node.props["flash-devices"].val)
+
+    return [flash_node]
+
+
+def _flash_jedec_ids(nodes: list) -> list[int]:
+    """
+    The JEDEC IDs the given flash configurations accept, packed as telemetry
+    reports them: 0x00MMTTCC.
+    """
+
+    ids = []
+    for node in nodes:
+        prop = node.props.get("jedec-id")
+        if prop is None:
+            # A configuration with no jedec-id says nothing about which part
+            # it is for, so it contributes no permitted value. Among mux
+            # candidates that is the slow single-lane fallback, which keeps an
+            # unrecognized chip readable and reflashable: a recovery path, not
+            # a configuration the image is built for. On a board with a single
+            # flash node it leaves the image with nothing to declare, which
+            # correctly refuses a board carrying an unexpected part.
+            continue
+        ids.append(int.from_bytes(bytes(prop.val), "big"))
+
+    return ids
+
+
+def _compat_variables(edt) -> dict:
+    """
+    Describes the hardware this image is compatible with, as the values each
+    board variable may take. See scripts/schemas/compat-variables-schema.json.
+    """
+
+    variables = []
+
+    jedec_ids = _flash_jedec_ids(_flash_candidate_nodes(edt))
+    if jedec_ids:
+        values = [f"0x{jedec_id:06x}" for jedec_id in jedec_ids]
+        properties = BOARD_VARIABLES[BOARD_VAR_SPI_JEDEC_ID]
+        variables.append(
+            {
+                "name": properties["name"],
+                "number": BOARD_VAR_SPI_JEDEC_ID,
+                "formatter": properties["formatter"],
+                "source": properties["source"],
+                "constraints": (
+                    [{"eq": values[0]}] if len(values) == 1 else [{"in": values}]
+                ),
+            }
+        )
+
+    return {"version": COMPAT_VARIABLES_VERSION, "variables": variables}
+
+
+def invoke_generate_compat_variables(args):
+    """
+    Generates compat-variables.json from the Zephyr devicetree at build time.
+
+    See parse_args() for a descriptive list of arguments.
+    """
+
+    if args.verbose:
+        logging.basicConfig(format="%(message)s", level=logging.DEBUG)
+
+    compat_variables = _compat_variables(_load_edt(args.dts_file, args.bindings_dirs))
+
+    try:
+        with open(COMPAT_VARIABLES_SCHEMA_PATH, "r") as f:
+            schema = json.load(f)
+        jsonschema.validate(instance=compat_variables, schema=schema)
+    except Exception as e:
+        _logger.error(
+            f"Generated compat variables do not validate against "
+            f"{COMPAT_VARIABLES_SCHEMA_PATH}: {e}"
+        )
+        return os.EX_DATAERR
+
+    output_dir = os.path.dirname(args.output_file)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
+    with open(args.output_file, "w", encoding="utf-8") as f:
+        json.dump(compat_variables, f)
+
+    _logger.debug(f"\nGenerated {args.output_file}\n{compat_variables}")
 
     return os.EX_OK
 
@@ -1175,6 +1309,31 @@ def parse_args():
         "--verbose", default=0, action="count", help="Log the YAML file."
     )
     generate_bootfs_parser.set_defaults(func=invoke_generate_bootfs_yaml)
+
+    generate_compat_variables_parser = subparsers.add_parser(
+        name="generate_compat_variables",
+        description="Generate compat-variables.json from the Zephyr devicetree.",
+        allow_abbrev=False,
+    )
+    generate_compat_variables_parser.add_argument(
+        "--dts-file",
+        required=True,
+        help="Zephyr devicetree file containing the flash node.",
+    )
+    generate_compat_variables_parser.add_argument(
+        "--bindings-dirs",
+        nargs="+",
+        required=True,
+        help="Binding directories for the Zephyr devicetree. Should include Zephyr's "
+        "bindings and any custom bindings.",
+    )
+    generate_compat_variables_parser.add_argument(
+        "--output-file", required=True, help="Output JSON file."
+    )
+    generate_compat_variables_parser.add_argument(
+        "--verbose", default=0, action="count", help="Log the JSON file."
+    )
+    generate_compat_variables_parser.set_defaults(func=invoke_generate_compat_variables)
 
     # MKFS command- build a tt_boot_fs given a specification
     mkfs_parser = subparsers.add_parser("mkfs", help="Make tt_boot_fs filesystem")

--- a/scripts/tt_boot_fs.py
+++ b/scripts/tt_boot_fs.py
@@ -1125,46 +1125,60 @@ def invoke_generate_bootfs_yaml(args):
     return os.EX_OK
 
 
-def _flash_candidate_nodes(edt) -> list:
+def _flash_candidate_nodes(edt) -> tuple[list, bool]:
     """
-    The flash configurations the firmware image can drive.
+    The flash configurations the firmware image can drive, and whether a mux
+    selects between them at runtime.
 
-    A board that may be built with more than one flash part selects between
-    them at runtime with a flash mux, whose candidates are exactly the parts
-    the image supports. Any other board drives a single flash node.
+    A board that may be built with more than one flash part has a mux, whose
+    candidates are the configurations the image can use. Any other board drives
+    a single flash node.
     """
 
     flash_node = edt.label2node.get("spi_flash")
     if flash_node is None:
-        return []
+        return [], False
 
     if "tenstorrent,flash-mux" in flash_node.compats:
-        return list(flash_node.props["flash-devices"].val)
+        return list(flash_node.props["flash-devices"].val), True
 
-    return [flash_node]
+    return [flash_node], False
 
 
-def _flash_jedec_ids(nodes: list) -> list[int]:
+def _spi_jedec_constraints(edt) -> Optional[list]:
     """
-    The JEDEC IDs the given flash configurations accept, packed as telemetry
-    reports them: 0x00MMTTCC.
+    The constraints on the JEDEC IDs this image supports, or None if it does
+    not say. An empty list means it supports any part.
+
+    IDs are packed as telemetry reports them: 0x00MMTTCC.
     """
+
+    nodes, muxed = _flash_candidate_nodes(edt)
+    if not nodes:
+        return None
 
     ids = []
     for node in nodes:
         prop = node.props.get("jedec-id")
         if prop is None:
-            # A configuration with no jedec-id says nothing about which part
-            # it is for, so it contributes no permitted value. Among mux
-            # candidates that is the slow single-lane fallback, which keeps an
-            # unrecognized chip readable and reflashable: a recovery path, not
-            # a configuration the image is built for. On a board with a single
-            # flash node it leaves the image with nothing to declare, which
-            # correctly refuses a board carrying an unexpected part.
-            continue
+            if muxed:
+                # A mux candidate with no jedec-id is the single-lane fallback,
+                # which drives universal commands and so accepts any chip. The
+                # mux can always fall back to it, so the image supports any
+                # part, whatever the other candidates name.
+                return []
+
+            # A lone flash node that names no part says nothing about which
+            # part its settings suit, so the image declares nothing and cannot
+            # flash a board that requires the variable. Boards that fit exactly
+            # one part name it for this reason.
+            return None
+
         ids.append(int.from_bytes(bytes(prop.val), "big"))
 
-    return ids
+    values = [f"0x{jedec_id:06x}" for jedec_id in ids]
+
+    return [{"eq": values[0]}] if len(values) == 1 else [{"in": values}]
 
 
 def _compat_variables(edt) -> dict:
@@ -1175,9 +1189,8 @@ def _compat_variables(edt) -> dict:
 
     variables = []
 
-    jedec_ids = _flash_jedec_ids(_flash_candidate_nodes(edt))
-    if jedec_ids:
-        values = [f"0x{jedec_id:06x}" for jedec_id in jedec_ids]
+    constraints = _spi_jedec_constraints(edt)
+    if constraints is not None:
         properties = BOARD_VARIABLES[BOARD_VAR_SPI_JEDEC_ID]
         variables.append(
             {
@@ -1185,9 +1198,7 @@ def _compat_variables(edt) -> dict:
                 "number": BOARD_VAR_SPI_JEDEC_ID,
                 "formatter": properties["formatter"],
                 "source": properties["source"],
-                "constraints": (
-                    [{"eq": values[0]}] if len(values) == 1 else [{"in": values}]
-                ),
+                "constraints": constraints,
             }
         )
 

--- a/scripts/tt_fwbundle.py
+++ b/scripts/tt_fwbundle.py
@@ -14,6 +14,7 @@ import hashlib
 from intelhex import IntelHex
 from base64 import b16encode
 from pathlib import Path
+from typing import Optional
 import os
 import sys
 import shutil
@@ -68,6 +69,18 @@ def bundle_metadata(bundle: Path, board: str = "") -> dict:
                 with open(Path(tempdir) / img, "rb") as f:
                     bundle_binary = f.read()
                     board_data["sha256"] = hashlib.sha256(bundle_binary).hexdigest()
+                # The compatibility data decides whether this image may be
+                # written to a board at all, so it belongs in any comparison
+                # of two bundles. Bundles built before board variables have
+                # none, and simply do not carry the key.
+                try:
+                    compat_file = tar.extractfile(
+                        f"./{board_name}/compat-variables.json"
+                    )
+                except KeyError:
+                    compat_file = None
+                if compat_file is not None:
+                    board_data["compat_variables"] = json.load(compat_file)
                 data[board_name] = board_data
     except KeyError as e:
         print(f"Firmware bundle missing expected file: {e}")
@@ -200,6 +213,15 @@ def diff_fw_bundles(bundle1: Path, bundle2: Path):
             print(f"Board {board} images differ:")
             print(f"  Bundle 1 SHA256: {board_data1['sha256']}")
             print(f"  Bundle 2 SHA256: {board_data2['sha256']}")
+        # Two bundles carrying the same image can still disagree about the
+        # hardware it may be written to
+        compat1 = board_data1.get("compat_variables", "<missing>")
+        compat2 = board_data2.get("compat_variables", "<missing>")
+        if compat1 != compat2:
+            diff_found = True
+            print(f"Board {board} compatibility variables differ:")
+            print(f"  Bundle 1: {compat1}")
+            print(f"  Bundle 2: {compat2}")
     if not diff_found:
         print("No differences found between the two firmware bundles.")
         return os.EX_OK
@@ -230,7 +252,12 @@ def combine_fw_bundles(combine: list[Path], output: Path):
         shutil.rmtree(temp_dir)
 
 
-def create_fw_bundle(output: Path, version: list[int], boot_fs: dict[str, Path] = {}):
+def create_fw_bundle(
+    output: Path,
+    version: list[int],
+    boot_fs: dict[str, Path] = {},
+    compat_variables: Optional[Path] = None,
+):
     """
     Creates a firmware bundle tar.gz file, from tt_boot_fs images.
     """
@@ -246,6 +273,10 @@ def create_fw_bundle(output: Path, version: list[int], boot_fs: dict[str, Path] 
             mapping = []
             with open(board_dir / "mapping.json", "w") as file:
                 file.write(json.dumps(mapping))
+            if compat_variables is not None:
+                # Tells the flashing tool which hardware this image is
+                # compatible with, beyond the board type that selected it.
+                shutil.copyfile(compat_variables, board_dir / "compat-variables.json")
             if image.suffix == ".hex":
                 # Encode offsets using @addr format tt-flash supports
                 ih = IntelHex(str(image))
@@ -307,7 +338,7 @@ def invoke_create_fw_bundle(args):
         bootfs[args.bootfs[i]] = Path(args.bootfs[i + 1])
     setattr(args, "bootfs", bootfs)
 
-    create_fw_bundle(args.output, args.version, args.bootfs)
+    create_fw_bundle(args.output, args.version, args.bootfs, args.compat_variables)
     print(f"Wrote fwbundle to {args.output}")
     return os.EX_OK
 
@@ -363,6 +394,13 @@ def parse_args():
         help="output bundle file name",
         type=Path,
         required=True,
+    )
+    fw_bundle_create_parser.add_argument(
+        "--compat-variables",
+        metavar="JSON",
+        help="compat-variables.json describing the hardware the image supports",
+        type=Path,
+        default=None,
     )
     fw_bundle_create_parser.add_argument(
         "bootfs",

--- a/tests/lib/tenstorrent/bh_arc/src/msgqueue.c
+++ b/tests/lib/tenstorrent/bh_arc/src/msgqueue.c
@@ -13,6 +13,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/misc/bh_fwtable.h>
 
+#include <tenstorrent/board_variables.h>
 #include <tenstorrent/smc_msg.h>
 #include <tenstorrent/msgqueue.h>
 #include <tenstorrent/tt_smbus_regs.h>
@@ -651,14 +652,50 @@ ZTEST(msgqueue, test_msg_type_trigger_reset_invalid)
 	zassert_equal(rsp.data[0], 5, "Invalid level should return the level as error");
 }
 
-ZTEST(msgqueue, test_msg_type_flash_unlock)
+/* Micron MT25QU512ABB, the part FLASH_UNLOCK exempts from the JEDEC ID check */
+#define FLASH_JEDEC_ID_MT25QU512ABB 0x20BB20
+/* GigaDevice GD25LF512MF, standing in for any second-source part */
+#define FLASH_JEDEC_ID_GD25LF512MF  0xC8631A
+
+/* A write that reaches the flash driver fails with 1 (flash not ready) in
+ * this environment; one refused by the lock fails with 2.
+ */
+#define FLASH_WRITE_NOT_READY 1
+#define FLASH_WRITE_LOCKED    2
+
+/* Put the flash back in its boot state: locked, with no board variables
+ * accepted. The flash state is static in spi_eeprom.c and outlives a single
+ * test, so each test establishes it rather than inheriting it.
+ */
+static void flash_lock_reset(void)
 {
-	/* Test flash unlock message */
+	memset(&req, 0, sizeof(req));
+	memset(&rsp, 0, sizeof(rsp));
+	req.flash_lock.command_code = TT_SMC_MSG_FLASH_LOCK;
+
+	msgqueue_request_push(0, &req);
+	process_message_queues();
+	msgqueue_response_pop(0, &rsp);
+	zassert_equal(rsp.data[0], 0, "Flash lock should succeed");
+}
+
+static uint32_t send_flash_unlock(uint8_t num_variable_words, uint32_t verified)
+{
+	memset(&req, 0, sizeof(req));
+	memset(&rsp, 0, sizeof(rsp));
 	req.flash_unlock.command_code = TT_SMC_MSG_FLASH_UNLOCK;
+	req.flash_unlock.num_variable_words = num_variable_words;
+	req.flash_unlock.verified_variables[0] = verified;
 
-	push_msg_success();
+	msgqueue_request_push(0, &req);
+	process_message_queues();
+	msgqueue_response_pop(0, &rsp);
 
-	/* Verify flash is unlocked by attempting EEPROM write */
+	return rsp.data[0];
+}
+
+static uint32_t try_eeprom_write(void)
+{
 	memset(&req, 0, sizeof(req));
 	memset(&rsp, 0, sizeof(rsp));
 	req.eeprom.command_code = TT_SMC_MSG_WRITE_EEPROM;
@@ -671,39 +708,114 @@ ZTEST(msgqueue, test_msg_type_flash_unlock)
 	process_message_queues();
 	msgqueue_response_pop(0, &rsp);
 
-	/* Should fail with error 1 (flash not ready), not error 2 (flash locked) */
-	zassert_equal(rsp.data[0], 1, "Write should fail due to flash not ready, not locked");
+	return rsp.data[0];
+}
+
+ZTEST(msgqueue, test_msg_type_flash_unlock)
+{
+	/* An MT25 board requires nothing of the host, so a request that
+	 * predates board variables still unlocks it.
+	 */
+	UpdateTelemetryFlashJedecId(FLASH_JEDEC_ID_MT25QU512ABB);
+	flash_lock_reset();
+
+	zassert_equal(send_flash_unlock(0, 0), 0, "Flash unlock should succeed");
+	zassert_equal(rsp.data[1], 0, "No board variables should be required");
+	zassert_equal(try_eeprom_write(), FLASH_WRITE_NOT_READY,
+		      "Write should fail due to flash not ready, not locked");
+}
+
+ZTEST(msgqueue, test_msg_type_flash_unlock_missing_variables)
+{
+	/* Any other part needs the host to have checked the JEDEC ID */
+	UpdateTelemetryFlashJedecId(FLASH_JEDEC_ID_GD25LF512MF);
+	flash_lock_reset();
+
+	zassert_equal(send_flash_unlock(0, 0), 1,
+		      "Flash unlock should be refused without the JEDEC ID variable");
+	zassert_equal(rsp.data[1], BIT(BOARD_VAR_SPI_JEDEC_ID),
+		      "The reply should name the required board variable");
+	zassert_equal(try_eeprom_write(), FLASH_WRITE_LOCKED,
+		      "Write should fail due to flash locked");
+}
+
+ZTEST(msgqueue, test_msg_type_flash_unlock_verified_variables)
+{
+	UpdateTelemetryFlashJedecId(FLASH_JEDEC_ID_GD25LF512MF);
+	flash_lock_reset();
+
+	zassert_equal(send_flash_unlock(1, BIT(BOARD_VAR_SPI_JEDEC_ID)), 0,
+		      "Flash unlock should succeed once the JEDEC ID is verified");
+	zassert_equal(rsp.data[1], BIT(BOARD_VAR_SPI_JEDEC_ID),
+		      "The requirement should be reported on success too");
+	zassert_equal(try_eeprom_write(), FLASH_WRITE_NOT_READY,
+		      "Write should fail due to flash not ready, not locked");
+
+	/* The SPI write path issues its own bare unlock per transfer, which
+	 * rides on the variables already accepted.
+	 */
+	zassert_equal(send_flash_unlock(0, 0), 0,
+		      "A bare unlock should ride on the accepted variables");
+
+	/* Locking withdraws them again */
+	flash_lock_reset();
+	zassert_equal(send_flash_unlock(0, 0), 1, "Locking should withdraw the accepted variables");
+}
+
+ZTEST(msgqueue, test_msg_type_flash_unlock_word_count)
+{
+	/* Variable words past num_variable_words are not read */
+	UpdateTelemetryFlashJedecId(FLASH_JEDEC_ID_GD25LF512MF);
+	flash_lock_reset();
+
+	zassert_equal(send_flash_unlock(0, BIT(BOARD_VAR_SPI_JEDEC_ID)), 1,
+		      "A word count of zero should leave the variables unread");
+}
+
+ZTEST(msgqueue, test_msg_type_flash_unlock_write_sequence)
+{
+	/* The message sequence a real flash produces. tt-flash unlocks with
+	 * the variables it verified, then hands off to luwen, whose spi_write
+	 * issues its own bare unlock, writes the data a chunk at a time, and
+	 * locks again. A flash is many such calls, so run it twice.
+	 */
+	UpdateTelemetryFlashJedecId(FLASH_JEDEC_ID_GD25LF512MF);
+	flash_lock_reset();
+
+	for (int cycle = 0; cycle < 2; cycle++) {
+		zassert_equal(send_flash_unlock(1, BIT(BOARD_VAR_SPI_JEDEC_ID)), 0,
+			      "tt-flash unlock should succeed in cycle %d", cycle);
+
+		zassert_equal(send_flash_unlock(0, 0), 0,
+			      "luwen bare unlock should succeed in cycle %d", cycle);
+
+		/* The bare unlock must leave the flash open, not merely report
+		 * success: luwen writes every chunk after it.
+		 */
+		zassert_equal(try_eeprom_write(), FLASH_WRITE_NOT_READY,
+			      "First chunk should not be locked out in cycle %d", cycle);
+		zassert_equal(try_eeprom_write(), FLASH_WRITE_NOT_READY,
+			      "Second chunk should not be locked out in cycle %d", cycle);
+
+		flash_lock_reset();
+
+		zassert_equal(try_eeprom_write(), FLASH_WRITE_LOCKED,
+			      "Write after the lock should be refused in cycle %d", cycle);
+	}
 }
 
 ZTEST(msgqueue, test_msg_type_flash_lock)
 {
+	UpdateTelemetryFlashJedecId(FLASH_JEDEC_ID_MT25QU512ABB);
+
 	/* First unlock flash */
-	req.flash_unlock.command_code = TT_SMC_MSG_FLASH_UNLOCK;
-	push_msg_success();
-	zassert_equal(rsp.data[0], 0, "Flash unlock should succeed");
+	zassert_equal(send_flash_unlock(0, 0), 0, "Flash unlock should succeed");
 
 	/* Then lock it */
-	memset(&req, 0, sizeof(req));
-	memset(&rsp, 0, sizeof(rsp));
-	req.flash_lock.command_code = TT_SMC_MSG_FLASH_LOCK;
-	push_msg_success();
-	zassert_equal(rsp.data[0], 0, "Flash lock should succeed");
+	flash_lock_reset();
 
-	/* Verify flash is locked by attempting EEPROM write */
-	memset(&req, 0, sizeof(req));
-	memset(&rsp, 0, sizeof(rsp));
-	req.eeprom.command_code = TT_SMC_MSG_WRITE_EEPROM;
-	req.eeprom.spi_address = 0x1000;
-	req.eeprom.num_bytes = 4;
-	req.eeprom.csm_addr = 0x12345678; /* Valid CSM address range */
-	req.eeprom.buffer_mem_type = 0;
-
-	msgqueue_request_push(0, &req);
-	process_message_queues();
-	msgqueue_response_pop(0, &rsp);
-
-	/* Should fail with error 2 (flash locked) */
-	zassert_equal(rsp.data[0], 2, "Write should fail due to flash locked");
+	zassert_equal(try_eeprom_write(), FLASH_WRITE_LOCKED,
+		      "Write should fail due to flash locked");
 }
 
 ZTEST(msgqueue, test_msg_type_confirm_flashed_spi)

--- a/tests/lib/tenstorrent/tt_boot_fs/pytest/test-tt-boot-fs.py
+++ b/tests/lib/tenstorrent/tt_boot_fs/pytest/test-tt-boot-fs.py
@@ -565,108 +565,21 @@ def test_compat_variables_schema():
     """
     validator = _compat_variables_validator()
 
-    mux = _flash_node(
-        compats=("tenstorrent,flash-mux",),
-        children=(_flash_node(b"\x20\xbb\x20"), _flash_node(b"\xc8\x63\x1a")),
-    )
-    compat_variables = tt_boot_fs._compat_variables(_edt(mux))
-
-    validator.validate(compat_variables)
-
-
-def test_compat_variables_from_flash_mux():
-    """
-    A board that selects between flash parts at runtime supports all of them,
-    except the fallback that names no part.
-    """
-    mux = _flash_node(
-        compats=("tenstorrent,flash-mux",),
-        children=(
-            _flash_node(b"\x20\xbb\x20"),
-            _flash_node(b"\xc2\x25\x3a"),
-            _flash_node(b"\xc8\x63\x1a"),
-            _flash_node(b"\xef\x60\x20"),
-            # The universal single-lane fallback
-            _flash_node(),
+    for flash in (
+        # One part, several parts, and any part at all
+        _flash_node(b"\x20\xbb\x20"),
+        _flash_node(
+            compats=("tenstorrent,flash-mux",),
+            children=(_flash_node(b"\x20\xbb\x20"), _flash_node(b"\xc8\x63\x1a")),
         ),
-    )
+        _flash_node(
+            compats=("tenstorrent,flash-mux",),
+            children=(_flash_node(b"\x20\xbb\x20"), _flash_node()),
+        ),
+    ):
+        compat_variables = tt_boot_fs._compat_variables(_edt(flash))
 
-    compat_variables = tt_boot_fs._compat_variables(_edt(mux))
-
-    assert compat_variables == {
-        "version": tt_boot_fs.COMPAT_VARIABLES_VERSION,
-        "variables": [
-            {
-                "name": "SPI EEPROM",
-                "number": tt_boot_fs.BOARD_VAR_SPI_JEDEC_ID,
-                "formatter": "hex",
-                "source": {"type": "telemetry", "tag": 80},
-                "constraints": [
-                    {"in": ["0x20bb20", "0xc2253a", "0xc8631a", "0xef6020"]}
-                ],
-            }
-        ],
-    }
-
-
-def test_compat_variables_single_flash():
-    """
-    A board with one flash node supports only that part.
-    """
-    compat_variables = tt_boot_fs._compat_variables(_edt(_flash_node(b"\x20\xbb\x20")))
-
-    assert compat_variables["variables"][0]["constraints"] == [{"eq": "0x20bb20"}]
-
-
-def test_compat_variables_unknown_flash():
-    """
-    A flash node that names no part leaves nothing to declare, rather than
-    declaring that any part will do.
-    """
-    compat_variables = tt_boot_fs._compat_variables(_edt(_flash_node()))
-
-    assert compat_variables["variables"] == []
-
-
-def test_compat_variables_in_fwbundle(tmp_path: Path):
-    """
-    The generated file reaches the flashing tool in each board directory.
-    """
-    compat_variables = {
-        "version": 1,
-        "variables": [
-            {
-                "name": "SPI EEPROM",
-                "number": 0,
-                "formatter": "hex",
-                "source": {"type": "telemetry", "tag": 80},
-                "constraints": [{"eq": "0x20bb20"}],
-            }
-        ],
-    }
-    compat_variables_path = tmp_path / "compat-variables.json"
-    with open(compat_variables_path, "w") as f:
-        json.dump(compat_variables, f)
-
-    bootfs = tmp_path / "tt_boot_fs.bin"
-    with open(bootfs, "wb") as f:
-        f.write(tt_boot_fs.mkfs(TEST_ROOT / "p100a.yml"))
-
-    bundle = tmp_path / "update.fwbundle"
-    tt_fwbundle.create_fw_bundle(
-        bundle, [19, 1, 0, 0], {"P100A-1": bootfs}, compat_variables_path
-    )
-
-    with tarfile.open(bundle, "r") as tar:
-        packed = json.load(tar.extractfile("./P100A-1/compat-variables.json"))
-
-    assert packed == compat_variables
-
-    # Bundles built without compat variables must not gain the file
-    plain = tmp_path / "plain.fwbundle"
-    tt_fwbundle.create_fw_bundle(plain, [19, 1, 0, 0], {"P100A-1": bootfs})
-    with tarfile.open(plain, "r") as tar:
-        assert "./P100A-1/compat-variables.json" not in tar.getnames()
+        validator.validate(compat_variables)
 
 
 @pytest.mark.parametrize(
@@ -766,3 +679,116 @@ def test_compat_variables_schema_allows_an_unreadable_variable():
     _compat_variables_validator().validate(
         {"version": 1, "variables": [{"name": "x", "number": 0, "constraints": []}]}
     )
+
+
+def test_compat_variables_from_flash_mux():
+    """
+    A board that selects between flash parts at runtime supports all of them.
+    """
+    mux = _flash_node(
+        compats=("tenstorrent,flash-mux",),
+        children=(
+            _flash_node(b"\x20\xbb\x20"),
+            _flash_node(b"\xc2\x25\x3a"),
+            _flash_node(b"\xc8\x63\x1a"),
+            _flash_node(b"\xef\x60\x20"),
+        ),
+    )
+
+    compat_variables = tt_boot_fs._compat_variables(_edt(mux))
+
+    assert compat_variables == {
+        "version": tt_boot_fs.COMPAT_VARIABLES_VERSION,
+        "variables": [
+            {
+                "name": "SPI EEPROM",
+                "number": tt_boot_fs.BOARD_VAR_SPI_JEDEC_ID,
+                "formatter": "hex",
+                "source": {"type": "telemetry", "tag": 80},
+                "constraints": [
+                    {"in": ["0x20bb20", "0xc2253a", "0xc8631a", "0xef6020"]}
+                ],
+            }
+        ],
+    }
+
+
+def test_compat_variables_with_universal_fallback():
+    """
+    The mux can always fall back to the candidate that names no part, which
+    drives universal commands and so accepts any chip. The image therefore
+    supports any part, whatever the other candidates name.
+    """
+    mux = _flash_node(
+        compats=("tenstorrent,flash-mux",),
+        children=(
+            _flash_node(b"\x20\xbb\x20"),
+            # The universal single-lane fallback
+            _flash_node(),
+        ),
+    )
+
+    compat_variables = tt_boot_fs._compat_variables(_edt(mux))
+
+    assert compat_variables["variables"][0]["constraints"] == []
+
+
+def test_compat_variables_single_flash():
+    """
+    A board with one flash node supports only that part.
+    """
+    compat_variables = tt_boot_fs._compat_variables(_edt(_flash_node(b"\x20\xbb\x20")))
+
+    assert compat_variables["variables"][0]["constraints"] == [{"eq": "0x20bb20"}]
+
+
+def test_compat_variables_unknown_flash():
+    """
+    A lone flash node that names no part says nothing about which part its
+    settings suit, so leave nothing declared rather than claim any part will
+    do. Boards that fit exactly one part name it for this reason.
+    """
+    compat_variables = tt_boot_fs._compat_variables(_edt(_flash_node()))
+
+    assert compat_variables["variables"] == []
+
+
+def test_compat_variables_in_fwbundle(tmp_path: Path):
+    """
+    The generated file reaches the flashing tool in each board directory.
+    """
+    compat_variables = {
+        "version": 1,
+        "variables": [
+            {
+                "name": "SPI EEPROM",
+                "number": 0,
+                "formatter": "hex",
+                "source": {"type": "telemetry", "tag": 80},
+                "constraints": [{"eq": "0x20bb20"}],
+            }
+        ],
+    }
+    compat_variables_path = tmp_path / "compat-variables.json"
+    with open(compat_variables_path, "w") as f:
+        json.dump(compat_variables, f)
+
+    bootfs = tmp_path / "tt_boot_fs.bin"
+    with open(bootfs, "wb") as f:
+        f.write(tt_boot_fs.mkfs(TEST_ROOT / "p100a.yml"))
+
+    bundle = tmp_path / "update.fwbundle"
+    tt_fwbundle.create_fw_bundle(
+        bundle, [19, 1, 0, 0], {"P100A-1": bootfs}, compat_variables_path
+    )
+
+    with tarfile.open(bundle, "r") as tar:
+        packed = json.load(tar.extractfile("./P100A-1/compat-variables.json"))
+
+    assert packed == compat_variables
+
+    # Bundles built without compat variables must not gain the file
+    plain = tmp_path / "plain.fwbundle"
+    tt_fwbundle.create_fw_bundle(plain, [19, 1, 0, 0], {"P100A-1": bootfs})
+    with tarfile.open(plain, "r") as tar:
+        assert "./P100A-1/compat-variables.json" not in tar.getnames()

--- a/tests/lib/tenstorrent/tt_boot_fs/pytest/test-tt-boot-fs.py
+++ b/tests/lib/tenstorrent/tt_boot_fs/pytest/test-tt-boot-fs.py
@@ -3,12 +3,16 @@
 
 import argparse
 import base64
+import json
+import jsonschema
 import logging
 import os
 import pykwalify.core
+import pytest
 import requests
 import sys
 import tarfile
+import types
 import yaml
 
 from pathlib import Path
@@ -516,4 +520,249 @@ def test_tensix_disable(tmp_path: Path):
 
     assert tt_fwbundle.diff_fw_bundles(input_path, output_path) != os.EX_OK, (
         "diff_fw_bundles should detect changes after Tensix disable count update"
+    )
+
+
+def _flash_node(jedec_id: bytes = None, compats=("jedec,mspi-nor",), children=()):
+    """
+    The parts of an edtlib node the compat variables generator reads.
+    """
+    props = {}
+    if jedec_id is not None:
+        props["jedec-id"] = types.SimpleNamespace(val=jedec_id)
+    if children:
+        props["flash-devices"] = types.SimpleNamespace(val=list(children))
+    return types.SimpleNamespace(compats=list(compats), props=props)
+
+
+def _edt(flash_node):
+    return types.SimpleNamespace(label2node={"spi_flash": flash_node})
+
+
+def _compat_variables_validator():
+    with open(tt_boot_fs.COMPAT_VARIABLES_SCHEMA_PATH) as f:
+        schema = json.load(f)
+
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(schema)
+
+
+def _compat_variables_doc(constraints: list, **overrides) -> dict:
+    variable = {
+        "name": "SPI EEPROM",
+        "number": 0,
+        "formatter": "hex",
+        "source": {"type": "telemetry", "tag": 80},
+        "constraints": constraints,
+    }
+    variable.update(overrides)
+    return {"version": 1, "variables": [variable]}
+
+
+def test_compat_variables_schema():
+    """
+    The generated compat variables must validate against the published schema.
+    """
+    validator = _compat_variables_validator()
+
+    mux = _flash_node(
+        compats=("tenstorrent,flash-mux",),
+        children=(_flash_node(b"\x20\xbb\x20"), _flash_node(b"\xc8\x63\x1a")),
+    )
+    compat_variables = tt_boot_fs._compat_variables(_edt(mux))
+
+    validator.validate(compat_variables)
+
+
+def test_compat_variables_from_flash_mux():
+    """
+    A board that selects between flash parts at runtime supports all of them,
+    except the fallback that names no part.
+    """
+    mux = _flash_node(
+        compats=("tenstorrent,flash-mux",),
+        children=(
+            _flash_node(b"\x20\xbb\x20"),
+            _flash_node(b"\xc2\x25\x3a"),
+            _flash_node(b"\xc8\x63\x1a"),
+            _flash_node(b"\xef\x60\x20"),
+            # The universal single-lane fallback
+            _flash_node(),
+        ),
+    )
+
+    compat_variables = tt_boot_fs._compat_variables(_edt(mux))
+
+    assert compat_variables == {
+        "version": tt_boot_fs.COMPAT_VARIABLES_VERSION,
+        "variables": [
+            {
+                "name": "SPI EEPROM",
+                "number": tt_boot_fs.BOARD_VAR_SPI_JEDEC_ID,
+                "formatter": "hex",
+                "source": {"type": "telemetry", "tag": 80},
+                "constraints": [
+                    {"in": ["0x20bb20", "0xc2253a", "0xc8631a", "0xef6020"]}
+                ],
+            }
+        ],
+    }
+
+
+def test_compat_variables_single_flash():
+    """
+    A board with one flash node supports only that part.
+    """
+    compat_variables = tt_boot_fs._compat_variables(_edt(_flash_node(b"\x20\xbb\x20")))
+
+    assert compat_variables["variables"][0]["constraints"] == [{"eq": "0x20bb20"}]
+
+
+def test_compat_variables_unknown_flash():
+    """
+    A flash node that names no part leaves nothing to declare, rather than
+    declaring that any part will do.
+    """
+    compat_variables = tt_boot_fs._compat_variables(_edt(_flash_node()))
+
+    assert compat_variables["variables"] == []
+
+
+def test_compat_variables_in_fwbundle(tmp_path: Path):
+    """
+    The generated file reaches the flashing tool in each board directory.
+    """
+    compat_variables = {
+        "version": 1,
+        "variables": [
+            {
+                "name": "SPI EEPROM",
+                "number": 0,
+                "formatter": "hex",
+                "source": {"type": "telemetry", "tag": 80},
+                "constraints": [{"eq": "0x20bb20"}],
+            }
+        ],
+    }
+    compat_variables_path = tmp_path / "compat-variables.json"
+    with open(compat_variables_path, "w") as f:
+        json.dump(compat_variables, f)
+
+    bootfs = tmp_path / "tt_boot_fs.bin"
+    with open(bootfs, "wb") as f:
+        f.write(tt_boot_fs.mkfs(TEST_ROOT / "p100a.yml"))
+
+    bundle = tmp_path / "update.fwbundle"
+    tt_fwbundle.create_fw_bundle(
+        bundle, [19, 1, 0, 0], {"P100A-1": bootfs}, compat_variables_path
+    )
+
+    with tarfile.open(bundle, "r") as tar:
+        packed = json.load(tar.extractfile("./P100A-1/compat-variables.json"))
+
+    assert packed == compat_variables
+
+    # Bundles built without compat variables must not gain the file
+    plain = tmp_path / "plain.fwbundle"
+    tt_fwbundle.create_fw_bundle(plain, [19, 1, 0, 0], {"P100A-1": bootfs})
+    with tarfile.open(plain, "r") as tar:
+        assert "./P100A-1/compat-variables.json" not in tar.getnames()
+
+
+@pytest.mark.parametrize(
+    "constraints",
+    [
+        # Both representations of an unsigned 32 bit value, at both ends
+        [{"eq": 0}],
+        [{"eq": 4294967295}],
+        [{"eq": "0x20bb20"}],
+        [{"eq": "0X20BB20"}],
+        [{"in": ["0x20bb20", 2145056]}],
+        # No restriction at all
+        [],
+        # Every operator, and more than one at once
+        [{"ne": 1}],
+        [{"lt": 1}],
+        [{"le": 1}],
+        [{"gt": 1}],
+        [{"ge": 1}],
+        [{"not_in": [1]}],
+        [{"ge": 2}, {"lt": 4}],
+        # A list can repeat an operator, which a map could not
+        [{"ne": 1}, {"ne": 2}],
+    ],
+)
+def test_compat_variables_schema_accepts(constraints):
+    _compat_variables_validator().validate(_compat_variables_doc(constraints))
+
+
+@pytest.mark.parametrize(
+    "constraints",
+    [
+        # Outside the range a board variable can hold
+        [{"eq": -1}],
+        [{"eq": 4294967296}],
+        [{"eq": "0x100000000"}],
+        # Not one of the two representations
+        [{"eq": "20bb20"}],
+        [{"eq": "nope"}],
+        [{"eq": None}],
+        [{"eq": True}],
+        [{"eq": {"a": 1}}],
+        [{"eq": [1]}],
+        [{"in": [None]}],
+        # A list of permitted values that permits nothing
+        [{"in": []}],
+        # An operator no consumer of version 1 knows how to evaluate
+        [{"between": [1, 2]}],
+        # An entry must name exactly one comparison
+        [{"ge": 2, "lt": 4}],
+        [{}],
+        # The whole field is a list now, not a map
+        {"eq": 0},
+    ],
+)
+def test_compat_variables_schema_rejects(constraints):
+    with pytest.raises(jsonschema.ValidationError):
+        _compat_variables_validator().validate(_compat_variables_doc(constraints))
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        # A misspelled key would otherwise be silently ignored
+        _compat_variables_doc([{"eq": 0}], formater="hex"),
+        _compat_variables_doc([{"eq": 0}], formatter="hexx"),
+        _compat_variables_doc([{"eq": 0}], number=-1),
+        # Past the last bit the unlock message can carry
+        _compat_variables_doc([{"eq": 0}], number=224),
+        _compat_variables_doc([{"eq": 0}], name=""),
+        # A telemetry source with no tag names nothing to read
+        _compat_variables_doc([{"eq": 0}], source={"type": "telemetry"}),
+        _compat_variables_doc([{"eq": 0}], source={"type": "dmc_message"}),
+        {"version": 1, "variables": [{"name": "x", "number": 0}]},
+        {"version": 1},
+        # This schema describes version 1 only
+        {"version": 2, "variables": []},
+    ],
+)
+def test_compat_variables_schema_rejects_structure(document):
+    with pytest.raises(jsonschema.ValidationError):
+        _compat_variables_validator().validate(document)
+
+
+def test_compat_variables_schema_allows_the_last_representable_variable():
+    """
+    The verified bitmap is at most seven 32 bit words, so 223 is the highest
+    number a host can ever report back.
+    """
+    _compat_variables_validator().validate(
+        {"version": 1, "variables": [{"name": "x", "number": 223, "constraints": []}]}
+    )
+
+
+def test_compat_variables_schema_allows_an_unreadable_variable():
+    """A variable with no source is one no consumer can check, not an error."""
+    _compat_variables_validator().validate(
+        {"version": 1, "variables": [{"name": "x", "number": 0, "constraints": []}]}
     )

--- a/tests/lib/tenstorrent/tt_boot_fs/pytest/test-tt-fwbundle.py
+++ b/tests/lib/tenstorrent/tt_boot_fs/pytest/test-tt-fwbundle.py
@@ -421,3 +421,82 @@ def test_combine_fwbundle(workdir: Path):
     # Not much else we can check here, this isn't really a logical combination
     # of bundles. Just verify the output exists.
     assert combined_fwbundle_path.exists(), "Combined firmware bundle does not exist"
+
+
+def compat_variables_bundle(path: Path, workdir: Path, jedec_id: str):
+    """
+    A bundle whose only variable is the permitted SPI EEPROM JEDEC ID.
+    """
+    import json
+
+    image = workdir / "image.bin"
+    if not image.exists():
+        image.write_bytes(b"\xa5" * 64)
+
+    compat_variables = workdir / f"compat-{jedec_id}.json"
+    with open(compat_variables, "w") as f:
+        json.dump(
+            {
+                "version": 1,
+                "variables": [
+                    {
+                        "name": "SPI EEPROM",
+                        "number": 0,
+                        "formatter": "hex",
+                        "source": {"type": "telemetry", "tag": 80},
+                        "constraints": [{"eq": jedec_id}],
+                    }
+                ],
+            },
+            f,
+        )
+
+    tt_fwbundle.create_fw_bundle(
+        path, [19, 1, 0, 0], {"P150A-1": image}, compat_variables
+    )
+
+
+def test_fwbundle_diff_compat_variables(workdir: Path):
+    """
+    Two bundles carrying the same image can still disagree about the hardware
+    it may be written to, and that is a difference worth reporting: it decides
+    whether the bundle may be flashed at all.
+    """
+    mt25 = workdir / "mt25.fwbundle"
+    gd25 = workdir / "gd25.fwbundle"
+    mt25_again = workdir / "mt25-again.fwbundle"
+    compat_variables_bundle(mt25, workdir, "0x20bb20")
+    compat_variables_bundle(gd25, workdir, "0xc8631a")
+    compat_variables_bundle(mt25_again, workdir, "0x20bb20")
+
+    # Same image, same constraints
+    assert tt_fwbundle.diff_fw_bundles(mt25, mt25_again) == os.EX_OK, (
+        "Bundles that agree should show no differences"
+    )
+
+    # Same image, different constraints
+    assert tt_fwbundle.diff_fw_bundles(mt25, gd25) != os.EX_OK, (
+        "A compatibility-only difference must be reported"
+    )
+
+
+def test_bundle_metadata_records_compat_variables(workdir: Path):
+    """
+    A bundle that predates board variables carries none, and must not grow the
+    key.
+    """
+    with_compat = workdir / "with-compat.fwbundle"
+    compat_variables_bundle(with_compat, workdir, "0x20bb20")
+    metadata = tt_fwbundle.bundle_metadata(with_compat, board="P150A-1")
+    assert metadata["P150A-1"]["compat_variables"]["variables"][0]["constraints"] == [
+        {"eq": "0x20bb20"}
+    ]
+
+    without = workdir / "without-compat.fwbundle"
+    tt_fwbundle.create_fw_bundle(
+        without, [19, 1, 0, 0], {"P150A-1": workdir / "image.bin"}
+    )
+    assert (
+        "compat_variables"
+        not in tt_fwbundle.bundle_metadata(without, board="P150A-1")["P150A-1"]
+    )


### PR DESCRIPTION
Due to BH Galaxy second-source SPI EEPROM, we now have board variants not supported by old firmware.

This add an interlock between tt-flash and the firmware to ensure that tt-flash won't flash firmware that can't support the board.

There are 3 participants to the interlock: the flash bundle, tt-flash and the running firmware.
- Each image in the flash bundle declares a list of *board variables* and the values for each variable it supports.
- tt-flash checks supported values against the actual value reported by running firmware.
- tt-flash reports to firmware which variables it checked to prevent old oblivious tt-flash from flashing incompatible firmware.

This PR includes the definition & implementation of the first board variable: SPI EEPROM JEDEC ID.