### PR TITLE
tt_grendel: add shim for Keranous reg names

### DIFF
--- a/drivers/gpio/gpio_tt_grendel.c
+++ b/drivers/gpio/gpio_tt_grendel.c
@@ -12,6 +12,15 @@
 
 #include <platform.h>
 
+/*
+ * TODO: Temporary shim to resolve header names for Keraunos
+ * (prefixed types, absolute _REG_ADDR). Remove when proper SiVal drop
+ * is received with shared header naming scheme.
+ */
+#ifdef PLATFORM_KER_SMC
+typedef SMC_CPU_GPIO_WRAP_GPIO_0_CONTROL_reg_u GPIO_CTRL_CONTROL_reg_u;
+#endif
+
 struct gpio_grendel_config {
 	/* gpio_driver_config needs to be first */
 	struct gpio_driver_config common;

--- a/soc/tenstorrent/tt_grendel/tt_grendel_smc/soc.c
+++ b/soc/tenstorrent/tt_grendel/tt_grendel_smc/soc.c
@@ -9,6 +9,21 @@
 
 #include "platform.h"
 
+/*
+ * TODO: Temporary shim to resolve header names for Keraunos
+ * (prefixed types, absolute _REG_ADDR). Remove when proper SiVal drop
+ * is received with shared header naming scheme.
+ */
+#ifdef PLATFORM_KER_SMC
+typedef SMC_CPU_UART_WRAP0_UART_CTRL_reg_u UART_CTRL_reg_u;
+typedef SMC_CPU_I3C_WRAP_0_I3C_CTRL_I3C_RESET_CTRL_STATUS_reg_u
+	I3C_CTRL_I3C_RESET_CTRL_STATUS_reg_u;
+typedef SMC_CPU_I3C_WRAP_0_I3C_CTRL_PINSTRAPS_GROUP_1A_reg_u I3C_CTRL_PINSTRAPS_GROUP_1A_reg_u;
+typedef SMC_CPU_RESET_UNIT_PERIPHERAL_RESETS_reg_u
+	SMC_WRAP_RESET_UNIT_MASTER_PERIPHERAL_RESETS_reg_u;
+#define SMC_CPU_CTRL_LOCAL_BASE_REG_DEFAULT 0
+#endif
+
 #define UART_INIT_IF_OKAY(n, ...)                                                                  \
 	do {                                                                                       \
 		if (DT_NODE_HAS_STATUS_OKAY(DT_NODELABEL(uart##n))) {                              \


### PR DESCRIPTION
Adds shim required for compiling Keranous images. This shim is temporary until a proper shared header naming scheme is implemented.