### PR TITLE
D2d fw load

### DIFF
--- a/boards/tenstorrent/tt_mimir/tt_mimir_tt_mimir_smc.dts
+++ b/boards/tenstorrent/tt_mimir/tt_mimir_tt_mimir_smc.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <tenstorrent/tt_grendel_smc.dtsi>
+#include <tenstorrent/tt_mimir_d2d.dtsi>
 #include <tenstorrent/tt_mimir_gddr.dtsi>
 
 / {

--- a/boards/tenstorrent/tt_mmk/tt_mmk_tt_mimir_smc.dts
+++ b/boards/tenstorrent/tt_mmk/tt_mmk_tt_mimir_smc.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <tenstorrent/tt_grendel_smc.dtsi>
+#include <tenstorrent/tt_mimir_d2d.dtsi>
 
 / {
 	vuarts {

--- a/drivers/misc/CMakeLists.txt
+++ b/drivers/misc/CMakeLists.txt
@@ -3,6 +3,7 @@
 # zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_BH_FWTABLE bh_fwtable)
 add_subdirectory_ifdef(CONFIG_TT_BH_EFUSE bh_efuse)
+add_subdirectory_ifdef(CONFIG_TT_D2D tt_d2d)
 add_subdirectory_ifdef(CONFIG_TT_MIMIR_REMOTE_BOOT tt_mimir_remote_boot)
 add_subdirectory_ifdef(CONFIG_TT_SMC_REMOTEPROC tt_smc_remoteproc)
 # zephyr-keep-sorted-stop

--- a/drivers/misc/Kconfig
+++ b/drivers/misc/Kconfig
@@ -8,6 +8,7 @@ menu "Miscellaneous Drivers"
 # zephyr-keep-sorted-start
 rsource "bh_efuse/Kconfig"
 rsource "bh_fwtable/Kconfig"
+rsource "tt_d2d/Kconfig"
 rsource "tt_mimir_remote_boot/Kconfig"
 rsource "tt_smc_remoteproc/Kconfig"
 # zephyr-keep-sorted-stop

--- a/drivers/misc/tt_d2d/CMakeLists.txt
+++ b/drivers/misc/tt_d2d/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+zephyr_library()
+zephyr_library_sources_ifdef(CONFIG_TT_D2D tt_d2d.c)
+
+# Include closed source SiVal drop.
+if(CONFIG_TT_D2D)
+  set(SIVAL_EXTDIR ${CMAKE_BINARY_DIR}/grendel-sival-sdk)
+  set(SIVAL_BLOBS_TARBALL
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../../zephyr/blobs/grendel-sival-sdk.tar.gz)
+
+  if(NOT EXISTS "${SIVAL_BLOBS_TARBALL}")
+    message(FATAL_ERROR
+            "The Sival SDK drop is missing:\n  ${SIVAL_BLOBS_TARBALL}\n"
+            "It is closed source and distributed separately.")
+  endif()
+
+  file(MAKE_DIRECTORY ${SIVAL_EXTDIR})
+  execute_process(COMMAND tar -xzf ${SIVAL_BLOBS_TARBALL}
+    WORKING_DIRECTORY ${SIVAL_EXTDIR}
+  )
+
+  zephyr_include_directories(
+    ${SIVAL_EXTDIR}/grendel_sival_sdk/firmware/drivers/d2d/include)
+endif()

--- a/drivers/misc/tt_d2d/Kconfig
+++ b/drivers/misc/tt_d2d/Kconfig
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+config TT_D2D
+	bool "Tenstorrent Grendel D2D firmware loader"
+	default y
+	depends on DT_HAS_TENSTORRENT_GRENDEL_D2D_ENABLED
+	help
+	  Enable the die-to-die (D2D) firmware loader for Tenstorrent Grendel.
+	  The driver writes a firmware image into a D2D tile's Rocket SRAM,
+	  fills in the configuration block that firmware reads at startup, and
+	  releases the Rocket to run it.
+
+if TT_D2D
+
+config TT_D2D_INIT_PRIO
+	int
+	default 75
+	help
+	  Initialization priority of the D2D driver. Nothing is touched at init
+	  time, so this only has to leave the device available before any
+	  application code that loads firmware into it.
+
+config TT_D2D_VERIFY_LOAD
+	bool "Read back the image after loading"
+	default y
+	help
+	  Read the firmware image back out of D2D SRAM and compare it against
+	  the source before releasing the Rocket. Catches a bad or unmapped
+	  SRAM window as a load failure rather than as an unexplained failure
+	  to train the link later on. Costs one extra read per word.
+
+module = TT_D2D
+module-str = tt_d2d
+source "subsys/logging/Kconfig.template.log_config"
+
+endif # TT_D2D

--- a/drivers/misc/tt_d2d/tt_d2d.c
+++ b/drivers/misc/tt_d2d/tt_d2d.c
@@ -1,0 +1,462 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/dma.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/sys_io.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(tt_d2d, CONFIG_TT_D2D_LOG_LEVEL);
+
+#include <d2d_api_driver.h>
+#include <d2d_api_general_definitions.h>
+#include <platform.h>
+
+#include <zephyr/drivers/misc/tt_d2d.h>
+
+#define DT_DRV_COMPAT tenstorrent_grendel_d2d
+
+#ifdef CONFIG_DMA
+BUILD_ASSERT(CONFIG_TT_D2D_INIT_PRIO > CONFIG_DMA_INIT_PRIORITY,
+	     "TT_D2D_INIT_PRIO must be higher than DMA_INIT_PRIORITY so the DMA "
+	     "controller is ready when a tile checks for it");
+#endif
+
+/*
+ * Offsets within a D2D tile's register map.
+ */
+#define TT_D2D_OFFSET(addr) ((addr) - D2D_0_REG_MAP_BASE_ADDR)
+
+#define TT_D2D_STRAP_RESET_OFFSET TT_D2D_OFFSET(D2D_0_STRAP_RESET_REG_ADDR)
+#define TT_D2D_CPU_CTRL_OFFSET    TT_D2D_OFFSET(D2D_0_D2D_D2D_SS_ASYNC_CPU_CTRL_REG_ADDR)
+#define TT_D2D_SRAM_OFFSET        TT_D2D_OFFSET(D2D_0_D2D_D2D_ROCKET_REG_MAP_BASE_ADDR)
+
+BUILD_ASSERT(D2D_1_STRAP_RESET_REG_ADDR - D2D_1_REG_MAP_BASE_ADDR == TT_D2D_STRAP_RESET_OFFSET &&
+		     D2D_1_D2D_D2D_SS_ASYNC_CPU_CTRL_REG_ADDR - D2D_1_REG_MAP_BASE_ADDR ==
+			     TT_D2D_CPU_CTRL_OFFSET &&
+		     D2D_1_D2D_D2D_ROCKET_REG_MAP_BASE_ADDR - D2D_1_REG_MAP_BASE_ADDR ==
+			     TT_D2D_SRAM_OFFSET,
+	     "every D2D tile must share one register layout for base-relative offsets to hold");
+
+/*
+ * The firmware's side of the same window, from the drop's D2D API headers: the
+ * addresses there are tile-relative and start at the SRAM, so the two views
+ * have to agree on where that is before any of them can be used as offsets.
+ */
+BUILD_ASSERT(D2D_MEMORY_BASE == TT_D2D_SRAM_OFFSET,
+	     "the D2D API memory map and the register map disagree on the SRAM window");
+
+/*
+ * The config space is an SRAM region for firmware to read once at statup.
+ */
+#define TT_D2D_CFG_OFFSET ((uint32_t)(HOST_CONFIGURATION_AVAILABLE_REG - D2D_MEMORY_BASE))
+#define TT_D2D_CFG_PARM_OFFSET(parm)                                                               \
+	((uint32_t)((HOST_CONFIGURATION_START - D2D_MEMORY_BASE) + ((parm) * sizeof(uint32_t))))
+
+/*
+ * The firmware reads the whole parameter table, up to and including
+ * RECOVERY_MODE, so the window has to be big enough to hold all of it.
+ */
+#define TT_D2D_CFG_END TT_D2D_CFG_PARM_OFFSET(RECOVERY_MODE + 1)
+
+/* Anything at or past the configuration block would be overwritten by it. */
+#define TT_D2D_IMAGE_MAX TT_D2D_CFG_OFFSET
+
+/*
+ * Loopback-2 stays disabled, but its parameters are still filled in to match
+ * the drop's default configuration table, so the block the firmware reads is
+ * the reference one wherever devicetree does not override it. These two have
+ * no named constant in the drop; everything else here does.
+ */
+#define TT_D2D_LPBK2_RX_SLICE    4U
+#define TT_D2D_LPBK2_MEM_PATTERN 0xABCDU
+
+/*
+ * Reset default asserts all three of the CPU control resets,
+ * D2D_SS_ASYNC_CPU_CTRL_REG_DEFAULT.
+ *
+ * Releasing uncore is what makes the Rocket's SRAM reachable from here, so it
+ * has to come out before a load while the core stays in reset.
+ *
+ * debug_reset is left asserted throughout, the reference bring-up keeps it that
+ * way and clearing it is not needed to run firmware.
+ */
+static inline uint32_t tt_d2d_cpu_ctrl(bool run_core)
+{
+	D2D_SS_ASYNC_CPU_CTRL_reg_u ctrl = {.f = {
+						    .core_reset = run_core ? 0U : 1U,
+						    .uncore_reset = 0U,
+						    .debug_reset = 1U,
+					    }};
+
+	return ctrl.val;
+}
+
+/*
+ * Written to the first SRAM word and read back before a load, to tell an
+ * unreachable tile apart from a genuine load failure. Any value works; this
+ * one is just recognisable in a bus trace.
+ */
+#define TT_D2D_PROBE_PATTERN 0xD2D0F00DU
+
+/*
+ * Block size for the DMA zero-fill. The engine has no fill mode, so zeroing is
+ * a copy from a page of zeroes whose source address never advances; this is
+ * both that page's size and the transfer block size.
+ */
+#define TT_D2D_ZERO_BLOCK 4096U
+
+/*
+ * Re-read once per block by the DMA, so one page covers a window of any size.
+ * In .bss, which the kernel has already zeroed by the time any of this runs,
+ * and 4 KB aligned to match the block size the engine is given.
+ */
+static uint64_t tt_d2d_zero_page[TT_D2D_ZERO_BLOCK / sizeof(uint64_t)] __aligned(TT_D2D_ZERO_BLOCK);
+
+struct tt_d2d_config {
+	uintptr_t base;
+	const struct device *dma_dev; /* NULL when no dmas property: CPU stores */
+	uint32_t dma_channel;
+	uint32_t sram_size;
+	uint32_t bits_per_channel;
+	uint32_t refclk_period_ns;
+	uint32_t apb_clk_period_ps;
+	uint32_t pll_freq_ghz;
+	uint32_t package_type_this_die;
+	uint32_t package_type_other_die;
+	bool bypass_phy;
+	bool bypass_vreg;
+	bool disable_sideband;
+};
+
+static inline uintptr_t tt_d2d_sram(const struct tt_d2d_config *config)
+{
+	return config->base + TT_D2D_SRAM_OFFSET;
+}
+
+static inline void tt_d2d_cfg_write(const struct tt_d2d_config *config, tCONFIG_PARM parm,
+				    uint32_t value)
+{
+	sys_write32(value, tt_d2d_sram(config) + TT_D2D_CFG_PARM_OFFSET(parm));
+}
+
+int tt_d2d_reset_release(const struct device *dev)
+{
+	const struct tt_d2d_config *config = dev->config;
+	uintptr_t strap = config->base + TT_D2D_STRAP_RESET_OFFSET;
+	TT_MIMIR_D2D_STRAP_RESET_reg_u reset = {.val = 0};
+
+	/*
+	 * One reset per write, in the order the hardware requires, so each is
+	 * added to the ones already deasserted rather than replacing them.
+	 *
+	 * 64-bit accesses: the strap block is only reachable that way, unlike
+	 * the rest of the tile which is written 32 bits at a time.
+	 */
+	reset.f.d2d_noc_reset_n = 1;
+	sys_write64(reset.val, strap);
+
+	reset.f.d2d_i_apb_resetn = 1;
+	sys_write64(reset.val, strap);
+
+	reset.f.d2d_sys_rst_ni = 1;
+	sys_write64(reset.val, strap);
+
+	reset.f.d2d_ll_aresetn = 1;
+	sys_write64(reset.val, strap);
+
+	reset.f.d2d_i_axi4l_aresetn = 1;
+	sys_write64(reset.val, strap);
+
+	reset.f.d2d_qnp_aresetn = 1;
+	sys_write64(reset.val, strap);
+
+	reset.f.noc2axi_reset_n = 1;
+	sys_write64(reset.val, strap);
+
+	LOG_DBG("%s: subsystem resets released (straps 0x%02x)", dev->name, reset.val);
+
+	return 0;
+}
+
+/*
+ * One synchronous memory-to-memory transfer.
+ *
+ * The Zephyr DMA block fields do not map onto this engine's registers by name,
+ * so the correspondence is worth stating: source_gather_interval and
+ * dest_scatter_interval are the source and destination strides, and
+ * source_gather_count is the repetition count. A stride of zero means the
+ * address does not advance between repetitions, which is what turns a copy
+ * into a fill.
+ *
+ * The Grendel DMA driver polls the transfer to completion inside dma_start(),
+ * so there is nothing to wait for afterwards.
+ */
+static int tt_d2d_dma_run(const struct device *dev, uintptr_t src, uintptr_t dst, uint32_t len,
+			  uint32_t src_stride, uint32_t dst_stride, uint32_t repetitions)
+{
+	const struct tt_d2d_config *config = dev->config;
+	struct dma_block_config block = {
+		.source_address = src,
+		.dest_address = dst,
+		.block_size = len,
+		.source_gather_interval = src_stride,
+		.dest_scatter_interval = dst_stride,
+		.source_gather_count = repetitions,
+		.source_gather_en = (src_stride == 0) ? 1 : 0,
+		.dest_scatter_en = (dst_stride != 0) ? 1 : 0,
+	};
+	struct dma_config dma_cfg = {
+		.channel_direction = MEMORY_TO_MEMORY,
+		.source_data_size = sizeof(uint32_t),
+		.dest_data_size = sizeof(uint32_t),
+		.block_count = 1,
+		.head_block = &block,
+	};
+	int ret;
+
+	ret = dma_config(config->dma_dev, config->dma_channel, &dma_cfg);
+	if (ret != 0) {
+		LOG_ERR("%s: dma_config failed: %d", dev->name, ret);
+		return ret;
+	}
+
+	ret = dma_start(config->dma_dev, config->dma_channel);
+	if (ret != 0) {
+		LOG_ERR("%s: dma_start failed: %d", dev->name, ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int tt_d2d_clear_sram(const struct device *dev, uintptr_t sram)
+{
+	const struct tt_d2d_config *config = dev->config;
+
+	/* The zero-fill works in whole pages, so a window that is not a
+	 * multiple of one falls back rather than leaving a tail unwritten.
+	 */
+	if (config->dma_dev != NULL && (config->sram_size % TT_D2D_ZERO_BLOCK) == 0) {
+		return tt_d2d_dma_run(dev, (uintptr_t)tt_d2d_zero_page, sram, TT_D2D_ZERO_BLOCK, 0,
+				      TT_D2D_ZERO_BLOCK, config->sram_size / TT_D2D_ZERO_BLOCK);
+	}
+
+	for (uint32_t off = 0; off < config->sram_size; off += sizeof(uint32_t)) {
+		sys_write32(0, sram + off);
+	}
+
+	return 0;
+}
+
+static int tt_d2d_copy_image(const struct device *dev, uintptr_t sram, const uint8_t *img,
+			     size_t img_size)
+{
+	const struct tt_d2d_config *config = dev->config;
+
+	if (config->dma_dev != NULL) {
+		return tt_d2d_dma_run(dev, (uintptr_t)img, sram, img_size, 0, 0, 1);
+	}
+
+	for (size_t off = 0; off < img_size; off += sizeof(uint32_t)) {
+		sys_write32(sys_get_le32(&img[off]), sram + off);
+	}
+
+	return 0;
+}
+
+static void tt_d2d_write_config(const struct device *dev)
+{
+	const struct tt_d2d_config *config = dev->config;
+
+	tt_d2d_cfg_write(config, BITS_PER_CHANNEL, config->bits_per_channel);
+	tt_d2d_cfg_write(config, REFERENCE_CLOCK_PERIOD_NS, config->refclk_period_ns);
+	tt_d2d_cfg_write(config, APB_CLOCK_PERIOD_IN_PS, config->apb_clk_period_ps);
+	tt_d2d_cfg_write(config, PLL_FREQUENCY_IN_GHZ, config->pll_freq_ghz);
+	tt_d2d_cfg_write(config, TX_WILD_CLOCK_0_FAST_1_SLOW, TX_WILD_CLOCK_FAST);
+	tt_d2d_cfg_write(config, RX_WILD_CLOCK_0_FAST_1_SLOW, RX_WILD_CLOCK_SLOW);
+	tt_d2d_cfg_write(config, BYPASS_VREG_0_FALSE_1_TRUE,
+			 config->bypass_vreg ? VREG_INIT_BYPASS : VREG_INIT_EXEC);
+	tt_d2d_cfg_write(config, PACKAGE_TYPE_THIS_DIE, config->package_type_this_die);
+	tt_d2d_cfg_write(config, PACKAGE_TYPE_OTHER_DIE, config->package_type_other_die);
+	tt_d2d_cfg_write(config, SLICE_COUNT_4_USED, SLICE_COUNT_6_STD_OR_8_ADV);
+	tt_d2d_cfg_write(config, LPBK_2_ENABLE, INTERNAL_LPBK_DISABLED);
+	tt_d2d_cfg_write(config, LPBK_2_PATTERN_TYPE, MEM_PATTERN);
+	tt_d2d_cfg_write(config, LPBK_2_TX_SLICE, 0U);
+	tt_d2d_cfg_write(config, LPBK_2_RX_SLICE, TT_D2D_LPBK2_RX_SLICE);
+	tt_d2d_cfg_write(config, LPBK_2_MEM_PATTERN_INFO, TT_D2D_LPBK2_MEM_PATTERN);
+	tt_d2d_cfg_write(config, LPBK_2_PRBS_PATTERN_SIZE, PRBS_31_BIT);
+	tt_d2d_cfg_write(config, PHY_BYPASS,
+			 config->bypass_phy ? PHY_BYPASS_ENABLED : PHY_BYPASS_DISABLED);
+	tt_d2d_cfg_write(config, DISABLE_SIDEBAND, config->disable_sideband ? 1U : 0U);
+
+	/*
+	 * Magic last, and in its own register rather than the parameter table:
+	 * it is what tells the firmware the rest of the block is populated, so
+	 * writing it first would expose a half-filled config.
+	 */
+	sys_write32(CFG_AVAILABLE_SPECIAL_CODE, tt_d2d_sram(config) + TT_D2D_CFG_OFFSET);
+}
+
+int tt_d2d_load_fw(const struct device *dev, const uint8_t *img, size_t img_size)
+{
+	const struct tt_d2d_config *config = dev->config;
+	uintptr_t sram = tt_d2d_sram(config);
+	D2D_SS_ASYNC_CPU_CTRL_reg_u ctrl;
+	uint32_t probe;
+	int ret;
+
+	if (img == NULL || img_size == 0 || (img_size % sizeof(uint32_t)) != 0) {
+		return -EINVAL;
+	}
+
+	if (img_size > TT_D2D_IMAGE_MAX) {
+		LOG_ERR("%s: image of %zu bytes would overwrite the config block at 0x%x",
+			dev->name, img_size, TT_D2D_CFG_OFFSET);
+		return -ENOSPC;
+	}
+
+	/*
+	 * Hold the Rocket in reset for the whole load; release its uncore,
+	 * which is what maps its SRAM into this address space at all. Read the
+	 * register back before using that mapping: the write is posted, and
+	 * the reference bring-up likewise confirms the bit cleared rather than
+	 * assuming it.
+	 */
+	sys_write32(tt_d2d_cpu_ctrl(false), config->base + TT_D2D_CPU_CTRL_OFFSET);
+	ctrl.val = sys_read32(config->base + TT_D2D_CPU_CTRL_OFFSET);
+	if (ctrl.f.uncore_reset != 0) {
+		LOG_ERR("%s: uncore still in reset (cpu_ctrl 0x%08x); SRAM is not mapped",
+			dev->name, ctrl.val);
+		return -ENODEV;
+	}
+
+	/*
+	 * One word before committing to the full image. Without this a tile
+	 * that is not responding at all fails identically to a corrupted load,
+	 * except 64 KB later and with a message that points at the image.
+	 */
+	sys_write32(TT_D2D_PROBE_PATTERN, sram);
+	probe = sys_read32(sram);
+	if (probe != TT_D2D_PROBE_PATTERN) {
+		LOG_ERR("%s: SRAM at 0x%lx not responding (wrote 0x%08x read 0x%08x); "
+			"tile unreachable -- check cold reset and SMC firewalls",
+			dev->name, (unsigned long)sram, TT_D2D_PROBE_PATTERN, probe);
+		return -ENODEV;
+	}
+
+	/*
+	 * Clear the whole window, not just the image: the firmware's .bss lives
+	 * here and nothing else zeroes it, and it also drops any stale config
+	 * block from a previous load.
+	 */
+	ret = tt_d2d_clear_sram(dev, sram);
+	if (ret != 0) {
+		LOG_ERR("%s: clearing SRAM failed: %d", dev->name, ret);
+		return ret;
+	}
+
+	ret = tt_d2d_copy_image(dev, sram, img, img_size);
+	if (ret != 0) {
+		LOG_ERR("%s: copying the image failed: %d", dev->name, ret);
+		return ret;
+	}
+
+	if (IS_ENABLED(CONFIG_TT_D2D_VERIFY_LOAD)) {
+		for (size_t off = 0; off < img_size; off += sizeof(uint32_t)) {
+			uint32_t want = sys_get_le32(&img[off]);
+			uint32_t got = sys_read32(sram + off);
+
+			if (got != want) {
+				LOG_ERR("%s: image mismatch at +0x%zx: wrote 0x%08x read 0x%08x",
+					dev->name, off, want, got);
+				return -EIO;
+			}
+		}
+	}
+
+	tt_d2d_write_config(dev);
+
+	LOG_DBG("%s: loaded %zu bytes, Rocket held in reset", dev->name, img_size);
+
+	return 0;
+}
+
+int tt_d2d_start(const struct device *dev)
+{
+	const struct tt_d2d_config *config = dev->config;
+
+	sys_write32(tt_d2d_cpu_ctrl(true), config->base + TT_D2D_CPU_CTRL_OFFSET);
+
+	LOG_DBG("%s: Rocket released", dev->name);
+
+	return 0;
+}
+
+static int tt_d2d_init(const struct device *dev)
+{
+	const struct tt_d2d_config *config = dev->config;
+
+	/*
+	 * No hardware is touched here. Reset release has to be ordered against
+	 * the CCE clock switch, which this driver knows nothing about, so it is
+	 * left to the caller.
+	 */
+	if (config->sram_size < TT_D2D_CFG_END) {
+		LOG_ERR("%s: sram-size 0x%x is too small to hold the config block, which ends at "
+			"0x%x",
+			dev->name, config->sram_size, TT_D2D_CFG_END);
+		return -EINVAL;
+	}
+
+	if ((config->sram_size % sizeof(uint32_t)) != 0U) {
+		LOG_ERR("%s: sram-size 0x%x is not a multiple of 4 bytes", dev->name,
+			config->sram_size);
+		return -EINVAL;
+	}
+
+	if (config->dma_dev != NULL && !device_is_ready(config->dma_dev)) {
+		LOG_ERR("%s: DMA controller %s is not ready", dev->name, config->dma_dev->name);
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+/*
+ * dmas is optional, so the phandle can only be dereferenced when it is there.
+ */
+#define TT_D2D_DMA_DEV(inst)                                                                       \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, dmas),                                             \
+		    (DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_IDX(inst, 0))), (NULL))
+
+#define TT_D2D_DMA_CHANNEL(inst)                                                                   \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, dmas),                                             \
+		    (DT_INST_DMAS_CELL_BY_IDX(inst, 0, channel)), (0))
+
+#define TT_D2D_INIT(inst)                                                                          \
+	static const struct tt_d2d_config tt_d2d_config_##inst = {                                 \
+		.base = DT_INST_REG_ADDR(inst),                                                    \
+		.dma_dev = TT_D2D_DMA_DEV(inst),                                                   \
+		.dma_channel = TT_D2D_DMA_CHANNEL(inst),                                           \
+		.sram_size = DT_INST_PROP(inst, sram_size),                                        \
+		.bits_per_channel = DT_INST_PROP(inst, bits_per_channel),                          \
+		.refclk_period_ns = DT_INST_PROP(inst, refclk_period_ns),                          \
+		.apb_clk_period_ps = DT_INST_PROP(inst, apb_clk_period_ps),                        \
+		.pll_freq_ghz = DT_INST_PROP(inst, pll_freq_ghz),                                  \
+		.package_type_this_die = DT_INST_PROP(inst, package_type_this_die),                \
+		.package_type_other_die = DT_INST_PROP(inst, package_type_other_die),              \
+		.bypass_phy = DT_INST_PROP(inst, bypass_phy),                                      \
+		.bypass_vreg = DT_INST_PROP(inst, bypass_vreg),                                    \
+		.disable_sideband = DT_INST_PROP(inst, disable_sideband),                          \
+	};                                                                                         \
+                                                                                                   \
+	DEVICE_DT_INST_DEFINE(inst, tt_d2d_init, NULL, NULL, &tt_d2d_config_##inst, POST_KERNEL,   \
+			      CONFIG_TT_D2D_INIT_PRIO, NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(TT_D2D_INIT)

--- a/dts/bindings/misc/tenstorrent,grendel-d2d.yaml
+++ b/dts/bindings/misc/tenstorrent,grendel-d2d.yaml
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Tenstorrent Grendel die-to-die (D2D) tile.
+
+  Each tile contains a Rocket CPU that runs the D2D link firmware. Before the
+  link can train, that firmware has to be written into the Rocket's SRAM, a
+  configuration block has to be filled in for it, and the Rocket has to be
+  released from reset.
+
+  The CPU control register and the Rocket SRAM both live at fixed offsets
+  inside the tile's register map, so a single reg entry describes the tile and
+  the driver derives the rest.
+
+  Chiplets differ in tile count and base address (Mimir has two, Keraunos has
+  five), so these nodes belong in chiplet-specific devicetree rather than the
+  shared Grendel SoC include.
+
+compatible: "tenstorrent,grendel-d2d"
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  dmas:
+    type: phandle-array
+    description: |
+      Optional DMA channel used to zero the SRAM window and copy the image
+      into it. Without it the driver writes both with CPU stores, which is
+      correct but issues one bus transaction per word: a 64 KB window plus a
+      27 KB image is around 23000 of them, and under emulation that is slow
+      enough to matter. The reference bring-up uses DMA for exactly this.
+
+  dma-names:
+    description: Name for the channel in dmas. Only the first entry is used.
+
+  sram-size:
+    type: int
+    default: 65536
+    description: |
+      Size in bytes of the SRAM belonging to this D2D tile's own Rocket core,
+      which is where the D2D firmware runs. Not SMC memory. This describes the
+      tile, not the image: every tile runs the same firmware, but the window it
+      is loaded into is per-chiplet hardware. The whole window is zeroed before
+      a load, it has to be large enough to hold the configuration block, and
+      images that would not fit in it are rejected.
+
+  bits-per-channel:
+    type: int
+    default: 16
+    description: Link width reported to the D2D firmware.
+
+  refclk-period-ns:
+    type: int
+    default: 10
+    description: Reference clock period in nanoseconds.
+
+  apb-clk-period-ps:
+    type: int
+    default: 1000
+    description: APB clock period in picoseconds.
+
+  pll-freq-ghz:
+    type: int
+    default: 4
+    description: Target D2D PLL frequency in GHz.
+
+  package-type-this-die:
+    type: int
+    default: 11
+    description: |
+      Package type code for the die this SMC runs on. The D2D firmware knows
+      these as STANDARD_PACKAGE (11), which is the standard Grendel package
+      and the default here, and ADVANCED_PACKAGE (10).
+
+  package-type-other-die:
+    type: int
+    default: 11
+    description: |
+      Package type code for the die on the far end of the link. Same encoding
+      as package-type-this-die.
+
+  bypass-phy:
+    type: boolean
+    description: |
+      Tell the D2D firmware to skip PHY bring-up. Required on emulation, where
+      the PHY lanes are force-wired in the testbench instead of being trained.
+
+  bypass-vreg:
+    type: boolean
+    description: |
+      Tell the D2D firmware to skip voltage regulator bring-up. Required on
+      emulation, which has no regulator model.
+
+  disable-sideband:
+    type: boolean
+    description: |
+      Tell the D2D firmware to skip sideband die-to-die synchronisation.
+      Required on emulation, where the sideband milestones are stubbed out.

--- a/dts/vendor/tenstorrent/tt_mimir_d2d.dtsi
+++ b/dts/vendor/tenstorrent/tt_mimir_d2d.dtsi
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	soc {
+		d2d0: d2d@4200000 {
+			compatible = "tenstorrent,grendel-d2d";
+			reg = <0x0 0x04200000 0x0 0x00180158>;
+			status = "disabled";
+		};
+
+		d2d1: d2d@4400000 {
+			compatible = "tenstorrent,grendel-d2d";
+			reg = <0x0 0x04400000 0x0 0x00180158>;
+			status = "disabled";
+		};
+	};
+};

--- a/include/zephyr/drivers/misc/tt_d2d.h
+++ b/include/zephyr/drivers/misc/tt_d2d.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_MISC_TT_D2D_H_
+#define ZEPHYR_INCLUDE_DRIVERS_MISC_TT_D2D_H_
+
+/**
+ * @file
+ * @brief Tenstorrent Grendel die-to-die (D2D) firmware loading APIs
+ *
+ * Bringing a D2D link up takes three steps, kept separate because each has to
+ * be sequenced against work this driver does not own:
+ *
+ *   1. tt_d2d_reset_release() - deassert the tile's subsystem resets. Must
+ *      happen before the CCE clock switches to the PLL, because the D2D logic
+ *      samples its straps at the clock rate in effect at the time.
+ *   2. tt_d2d_load_fw()       - put firmware in the Rocket's SRAM and fill in
+ *      its configuration block. Leaves the Rocket in reset.
+ *   3. tt_d2d_start()         - release the Rocket so the firmware runs.
+ *
+ * Step 3 is deliberately not folded into step 2. Both ends of a link must be
+ * started close together, and with sideband synchronisation disabled (as it is
+ * under emulation) there is nothing in hardware to make that happen: starting
+ * each Rocket as soon as its own image landed has been observed to leave
+ * Keraunos and the far Mimir unable to train. The caller is expected to load
+ * every tile first and start them as a group.
+ *
+ * Two things have to be true before any of this works, and neither is done
+ * here because neither belongs to a single tile:
+ *
+ *   - the SMC cold resets covering the tile and its interconnect must be
+ *     lifted, and
+ *   - the SMC inbound/outbound filters must permit the tile's address range.
+ *
+ * Until both hold, the tile does not answer at all and tt_d2d_load_fw() will
+ * fail its reachability probe with -ENODEV rather than appearing to succeed.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/device.h>
+
+/**
+ * @brief Deassert a D2D tile's subsystem resets.
+ *
+ * Brings the tile's NOC, APB, system, link-layer, AXI and QNP resets out one
+ * at a time, in the order the hardware requires. Until this runs the tile does
+ * not reliably answer accesses, so it must precede tt_d2d_load_fw().
+ *
+ * @param dev D2D tile device
+ *
+ * @retval 0 on success
+ */
+int tt_d2d_reset_release(const struct device *dev);
+
+/**
+ * @brief Load firmware into a D2D tile, leaving it halted.
+ *
+ * Holds the tile's Rocket in reset, clears its SRAM, copies @p img in,
+ * optionally reads it back to confirm it landed, and writes the configuration
+ * block the firmware reads at startup. Call tt_d2d_start() to run it.
+ *
+ * @param dev D2D tile device
+ * @param img Firmware image
+ * @param img_size Size of @p img in bytes. Must be a multiple of 4 and must
+ *                 leave the configuration block at the top of SRAM untouched.
+ *
+ * @retval 0 on success
+ * @retval -EINVAL if @p img is NULL, empty, or not a multiple of 4 bytes
+ * @retval -ENOSPC if @p img would overrun the configuration block
+ * @retval -ENODEV if the tile does not answer a write to its SRAM
+ * @retval -EIO if the image read back from SRAM does not match @p img
+ */
+int tt_d2d_load_fw(const struct device *dev, const uint8_t *img, size_t img_size);
+
+/**
+ * @brief Release a D2D tile's Rocket so loaded firmware begins executing.
+ *
+ * @param dev D2D tile device
+ *
+ * @retval 0 on success
+ */
+int tt_d2d_start(const struct device *dev);
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_MISC_TT_D2D_H_ */

--- a/soc/tenstorrent/tt_grendel/tt_grendel_smc/tc_util_user_override.h
+++ b/soc/tenstorrent/tt_grendel/tt_grendel_smc/tc_util_user_override.h
@@ -7,9 +7,12 @@
 
 #include <stdint.h>
 
-#define TEST_PASS_VALUE 0xacafaca1
+/* For WRITE_SCRATCH. Defining it here as well would collide with soc.h in any
+ * test that uses the scratch registers for its own reporting.
+ */
+#include <soc.h>
 
-#define WRITE_SCRATCH(num, val) (*(((volatile uint32_t *)0xC0010100) + (num * 2)) = (val))
+#define TEST_PASS_VALUE 0xacafaca1
 
 /*
  * Override ztest's testcase end report macro. We should still report

--- a/tests/drivers/tt_d2d/CMakeLists.txt
+++ b/tests/drivers/tt_d2d/CMakeLists.txt
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+# By default the test stands in a generated image of its own. The real D2D
+# firmware arrives in the Sival drop and is not in this tree.
+#
+# Pass -DD2D_FW_BIN=<path> to run against the real image instead.
+if(D2D_FW_BIN)
+  set(D2D_FW_BLOB_FILE "${D2D_FW_BIN}")
+
+  if(NOT IS_ABSOLUTE "${D2D_FW_BLOB_FILE}")
+    set(D2D_FW_BLOB_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${D2D_FW_BLOB_FILE}")
+  endif()
+
+  if(NOT EXISTS "${D2D_FW_BLOB_FILE}")
+    message(FATAL_ERROR
+            "D2D_FW_BIN names no such file:\n  ${D2D_FW_BLOB_FILE}\n"
+            "The image ships in the Sival tarball drop.")
+  endif()
+
+  # tt_d2d_load_fw() copies the image a word at a time and rejects a length
+  # that is not a multiple of four. Catching that here names the offending
+  # file; left to run time it is an -EINVAL from a call whose arguments look
+  # fine.
+  file(SIZE "${D2D_FW_BLOB_FILE}" d2d_fw_blob_size)
+  math(EXPR d2d_fw_blob_tail "${d2d_fw_blob_size} % 4")
+  if(NOT d2d_fw_blob_tail EQUAL 0)
+    message(FATAL_ERROR
+            "D2D firmware image is ${d2d_fw_blob_size} bytes, which is not a "
+            "multiple of 4 and cannot be loaded:\n  ${D2D_FW_BLOB_FILE}")
+  endif()
+else()
+  set(D2D_FW_STUB_UNIT "TT-D2D-FW-STUB..")
+  set(D2D_FW_STUB_REPEAT 16)
+  set(D2D_FW_BLOB_FILE "${CMAKE_CURRENT_BINARY_DIR}/d2d_fw_stub.bin")
+
+  string(REPEAT "${D2D_FW_STUB_UNIT}" ${D2D_FW_STUB_REPEAT} d2d_fw_stub_bytes)
+  file(WRITE "${D2D_FW_BLOB_FILE}" "${d2d_fw_stub_bytes}")
+endif()
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(tt_d2d)
+
+target_sources(app PRIVATE src/main.c src/chip_init.c src/d2d_fw_blob.c)
+
+# Turns the image into byte initialisers for d2d_fw_blob.c to include. The
+# generated file depends on the image, so a new drop rebuilds it.
+set(gen_dir ${ZEPHYR_BINARY_DIR}/misc/generated)
+generate_inc_file_for_target(app "${D2D_FW_BLOB_FILE}" ${gen_dir}/d2d_fw.inc)
+target_include_directories(app PRIVATE ${gen_dir})
+
+# So the test checks the image it generated rather than a copy of the pattern
+# that could drift from it. Absent when running against a real image, whose
+# contents the test has no business asserting.
+if(D2D_FW_STUB_UNIT)
+  target_compile_definitions(app PRIVATE
+                             D2D_FW_STUB_UNIT="${D2D_FW_STUB_UNIT}"
+                             D2D_FW_STUB_REPEAT=${D2D_FW_STUB_REPEAT})
+endif()
+
+# chip_init.c calls the drop's basic_init library rather than restating the
+# reset and firewall sequence, so the test needs the Sival SDK. The SDK is
+# closed source and not carried in this tree; without the tarball the test does
+# not build.
+set(SIVAL_EXTDIR ${CMAKE_BINARY_DIR}/grendel-sival-sdk)
+set(SIVAL_BLOBS_TARBALL
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../zephyr/blobs/grendel-sival-sdk.tar.gz)
+
+if(NOT EXISTS "${SIVAL_BLOBS_TARBALL}")
+  message(FATAL_ERROR
+          "The Sival SDK drop is missing:\n  ${SIVAL_BLOBS_TARBALL}\n"
+          "It is closed source and distributed separately.")
+endif()
+
+file(MAKE_DIRECTORY ${SIVAL_EXTDIR})
+execute_process(COMMAND tar -xzf ${SIVAL_BLOBS_TARBALL}
+  WORKING_DIRECTORY ${SIVAL_EXTDIR}
+)
+
+set(SIVAL_SDK ${SIVAL_EXTDIR}/grendel_sival_sdk)
+target_include_directories(app PRIVATE
+                           ${SIVAL_SDK}/common/include/registers
+                           ${SIVAL_SDK}/common/include/registers/common
+                           ${SIVAL_SDK}/common/include/registers/mimir
+                           ${SIVAL_SDK}/firmware/chiplet_config
+                           ${SIVAL_SDK}/firmware/common/include
+                           ${SIVAL_SDK}/firmware/drivers/addr_remap/include
+                           ${SIVAL_SDK}/firmware/drivers/firewall/include
+                           ${SIVAL_SDK}/firmware/drivers/noc/include
+                           ${SIVAL_SDK}/firmware/drivers/smc/include
+                           ${SIVAL_SDK}/firmware/libs/basic_init/include)
+
+target_sources(app PRIVATE
+               ${SIVAL_SDK}/firmware/drivers/firewall/src/firewall.c
+               ${SIVAL_SDK}/firmware/drivers/smc/src/smc_init.c
+               ${SIVAL_SDK}/firmware/libs/basic_init/src/basic_init.c)

--- a/tests/drivers/tt_d2d/app.overlay
+++ b/tests/drivers/tt_d2d/app.overlay
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * d2d0 carries the emulation bypasses and d2d1 deliberately does not, so the
+ * test can tell the flags are coming from devicetree rather than being applied
+ * unconditionally by the driver.
+ *
+ * The split is reused for the transfer path: only d2d0 names a DMA channel, so
+ * a run exercises both the DMA route and the CPU-store fallback and the two
+ * have to agree on what ends up in SRAM.
+ */
+
+&d2d0 {
+	status = "okay";
+	dmas = <&dma0 0>;
+	dma-names = "fw";
+	bypass-phy;
+	bypass-vreg;
+	disable-sideband;
+};
+
+&d2d1 {
+	status = "okay";
+};

--- a/tests/drivers/tt_d2d/prj.conf
+++ b/tests/drivers/tt_d2d/prj.conf
@@ -1,0 +1,13 @@
+CONFIG_TT_D2D=y
+# d2d0 loads over DMA, d2d1 over CPU stores, so a run covers both paths.
+CONFIG_DMA=y
+CONFIG_LOG=y
+CONFIG_TT_D2D_LOG_LEVEL_DBG=y
+CONFIG_TEST=y
+CONFIG_ZTEST=y
+# Makes a passing suite write 0xACAFACA1 to scratch[0] as well as reporting on
+# the console. Emulation has no console reader, so without this a run that
+# passes is indistinguishable from one that never finished.
+CONFIG_ZTEST_TC_UTIL_USER_OVERRIDE=y
+# VDK simulation does not support programming the PMP with stack protection
+CONFIG_TEST_HW_STACK_PROTECTION=n

--- a/tests/drivers/tt_d2d/src/chip_init.c
+++ b/tests/drivers/tt_d2d/src/chip_init.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * What mimir_init() in the Sival drop does before it goes near a D2D tile,
+ * called out of the drop's own basic_init library rather than restated here:
+ * lift the cold resets covering the tiles and their interconnect, then open
+ * the SMC and ITN firewall filters.
+ */
+
+#include <errno.h>
+
+#include <basic_init.h>
+
+#include "chip_init.h"
+
+int tt_d2d_test_chip_init(void)
+{
+	grendel_err_t err;
+
+	smc_release_reset(MIMIR_RST_SMN | MIMIR_RST_ITN | MIMIR_RST_D2D0 | MIMIR_RST_D2D1);
+
+	err = disable_all_mimir_firewall_filters();
+	if (err != GRENDEL_ERR_OK) {
+		return -EIO;
+	}
+
+	return 0;
+}

--- a/tests/drivers/tt_d2d/src/chip_init.h
+++ b/tests/drivers/tt_d2d/src/chip_init.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TT_D2D_TEST_CHIP_INIT_H_
+#define TT_D2D_TEST_CHIP_INIT_H_
+
+/**
+ * @brief Make the D2D tiles reachable from this SMC.
+ *
+ * Lifts the subsystem cold resets covering the D2D tiles and their
+ * interconnect, then opens the SMC and ITN firewall filters. Both are
+ * prerequisites of tt_d2d_load_fw() and neither belongs to the D2D driver:
+ * they are chip-wide, and in a shipping system BL1 will have done them long
+ * before any tile is loaded. The test does them itself so it can run
+ * standalone.
+ *
+ * @return 0 on success, -EIO if the drop rejected a filter configuration.
+ */
+int tt_d2d_test_chip_init(void);
+
+#endif /* TT_D2D_TEST_CHIP_INIT_H_ */

--- a/tests/drivers/tt_d2d/src/d2d_fw_blob.c
+++ b/tests/drivers/tt_d2d/src/d2d_fw_blob.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Embeds an image in the test so it has something to hand tt_d2d_load_fw().
+ * This lives here rather than beside the driver on purpose: a production image
+ * gets the firmware as its own bundle entry and passes the driver a pointer to
+ * it, so nothing under drivers/ should be able to embed it.
+ *
+ * d2d_fw.inc holds the image named by this test's CMakeLists, as a list of
+ * byte initialisers.
+ */
+
+#include <zephyr/toolchain.h>
+
+#include "d2d_fw_blob.h"
+
+/* tt_d2d_load_fw() reads the image with 32-bit loads. */
+static const uint8_t d2d_fw_bin[] __aligned(sizeof(uint32_t)) = {
+#include "d2d_fw.inc"
+};
+
+const uint8_t *d2d_fw_image(size_t *size)
+{
+	if (size != NULL) {
+		*size = sizeof(d2d_fw_bin);
+	}
+
+	return d2d_fw_bin;
+}

--- a/tests/drivers/tt_d2d/src/d2d_fw_blob.h
+++ b/tests/drivers/tt_d2d/src/d2d_fw_blob.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef TESTS_DRIVERS_TT_D2D_D2D_FW_BLOB_H_
+#define TESTS_DRIVERS_TT_D2D_D2D_FW_BLOB_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @brief Get the D2D firmware image embedded in this test.
+ *
+ * @param[out] size Length of the image in bytes, or NULL if not wanted
+ *
+ * @return Pointer to the image, suitable for passing to tt_d2d_load_fw()
+ */
+const uint8_t *d2d_fw_image(size_t *size);
+
+#endif /* TESTS_DRIVERS_TT_D2D_D2D_FW_BLOB_H_ */

--- a/tests/drivers/tt_d2d/src/main.c
+++ b/tests/drivers/tt_d2d/src/main.c
@@ -1,0 +1,504 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/ztest.h>
+
+#include <soc.h>
+
+#include <zephyr/drivers/misc/tt_d2d.h>
+
+#include "chip_init.h"
+#include "d2d_fw_blob.h"
+
+/*
+ * Mirrors of the driver's private layout. Duplicated on purpose: the test is
+ * checking that the driver puts things at these offsets, so sharing a header
+ * would let both drift together without failing.
+ */
+#define SRAM_OFFSET     0x2000U
+#define CPU_CTRL_OFFSET 0x1800U
+#define VERSION_OFFSET  0x1014U
+#define CFG_OFFSET      0xFCC0U
+#define IMAGE_MAX       CFG_OFFSET
+
+#define CFG_MAGIC_VALUE 0x1234BEAFU
+#define CPU_CTRL_HALT   0x00010001U
+#define CPU_CTRL_START  0x00010000U
+#define PROBE_PATTERN   0xD2D0F00DU
+
+#define CFG_IDX_MAGIC            0U
+#define CFG_IDX_BITS_PER_CHANNEL 1U
+#define CFG_IDX_PLL_FREQ_GHZ     4U
+#define CFG_IDX_BYPASS_VREG      7U
+#define CFG_IDX_BYPASS_PHY       17U
+#define CFG_IDX_DISABLE_SIDEBAND 18U
+
+#define D2D0_NODE DT_NODELABEL(d2d0)
+#define D2D1_NODE DT_NODELABEL(d2d1)
+
+static const struct device *const d2d0 = DEVICE_DT_GET(D2D0_NODE);
+static const struct device *const d2d1 = DEVICE_DT_GET(D2D1_NODE);
+
+#define D2D0_BASE DT_REG_ADDR(D2D0_NODE)
+#define D2D1_BASE DT_REG_ADDR(D2D1_NODE)
+
+/* Word i is distinguishable from both zero and its own offset. */
+#define IMAGE_WORDS 64U
+static uint32_t test_image[IMAGE_WORDS];
+
+static uint32_t cfg_read(uintptr_t base, uint32_t index)
+{
+	return sys_read32(base + SRAM_OFFSET + CFG_OFFSET + (index * sizeof(uint32_t)));
+}
+
+/*
+ * The only thing visible from the host while the tests run are the scratch registers
+ * which the harness prints on every poll.
+ * Each step publishes which test it is in and how far it got, so a run that stops
+ * responding names the call it stopped in instead of just failing to reach the
+ * pass token. scratch[4] carries the value the step just produced for example a
+ * driver return code.
+ *
+ * The tag makes step 0 distinguishable from a scratch register nobody has
+ * written yet.
+ */
+#define STEP(test, step) WRITE_SCRATCH(3, 0xB0000000U | ((test) << 8) | (step))
+#define STEP_RESULT(val) WRITE_SCRATCH(4, (uint32_t)(val))
+
+#define T_SETUP  0x00U
+#define T_IMAGE  0x10U
+#define T_CLEAR  0x20U
+#define T_CONFIG 0x30U
+#define T_BYPASS 0x40U
+#define T_ARGS   0x50U
+#define T_START  0x60U
+#define T_BLOB   0x70U
+#define T_EXEC   0x80U
+
+/*
+ * A failing assertion ends its test but not the suite, and the suite's pass
+ * token is only written if every test passed -- so without this a run with one
+ * broken test is indistinguishable from a run with six. Each test sets its bit
+ * on the way out; whatever is missing at the end failed.
+ */
+static uint32_t passed_mask;
+
+#define PASSED(bit)                                                                                \
+	do {                                                                                       \
+		passed_mask |= BIT(bit);                                                           \
+		WRITE_SCRATCH(1, 0xA5000000U | passed_mask);                                       \
+	} while (0)
+
+#define P_IMAGE  0
+#define P_CLEAR  1
+#define P_CONFIG 2
+#define P_BYPASS 3
+#define P_ARGS   4
+#define P_START  5
+#define P_BLOB   6
+#define P_EXEC   7
+
+static void *tt_d2d_setup(void)
+{
+	for (uint32_t i = 0; i < IMAGE_WORDS; i++) {
+		test_image[i] = 0xD2D00000U + i;
+	}
+
+	STEP(T_SETUP, 1);
+	zassert_true(device_is_ready(d2d0), "d2d0 not ready");
+	zassert_true(device_is_ready(d2d1), "d2d1 not ready");
+
+	/* Without this the tiles do not answer and every load fails -ENODEV. */
+	STEP(T_SETUP, 2);
+	zassert_ok(tt_d2d_test_chip_init(), "chip init failed");
+
+	STEP(T_SETUP, 3);
+	zassert_ok(tt_d2d_reset_release(d2d0), "d2d0 reset release failed");
+	STEP(T_SETUP, 4);
+	zassert_ok(tt_d2d_reset_release(d2d1), "d2d1 reset release failed");
+
+	/*
+	 * Walk d2d0 by hand up to the point tt_d2d_load_fw() starts from, and
+	 * leave each answer in its own scratch register rather than the shared
+	 * step result, so all three survive to the end of the run. A load that
+	 * wedges is then attributable: if these three are right, the tile was
+	 * reachable and the driver lost it later.
+	 *
+	 * d2d_version is read-only and valid with the Rocket still in reset,
+	 * which is what the reference bring-up checks first; cpu_ctrl confirms
+	 * uncore reset actually cleared; the SRAM word confirms the window that
+	 * clearing opens is writable.
+	 */
+	STEP(T_SETUP, 5);
+	WRITE_SCRATCH(5, sys_read32(D2D0_BASE + VERSION_OFFSET));
+
+	STEP(T_SETUP, 6);
+	sys_write32(CPU_CTRL_HALT, D2D0_BASE + CPU_CTRL_OFFSET);
+	STEP(T_SETUP, 7);
+	WRITE_SCRATCH(6, sys_read32(D2D0_BASE + CPU_CTRL_OFFSET));
+
+	STEP(T_SETUP, 8);
+	sys_write32(PROBE_PATTERN, D2D0_BASE + SRAM_OFFSET);
+	STEP(T_SETUP, 9);
+	WRITE_SCRATCH(7, sys_read32(D2D0_BASE + SRAM_OFFSET));
+
+	STEP(T_SETUP, 10);
+
+	return NULL;
+}
+
+ZTEST(tt_d2d, test_load_writes_image)
+{
+	int ret;
+
+	STEP(T_IMAGE, 1);
+	ret = tt_d2d_load_fw(d2d0, (const uint8_t *)test_image, sizeof(test_image));
+	STEP(T_IMAGE, 2);
+	STEP_RESULT(ret);
+	zassert_ok(ret);
+
+	STEP(T_IMAGE, 3);
+	for (uint32_t i = 0; i < IMAGE_WORDS; i++) {
+		uint32_t got = sys_read32(D2D0_BASE + SRAM_OFFSET + (i * sizeof(uint32_t)));
+
+		STEP_RESULT(got);
+		zassert_equal(got, test_image[i], "word %u: expected 0x%08x got 0x%08x", i,
+			      test_image[i], got);
+	}
+
+	PASSED(P_IMAGE);
+}
+
+ZTEST(tt_d2d, test_load_clears_sram_beyond_image)
+{
+	/* Dirty a word past the image so a load that only writes the image
+	 * itself, without clearing, would leave it behind.
+	 */
+	uintptr_t stale = D2D0_BASE + SRAM_OFFSET + sizeof(test_image);
+	int ret;
+
+	STEP(T_CLEAR, 1);
+	sys_write32(0xDEADBEEF, stale);
+
+	STEP(T_CLEAR, 2);
+	ret = tt_d2d_load_fw(d2d0, (const uint8_t *)test_image, sizeof(test_image));
+	STEP(T_CLEAR, 3);
+	STEP_RESULT(ret);
+	zassert_ok(ret);
+
+	STEP(T_CLEAR, 4);
+	STEP_RESULT(sys_read32(stale));
+	zassert_equal(sys_read32(stale), 0, "SRAM past the image was not cleared");
+
+	PASSED(P_CLEAR);
+}
+
+ZTEST(tt_d2d, test_load_writes_config_block)
+{
+	int ret;
+
+	STEP(T_CONFIG, 1);
+	ret = tt_d2d_load_fw(d2d0, (const uint8_t *)test_image, sizeof(test_image));
+	STEP(T_CONFIG, 2);
+	STEP_RESULT(ret);
+	zassert_ok(ret);
+
+	STEP(T_CONFIG, 3);
+	STEP_RESULT(cfg_read(D2D0_BASE, CFG_IDX_MAGIC));
+	zassert_equal(cfg_read(D2D0_BASE, CFG_IDX_MAGIC), CFG_MAGIC_VALUE,
+		      "config magic missing; firmware would ignore the block");
+
+	STEP(T_CONFIG, 4);
+	STEP_RESULT(cfg_read(D2D0_BASE, CFG_IDX_BITS_PER_CHANNEL));
+	zassert_equal(cfg_read(D2D0_BASE, CFG_IDX_BITS_PER_CHANNEL),
+		      DT_PROP(D2D0_NODE, bits_per_channel));
+
+	STEP(T_CONFIG, 5);
+	STEP_RESULT(cfg_read(D2D0_BASE, CFG_IDX_PLL_FREQ_GHZ));
+	zassert_equal(cfg_read(D2D0_BASE, CFG_IDX_PLL_FREQ_GHZ), DT_PROP(D2D0_NODE, pll_freq_ghz));
+
+	PASSED(P_CONFIG);
+}
+
+ZTEST(tt_d2d, test_bypass_flags_follow_devicetree)
+{
+	int ret;
+
+	STEP(T_BYPASS, 1);
+	ret = tt_d2d_load_fw(d2d0, (const uint8_t *)test_image, sizeof(test_image));
+	STEP(T_BYPASS, 2);
+	STEP_RESULT(ret);
+	zassert_ok(ret);
+
+	STEP(T_BYPASS, 3);
+	ret = tt_d2d_load_fw(d2d1, (const uint8_t *)test_image, sizeof(test_image));
+	STEP(T_BYPASS, 4);
+	STEP_RESULT(ret);
+	zassert_ok(ret);
+
+	/* d2d0 sets all three bypasses in the overlay, d2d1 sets none. */
+	STEP(T_BYPASS, 5);
+	STEP_RESULT(cfg_read(D2D0_BASE, CFG_IDX_BYPASS_PHY));
+	zassert_equal(cfg_read(D2D0_BASE, CFG_IDX_BYPASS_PHY), 1);
+	zassert_equal(cfg_read(D2D0_BASE, CFG_IDX_BYPASS_VREG), 1);
+	zassert_equal(cfg_read(D2D0_BASE, CFG_IDX_DISABLE_SIDEBAND), 1);
+
+	STEP(T_BYPASS, 6);
+	STEP_RESULT(cfg_read(D2D1_BASE, CFG_IDX_BYPASS_PHY));
+	zassert_equal(cfg_read(D2D1_BASE, CFG_IDX_BYPASS_PHY), 0);
+	zassert_equal(cfg_read(D2D1_BASE, CFG_IDX_BYPASS_VREG), 0);
+	zassert_equal(cfg_read(D2D1_BASE, CFG_IDX_DISABLE_SIDEBAND), 0);
+
+	PASSED(P_BYPASS);
+}
+
+ZTEST(tt_d2d, test_load_rejects_bad_arguments)
+{
+	STEP(T_ARGS, 1);
+	zassert_equal(tt_d2d_load_fw(d2d0, NULL, sizeof(test_image)), -EINVAL, "NULL image");
+	zassert_equal(tt_d2d_load_fw(d2d0, (const uint8_t *)test_image, 0), -EINVAL, "empty image");
+	zassert_equal(tt_d2d_load_fw(d2d0, (const uint8_t *)test_image, 6), -EINVAL,
+		      "image length not a multiple of 4");
+
+	/* Size is validated before the buffer is read, so a short buffer with an
+	 * oversized length is safe and avoids allocating 64 KB in the test.
+	 */
+	zassert_equal(tt_d2d_load_fw(d2d0, (const uint8_t *)test_image, IMAGE_MAX + 4), -ENOSPC,
+		      "image overlapping the config block");
+
+	PASSED(P_ARGS);
+}
+
+ZTEST(tt_d2d, test_load_halts_and_start_releases)
+{
+	int ret;
+
+	STEP(T_START, 1);
+	ret = tt_d2d_load_fw(d2d0, (const uint8_t *)test_image, sizeof(test_image));
+	STEP(T_START, 2);
+	STEP_RESULT(ret);
+	zassert_ok(ret);
+
+	STEP(T_START, 3);
+	STEP_RESULT(sys_read32(D2D0_BASE + CPU_CTRL_OFFSET));
+	zassert_equal(sys_read32(D2D0_BASE + CPU_CTRL_OFFSET), CPU_CTRL_HALT,
+		      "Rocket should still be in reset after a load");
+
+	STEP(T_START, 4);
+	zassert_ok(tt_d2d_start(d2d0));
+	STEP(T_START, 5);
+	STEP_RESULT(sys_read32(D2D0_BASE + CPU_CTRL_OFFSET));
+	/* Only that core reset was deasserted. Whether the Rocket then fetched
+	 * anything is test_started_firmware_executes' business; this readback
+	 * looks the same either way.
+	 */
+	zassert_equal(sys_read32(D2D0_BASE + CPU_CTRL_OFFSET), CPU_CTRL_START,
+		      "start did not clear core reset");
+
+	PASSED(P_START);
+}
+
+/*
+ * The firmware image is not compiled into the driver: it is a separate file,
+ * embedded by this test and handed to the loader as a plain buffer. This is
+ * the whole of that path, from the generated initialisers through to SRAM, so
+ * a drop that lands truncated fails here rather than as a link that will not
+ * train much later.
+ *
+ * The image under test is this test's generated stand-in, not the real
+ * firmware; what is being checked is the mechanism carrying it.
+ */
+ZTEST(tt_d2d, test_linked_fw_image_loads)
+{
+	const uint8_t *img;
+	size_t size = 0;
+	int ret;
+
+	STEP(T_BLOB, 1);
+	img = d2d_fw_image(&size);
+	STEP_RESULT(size);
+	zassert_not_null(img, "no image linked in");
+	zassert_true(size > 0, "linked image is empty");
+	zassert_equal(size % sizeof(uint32_t), 0, "image of %zu bytes is not word-sized", size);
+	zassert_true(size <= IMAGE_MAX, "image of %zu bytes overlaps the config block", size);
+
+#ifdef D2D_FW_STUB_UNIT
+	/* Only the generated stub has contents this test can predict, and
+	 * checking them confirms the bytes are the file's rather than zeroes
+	 * from a section that was allocated but never filled.
+	 */
+	{
+		static const char unit[] = D2D_FW_STUB_UNIT;
+		const size_t unit_len = sizeof(unit) - 1;
+
+		zassert_equal(size, unit_len * D2D_FW_STUB_REPEAT, "stub is %zu bytes", size);
+
+		STEP(T_BLOB, 2);
+		for (size_t i = 0; i < size; i++) {
+			STEP_RESULT(img[i]);
+			zassert_equal(img[i], unit[i % unit_len],
+				      "image byte %zu is 0x%02x, expected 0x%02x", i, img[i],
+				      unit[i % unit_len]);
+		}
+	}
+#endif
+
+	STEP(T_BLOB, 3);
+	ret = tt_d2d_load_fw(d2d0, img, size);
+	STEP(T_BLOB, 4);
+	STEP_RESULT(ret);
+	zassert_ok(ret, "loading the linked image failed");
+
+	STEP(T_BLOB, 5);
+	for (size_t off = 0; off < size; off += sizeof(uint32_t)) {
+		uint32_t got = sys_read32(D2D0_BASE + SRAM_OFFSET + off);
+		uint32_t want = sys_get_le32(&img[off]);
+
+		STEP_RESULT(got);
+		zassert_equal(got, want, "SRAM +0x%zx is 0x%08x, expected 0x%08x", off, got, want);
+	}
+
+	PASSED(P_BLOB);
+}
+
+/*
+ * Everything above this point stops at the loader: it shows bytes arriving in
+ * SRAM and the control register accepting a write, neither of which needs the
+ * Rocket to have executed a single instruction.
+ *
+ * This is the one test that distinguishes a core that ran from a core that is
+ * wedged, and it does it without a link partner, a PHY, or anything the
+ * emulation bypasses turn off. The loader zeroes the whole window before
+ * copying, so between the end of the image and the config block there is a
+ * region that is known to be zero and that the loader will not touch again.
+ * Anything non-zero there after the Rocket is released was put there by the
+ * Rocket. Confirming the region really is zero first is what makes that a
+ * proof rather than an inference.
+ *
+ * A stack push is the earliest such write and lands near the top of the
+ * window, hence the downward scan: when the firmware is alive the search ends
+ * almost immediately, and only a genuine failure pays for the full sweep.
+ */
+/*
+ * A live Rocket has written something before the first scan finishes: on
+ * emulation the sweep alone takes well over a minute, which dwarfs the time
+ * the core needs to reach its first store. The retries are there for margin,
+ * not because a pass is expected to need them, and the count is kept low
+ * deliberately -- each one is another full sweep, and enough of them would
+ * turn a clean failure into a harness timeout with nothing to read.
+ */
+#define EXEC_ATTEMPTS     3U
+#define EXEC_SETTLE_ITERS 0x1000U
+
+/* Offset of the highest non-zero word below `end`, or `end` if there is none. */
+static size_t highest_nonzero(uintptr_t sram, size_t start, size_t end)
+{
+	for (size_t off = end; off > start;) {
+		off -= sizeof(uint32_t);
+
+		if (sys_read32(sram + off) != 0) {
+			return off;
+		}
+	}
+
+	return end;
+}
+
+ZTEST(tt_d2d, test_started_firmware_executes)
+{
+	const uintptr_t sram = D2D0_BASE + SRAM_OFFSET;
+	const uint8_t *img;
+	size_t size = 0;
+	size_t hit;
+	int ret;
+
+#ifdef D2D_FW_STUB_UNIT
+	/* The generated stand-in is ASCII, not instructions. Releasing a core
+	 * onto it would prove nothing and leave it in an arbitrary state.
+	 */
+	ztest_test_skip();
+#endif
+
+	STEP(T_EXEC, 1);
+	img = d2d_fw_image(&size);
+	zassert_true(size > 0 && size < IMAGE_MAX, "no room between image and config block");
+
+	STEP(T_EXEC, 2);
+	ret = tt_d2d_load_fw(d2d0, img, size);
+	STEP_RESULT(ret);
+	zassert_ok(ret);
+
+	STEP(T_EXEC, 3);
+	hit = highest_nonzero(sram, size, IMAGE_MAX);
+	STEP_RESULT(hit);
+	zassert_equal(hit, IMAGE_MAX,
+		      "SRAM +0x%zx is already non-zero with the Rocket still in "
+		      "reset, so a later write there would prove nothing",
+		      hit);
+
+	STEP(T_EXEC, 4);
+	zassert_ok(tt_d2d_start(d2d0));
+
+	for (uint32_t attempt = 0; attempt < EXEC_ATTEMPTS; attempt++) {
+		STEP(T_EXEC, 5);
+		for (volatile uint32_t i = 0; i < EXEC_SETTLE_ITERS; i++) {
+		}
+
+		STEP(T_EXEC, 6);
+		hit = highest_nonzero(sram, size, IMAGE_MAX);
+		if (hit != IMAGE_MAX) {
+			break;
+		}
+	}
+
+	STEP_RESULT(hit);
+	zassert_not_equal(hit, IMAGE_MAX,
+			  "SRAM is untouched after releasing the Rocket: it is not executing the "
+			  "image. Check that the load landed (earlier tests) and that the core "
+			  "reset in cpu_ctrl actually deasserted");
+
+	PASSED(P_EXEC);
+}
+
+/*
+ * The harness's verdict is ztest's own, and ztest can fail a run for reasons
+ * no individual test reports: a result recorded outside a test body, or
+ * per-test stats that do not add up. With no readable console, publishing the
+ * framework's counters is what separates "a test failed" from "every test
+ * passed and the run was failed anyway".
+ */
+static void tt_d2d_teardown(void *fixture)
+{
+	uint32_t run = 0;
+	uint32_t pass = 0;
+	uint32_t fail = 0;
+	uint32_t skip = 0;
+	uint32_t inconsistent = 0;
+
+	ARG_UNUSED(fixture);
+
+	for (struct ztest_unit_test *t = _ztest_unit_test_list_start; t < _ztest_unit_test_list_end;
+	     t++) {
+		run += t->stats->run_count;
+		pass += t->stats->pass_count;
+		fail += t->stats->fail_count;
+		skip += t->stats->skip_count;
+
+		if (t->stats->pass_count + t->stats->fail_count + t->stats->skip_count !=
+		    t->stats->run_count) {
+			inconsistent = 1;
+		}
+	}
+
+	WRITE_SCRATCH(4, 0xC0000000U | (run << 16) | (pass << 12) | (fail << 8) | (skip << 4) |
+				 inconsistent);
+}
+
+ZTEST_SUITE(tt_d2d, NULL, tt_d2d_setup, NULL, NULL, tt_d2d_teardown);

--- a/tests/drivers/tt_d2d/testcase.yaml
+++ b/tests/drivers/tt_d2d/testcase.yaml
@@ -1,0 +1,9 @@
+common:
+  tags:
+    - drivers
+tests:
+  drivers.tt_d2d.load:
+    build_only: true
+    platform_allow:
+      - tt_mimir/tt_mimir/smc
+      - tt_mmk/tt_mimir/smc


### PR DESCRIPTION
Bring a D2D tile's Rocket CPU up on a supplied image:

  1) Hold the D2D core in reset
  2) Clear SRAM
  3) DMA the D2D FW to SRAM, falling back to CPU stores
  4) Verify the bytes
  5) Write the configuration block

The firmware image comes from the SiVal drop and is closed source, so
it is not in this repository.

---

Tests:

Ran on Mimir emulation 