### PR TITLE
doc: remove unused doxmlparser dependency

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -19,9 +19,6 @@ pykwalify
 pytest
 pyserial
 
-# Doxygen doxmlparser
-doxmlparser
-
 # Used by the Zephyr domain to organize code samples
 anytree
 


### PR DESCRIPTION
Fixes #1454. Internal ref: OSPO-829.

`doc/requirements.txt` pinned `doxmlparser`, which nothing in this repo uses.

### Why it is safe to remove

`doxmlparser` is imported by exactly two Zephyr Sphinx extensions, `zephyr.doxybridge` and `zephyr.api_overview`. `doc/conf.py` loads neither. The docs build invokes Doxygen as a standalone binary and publishes its HTML to `deploy/doxygen`, linked from `html_context` — it never parses the Doxygen XML from Python. The pin came over wholesale from Zephyr's own `doc/requirements.txt`.

### Why it was flagged

Cycode flags this repo under a strong-copyleft policy at risk score 80. That is a false positive, recorded here and in #1454 so a future scan does not reopen it:

- Doxygen the program is GPL-2.0, but `addon/doxmlparser` ships its [own MIT LICENSE](https://github.com/doxygen/doxygen/blob/master/addon/doxmlparser/LICENSE).
- Every wheel from 1.10.0 to 1.18.0 bundles that MIT file. No release shipped GPL terms.
- The three source files contain no `gpl`, `general public license`, or `copyleft` strings.
- `setup.py` sets `license=<full MIT text>` instead of an SPDX identifier and declares no license classifier, so scanners fall back to the project URL and pick up `doxygen/doxygen`, which is GPL-2.0.

Removing the dependency is the cheaper fix than curating the scanner, since the package is dead weight either way.

### Test

The `docs.yml` workflow exercises the full Sphinx and Doxygen build on this PR. No behaviour change is expected.
