### PR TITLE
drivers: misc: mimir remote boot

### DIFF
--- a/drivers/misc/CMakeLists.txt
+++ b/drivers/misc/CMakeLists.txt
@@ -3,5 +3,6 @@
 # zephyr-keep-sorted-start
 add_subdirectory_ifdef(CONFIG_BH_FWTABLE bh_fwtable)
 add_subdirectory_ifdef(CONFIG_TT_BH_EFUSE bh_efuse)
+add_subdirectory_ifdef(CONFIG_TT_MIMIR_REMOTE_BOOT tt_mimir_remote_boot)
 add_subdirectory_ifdef(CONFIG_TT_SMC_REMOTEPROC tt_smc_remoteproc)
 # zephyr-keep-sorted-stop

--- a/drivers/misc/Kconfig
+++ b/drivers/misc/Kconfig
@@ -8,6 +8,7 @@ menu "Miscellaneous Drivers"
 # zephyr-keep-sorted-start
 rsource "bh_efuse/Kconfig"
 rsource "bh_fwtable/Kconfig"
+rsource "tt_mimir_remote_boot/Kconfig"
 rsource "tt_smc_remoteproc/Kconfig"
 # zephyr-keep-sorted-stop
 

--- a/drivers/misc/tt_mimir_remote_boot/CMakeLists.txt
+++ b/drivers/misc/tt_mimir_remote_boot/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+zephyr_library()
+zephyr_library_sources_ifdef(CONFIG_TT_MIMIR_REMOTE_BOOT tt_mimir_remote_boot.c)

--- a/drivers/misc/tt_mimir_remote_boot/Kconfig
+++ b/drivers/misc/tt_mimir_remote_boot/Kconfig
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+config TT_MIMIR_REMOTE_BOOT
+	bool "Tenstorrent Mimir Remote Boot Driver"
+	default y
+	depends on DT_HAS_TENSTORRENT_MIMIR_REMOTE_BOOT_ENABLED
+	depends on TT_SMC_REMOTEPROC
+	help
+	  Enable the Mimir remote boot driver. Reads the Mimir FW image from
+	  the BUN2 staging area at the configured TOC index, then OCCP-loads it via
+	  the SMC remoteproc driver
+
+if TT_MIMIR_REMOTE_BOOT
+
+config TT_MIMIR_REMOTE_BOOT_INIT_PRIO
+	int
+	default 77
+	help
+	  Initialization priority of the Mimir remote boot driver. Must be
+	  higher than TT_SMC_REMOTEPROC_INIT_PRIO (75).
+
+module = TT_MIMIR_REMOTE_BOOT
+module-str = tt_mimir_remote_boot
+source "subsys/logging/Kconfig.template.log_config"
+
+endif # TT_MIMIR_REMOTE_BOOT

--- a/drivers/misc/tt_mimir_remote_boot/tt_mimir_remote_boot.c
+++ b/drivers/misc/tt_mimir_remote_boot/tt_mimir_remote_boot.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#define DT_DRV_COMPAT tenstorrent_mimir_remote_boot
+
+#include <errno.h>
+#include <inttypes.h>
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/misc/tt_bundle_loader.h>
+#include <zephyr/drivers/misc/tt_smc_remoteproc.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(tt_mimir_remote_boot, CONFIG_TT_MIMIR_REMOTE_BOOT_LOG_LEVEL);
+
+BUILD_ASSERT(CONFIG_TT_MIMIR_REMOTE_BOOT_INIT_PRIO > CONFIG_TT_SMC_REMOTEPROC_INIT_PRIO,
+	     "TT_MIMIR_REMOTE_BOOT_INIT_PRIO must be higher than TT_SMC_REMOTEPROC_INIT_PRIO");
+
+struct tt_mimir_remote_boot_config {
+	const struct device *const *remoteprocs;
+	size_t num_remoteprocs;
+	uint32_t fw_toc_index;
+	uint32_t d2d_fw_toc_index;
+	uint32_t gddr_params_toc_index;
+};
+
+struct tt_mimir_remote_boot_data {
+};
+
+static int tt_mimir_remote_boot_init(const struct device *dev)
+{
+	const struct tt_mimir_remote_boot_config *cfg = dev->config;
+
+	int ret;
+
+	/* A) Locate the Mimir image in the BUN2 staging area */
+	const struct fw_bundle_manifest *manifest =
+		(const struct fw_bundle_manifest *)TT_BUN2_STAGING_AREA_ADDR;
+	const struct fw_bundle_toc *toc = (const struct fw_bundle_toc *)(TT_BUN2_STAGING_AREA_ADDR +
+									 manifest->payload_offset);
+
+	if (cfg->fw_toc_index >= toc->image_count) {
+		LOG_ERR("TOC index %u out of range (bundle has %" PRIu64 " entries)",
+			cfg->fw_toc_index, toc->image_count);
+		return -ENOENT;
+	}
+
+	const struct fw_bundle_toc_entry *entry = &toc->entries[cfg->fw_toc_index];
+
+	/* B) OCCP-load and start the Mimir image on each remote processor */
+	LOG_INF("Loading Mimir FW from TOC[%u]: load_addr=0x%" PRIx64 " size=%" PRIu64,
+		cfg->fw_toc_index, entry->load_addr, entry->length);
+
+	for (size_t i = 0; i < cfg->num_remoteprocs; i++) {
+		if (!device_is_ready(cfg->remoteprocs[i])) {
+			LOG_ERR("remoteproc[%zu] is not ready", i);
+			return -ENODEV;
+		}
+
+		/* TODO - D2D FW copy via OCCP */
+
+		/* Remote execute the M-SMC_BL1 */
+		ret = tt_smc_remoteproc_boot(cfg->remoteprocs[i], entry->load_addr,
+					     (uint8_t *)(TT_BUN2_STAGING_AREA_ADDR +
+							 manifest->payload_offset + entry->offset),
+					     (size_t)entry->length);
+		if (ret != 0) {
+			LOG_ERR("Failed to OCCP-load Mimir FW on remoteproc[%zu]: %d", i, ret);
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+/* TODO - New SYS_INIT step to copy GDDR params over to mimir once D2D is trained */
+
+#define TT_MIMIR_REMOTE_BOOT_REMOTEPROC_GET(node_id, prop, idx)                                    \
+	DEVICE_DT_GET(DT_PHANDLE_BY_IDX(node_id, prop, idx)),
+
+#define TT_MIMIR_REMOTE_BOOT_DEFINE(inst)                                                          \
+	static const struct device *const tt_mimir_remote_boot_remoteprocs_##inst[] = {            \
+		DT_INST_FOREACH_PROP_ELEM(inst, smc_remoteproc,                                    \
+					  TT_MIMIR_REMOTE_BOOT_REMOTEPROC_GET)};                   \
+	static const struct tt_mimir_remote_boot_config tt_mimir_remote_boot_config_##inst = {     \
+		.remoteprocs = tt_mimir_remote_boot_remoteprocs_##inst,                            \
+		.num_remoteprocs = ARRAY_SIZE(tt_mimir_remote_boot_remoteprocs_##inst),            \
+		.fw_toc_index = DT_INST_PROP(inst, fw_toc_index),                                  \
+		.d2d_fw_toc_index = DT_INST_PROP(inst, d2d_fw_toc_index),                          \
+		.gddr_params_toc_index = DT_INST_PROP(inst, gddr_params_toc_index),                \
+	};                                                                                         \
+	static struct tt_mimir_remote_boot_data tt_mimir_remote_boot_data_##inst;                  \
+	DEVICE_DT_INST_DEFINE(inst, tt_mimir_remote_boot_init, NULL,                               \
+			      &tt_mimir_remote_boot_data_##inst,                                   \
+			      &tt_mimir_remote_boot_config_##inst, POST_KERNEL,                    \
+			      CONFIG_TT_MIMIR_REMOTE_BOOT_INIT_PRIO, NULL);
+
+DT_INST_FOREACH_STATUS_OKAY(TT_MIMIR_REMOTE_BOOT_DEFINE)

--- a/dts/bindings/misc/tenstorrent,mimir-remote-boot.yaml
+++ b/dts/bindings/misc/tenstorrent,mimir-remote-boot.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Tenstorrent Mimir remote boot driver.
+
+  Reads the Mimir FW image from the BUN2 staging area at the TOC index
+  given by fw-toc-index, then OCCP-loads it onto each remote processor
+  listed in smc-remoteproc. All Mimirs share the same FW, D2D FW, and
+  GDDR params images. Also records the TOC indices for the D2D FW and
+  GDDR params images, for future use.
+
+compatible: "tenstorrent,mimir-remote-boot"
+
+include: base.yaml
+
+properties:
+  smc-remoteproc:
+    type: phandles
+    required: true
+    description: |
+      List of tenstorrent,smc-remoteproc devices, one per Mimir, used to
+      OCCP-load and start Mimir.
+
+  fw-toc-index:
+    type: int
+    default: 1
+    description: |
+      Index into the BUN2 TOC for the Mimir FW image. Defaults to 1.
+
+  d2d-fw-toc-index:
+    type: int
+    default: 2
+    description: |
+      Index into the BUN2 TOC for the Mimir D2D FW image. Defaults to 2.
+
+  gddr-params-toc-index:
+    type: int
+    default: 3
+    description: |
+      Index into the BUN2 TOC for the Mimir GDDR params image. Defaults to 3.


### PR DESCRIPTION
This driver is intended to allow a Primary Chiplet to boot a remote Mimir. It acts as a glue layer between BUN2, remoteproc, and (potentially) mbox handshaking.

Remote mimirs need D2D FW and GDDR params loaded. The TOC params are carved out in the yaml but only the fw one is used, until we complete the link up to the full sysbuild/FW flow support for consuming these artifacts.

The bindings allow us to wire any given TOC setup to the driver, so hopefully this driver can be re-used on qsra1 with minimal rework.

TODO work in this driver includes D2D binary copy and GDDR param copy.

Out of scope is Mimir side handshaking and D2D loading/training

### Tests:

This is part of the working Bl0p5 -> MIS FW boot flow, when this driver is implemented inside BL1. No tests exist in tree.