### PR TITLE
drivers: bh_fwtable: Add max_pcie_speed to override table

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2024 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
 import os
 import shutil
@@ -2114,6 +2115,111 @@ def test_ccfgovr_eth_speed_override(arc_chip_dut, asic_id, board_name):
     if restore.returncode != 0:
         logger.warning(
             f"Failed to clear {ETH_SPEED_PATH} (rc={restore.returncode}); "
+            f"SPI flash may be left modified: "
+            f"{restore.stderr.decode(errors='replace')}"
+        )
+    else:
+        wait_arc_boot(asic_id, timeout=60)
+
+
+def test_ccfgovr_pcie_gen_override(arc_chip_dut, asic_id):
+    """
+    Exercise the PCIe generation override that ccfgovr merges into
+    FwTable.pci{0,1}_property_table.max_pcie_speed.
+
+    Negotiated host link gen is slot-dependent, so this test does not
+    require a Gen 5 slot. It drives the paths that would fail if the
+    override were mis-handled:
+
+    - `bh-mod` rejects a generation the SerDes firmware does not accept
+      before touching flash.
+    - Writing a supported generation on the EP instance and letting
+      `bh-mod` reset the chip leaves ARC coming back up, with `bh-mod get`
+      showing the override.
+    - `bh-mod res` clears the override.
+    """
+    bh_mod = shutil.which("bh-mod") or os.path.expanduser("~/bh-mod")
+    if not os.path.isfile(bh_mod):
+        pytest.skip("bh-mod not found (PATH or ~/bh-mod)")
+
+    reject = subprocess.run(
+        [bh_mod, "set", "pci0_property_table.max_pcie_speed=7"],
+        capture_output=True,
+        check=False,
+    )
+    assert reject.returncode != 0, (
+        "bh-mod set pci0_property_table.max_pcie_speed=7 should have been "
+        f"rejected; stdout={reject.stdout.decode(errors='replace')!r} "
+        f"stderr={reject.stderr.decode(errors='replace')!r}"
+    )
+
+    listing = subprocess.run(
+        [
+            bh_mod,
+            "get",
+            "-f",
+            "json",
+            "pci0_property_table.pcie_mode",
+            "pci1_property_table.pcie_mode",
+        ],
+        capture_output=True,
+        check=False,
+    )
+    assert listing.returncode == 0, (
+        f"bh-mod get pcie_mode failed, rc={listing.returncode}; "
+        f"stdout={listing.stdout.decode(errors='replace')!r} "
+        f"stderr={listing.stderr.decode(errors='replace')!r}"
+    )
+    modes = json.loads(listing.stdout.decode())
+
+    def is_ep(entry):
+        default = str(entry.get("default", "")).upper()
+        return default in ("EP", "1")
+
+    path = next(
+        (
+            f"pci{inst}_property_table.max_pcie_speed"
+            for inst in (0, 1)
+            if is_ep(modes.get(f"pci{inst}_property_table.pcie_mode", {}))
+        ),
+        None,
+    )
+    if path is None:
+        pytest.skip("no PCIe endpoint instance in cmfwcfg")
+
+    write = subprocess.run(
+        [bh_mod, "--reset-timeout=60s", "set", f"{path}=4"],
+        capture_output=True,
+        check=False,
+    )
+    assert write.returncode == 0, (
+        f"bh-mod set {path}=4 failed, rc={write.returncode}; "
+        f"stdout={write.stdout.decode(errors='replace')!r} "
+        f"stderr={write.stderr.decode(errors='replace')!r}"
+    )
+    wait_arc_boot(asic_id, timeout=60)
+
+    verify = subprocess.run(
+        [bh_mod, "get", "-f", "json", path],
+        capture_output=True,
+        check=False,
+    )
+    assert verify.returncode == 0, (
+        f"bh-mod get {path} failed, rc={verify.returncode}; "
+        f"stdout={verify.stdout.decode(errors='replace')!r} "
+        f"stderr={verify.stderr.decode(errors='replace')!r}"
+    )
+    row = json.loads(verify.stdout.decode())[path]
+    assert str(row.get("override")) == "4", f"expected override {path}=4, got {row!r}"
+
+    restore = subprocess.run(
+        [bh_mod, "--reset-timeout=60s", "res", path],
+        capture_output=True,
+        check=False,
+    )
+    if restore.returncode != 0:
+        logger.warning(
+            f"Failed to clear {path} (rc={restore.returncode}); "
             f"SPI flash may be left modified: "
             f"{restore.stderr.decode(errors='replace')}"
         )

--- a/doc/release/release-notes-19.15.md
+++ b/doc/release/release-notes-19.15.md
@@ -10,6 +10,13 @@ Major enhancements with this release include:
 
 ## Blackhole
 
+### Persistent SPI Flash Parameters
+- Expose `pci0_property_table.max_pcie_speed` and
+  `pci1_property_table.max_pcie_speed` to `bh-mod`, valid values
+  `{0, 1, 2, 3, 4, 5}`. `0` is unconstrained (Gen 5 default).
+  `bh-mod res` restores the cmfwcfg value. Set the instance
+  whose `pcie_mode` is EP.
+
 ## Migration guide
 
 An overview of required and recommended changes to make when migrating from the previous v19.14.0 release can be found in [19.15 Migration Guide](https://github.com/tenstorrent/tt-system-firmware/tree/main/doc/release/migration-guide-19.15.md).

--- a/drivers/misc/bh_fwtable/bh_fwtable.c
+++ b/drivers/misc/bh_fwtable/bh_fwtable.c
@@ -418,6 +418,20 @@ void tt_bh_fwtable_apply_ccfgovr(const struct device *dev)
 			data->fw_table.has_eth_property_table = true;
 		}
 
+		if (ovr.has_pci0_property_table && ovr.pci0_property_table.has_max_pcie_speed) {
+			LOG_INF("CCFGOVR override: pci0_property_table.max_pcie_speed = %u",
+				ovr.pci0_property_table.max_pcie_speed);
+			data->fw_table.pci0_property_table.max_pcie_speed =
+				ovr.pci0_property_table.max_pcie_speed;
+		}
+
+		if (ovr.has_pci1_property_table && ovr.pci1_property_table.has_max_pcie_speed) {
+			LOG_INF("CCFGOVR override: pci1_property_table.max_pcie_speed = %u",
+				ovr.pci1_property_table.max_pcie_speed);
+			data->fw_table.pci1_property_table.max_pcie_speed =
+				ovr.pci1_property_table.max_pcie_speed;
+		}
+
 		return;
 	}
 

--- a/drivers/misc/bh_fwtable/spirom_protobufs/fw_table_override.proto
+++ b/drivers/misc/bh_fwtable/spirom_protobufs/fw_table_override.proto
@@ -19,11 +19,13 @@ message FwTableOverride {
    * (FwTable field 1) is deliberately reserved here so tt-mod cannot forge
    * a bundle version.
    */
-  reserved 1, 4, 6, 7, 8, 10;
+  reserved 1, 4, 6, 10;
 
   optional ChipLimits chip_limits = 2;
   optional FeatureEnable feature_enable = 3;
   optional DramTable dram_table = 5;
+  optional PciPropertyTable pci0_property_table = 7;
+  optional PciPropertyTable pci1_property_table = 8;
   optional EthPropertyTable eth_property_table = 9;
 
   message ChipLimits {
@@ -47,6 +49,18 @@ message FwTableOverride {
     reserved 1, 2;
 
     optional uint32 soft_harvest_dram_mask = 3;
+  }
+
+  message PciPropertyTable {
+
+    reserved 2, 3, 4, 5, 6, 7;
+
+    /*
+     * PCIe generation cap passed to CntlInitV2. 0 is unconstrained
+     * (Gen 5 default). Distinct from `bh-mod res`, which
+     * clears the override and restores the cmfwcfg value.
+     */
+    optional uint32 max_pcie_speed = 1;
   }
 
   message EthPropertyTable {

--- a/tests/drivers/fw_table/src/main.c
+++ b/tests/drivers/fw_table/src/main.c
@@ -48,6 +48,9 @@ static const struct device *const fwtable_dev = DEVICE_DT_GET(FWTABLE_NODE);
 #define DEFAULT_TDP_LIMIT 150U
 /* Stands in for a cmfwcfg that pins the link speed, as the Galaxy tables do. */
 #define DEFAULT_ETH_SPEED 200U
+/* Distinct per instance so a pci0 override cannot silently rewrite pci1. */
+#define DEFAULT_PCI0_SPEED 0U
+#define DEFAULT_PCI1_SPEED 5U
 
 static void write_fd(size_t slot, const char *tag, uint32_t spi_addr, uint32_t image_size)
 {
@@ -119,6 +122,28 @@ static size_t encode_eth_speed_override(uint8_t *out, size_t out_size, uint32_t 
 	return encode_override(&ovr, out, out_size);
 }
 
+static size_t encode_pci_speed_override(uint8_t *out, size_t out_size, uint8_t inst, uint32_t speed)
+{
+	FwTableOverride ovr = FwTableOverride_init_zero;
+
+	switch (inst) {
+	case 0U:
+		ovr.has_pci0_property_table = true;
+		ovr.pci0_property_table.has_max_pcie_speed = true;
+		ovr.pci0_property_table.max_pcie_speed = speed;
+		break;
+	case 1U:
+		ovr.has_pci1_property_table = true;
+		ovr.pci1_property_table.has_max_pcie_speed = true;
+		ovr.pci1_property_table.max_pcie_speed = speed;
+		break;
+	default:
+		zassert_unreachable("invalid instance");
+	}
+
+	return encode_override(&ovr, out, out_size);
+}
+
 static size_t encode_gddr_therm_trip_override(uint8_t *out, size_t out_size, bool enabled)
 {
 	FwTableOverride ovr = FwTableOverride_init_zero;
@@ -175,6 +200,8 @@ static void reset_fwtable(void)
 	t->chip_limits.tdp_limit = DEFAULT_TDP_LIMIT;
 	t->eth_property_table.has_eth_speed_override = true;
 	t->eth_property_table.eth_speed_override = DEFAULT_ETH_SPEED;
+	t->pci0_property_table.max_pcie_speed = DEFAULT_PCI0_SPEED;
+	t->pci1_property_table.max_pcie_speed = DEFAULT_PCI1_SPEED;
 }
 
 /**
@@ -299,6 +326,48 @@ ZTEST(bh_fwtable_ccfgovr, test_eth_speed_override_of_zero_asks_for_auto_train)
 	zassert_equal(
 		tt_bh_fwtable_get_fw_table(fwtable_dev)->eth_property_table.eth_speed_override, 0U,
 		"expected the override to set eth_speed_override=0 (auto)");
+}
+
+/**
+ * @brief Test that pci0 max_pcie_speed can be capped at Gen 4
+ *
+ * pci1 must keep its cmfwcfg value: the two instances are independent.
+ */
+ZTEST(bh_fwtable_ccfgovr, test_pci0_max_pcie_speed_override_applies)
+{
+	uint8_t body[16];
+	size_t body_len = encode_pci_speed_override(body, sizeof(body), 0U, 4U);
+	struct ccfgovr_bank_hdr hdr = {.magic = CCFGOVR_MAGIC, .seq = 2};
+
+	write_bank(BANK_A_ADDR, &hdr, body, body_len);
+
+	tt_bh_fwtable_apply_ccfgovr(fwtable_dev);
+	zassert_equal(tt_bh_fwtable_get_fw_table(fwtable_dev)->pci0_property_table.max_pcie_speed,
+		      4U, "expected override to set pci0 max_pcie_speed=4");
+	zassert_equal(tt_bh_fwtable_get_fw_table(fwtable_dev)->pci1_property_table.max_pcie_speed,
+		      DEFAULT_PCI1_SPEED,
+		      "pci0 override must not clobber pci1's cmfwcfg max_pcie_speed");
+}
+
+/**
+ * @brief Test that pci1 max_pcie_speed can be set to Gen 5
+ *
+ * pci0 must keep its cmfwcfg value.
+ */
+ZTEST(bh_fwtable_ccfgovr, test_pci1_max_pcie_speed_override_applies)
+{
+	uint8_t body[16];
+	size_t body_len = encode_pci_speed_override(body, sizeof(body), 1U, 5U);
+	struct ccfgovr_bank_hdr hdr = {.magic = CCFGOVR_MAGIC, .seq = 2};
+
+	write_bank(BANK_A_ADDR, &hdr, body, body_len);
+
+	tt_bh_fwtable_apply_ccfgovr(fwtable_dev);
+	zassert_equal(tt_bh_fwtable_get_fw_table(fwtable_dev)->pci1_property_table.max_pcie_speed,
+		      5U, "expected override to set pci1 max_pcie_speed=5");
+	zassert_equal(tt_bh_fwtable_get_fw_table(fwtable_dev)->pci0_property_table.max_pcie_speed,
+		      DEFAULT_PCI0_SPEED,
+		      "pci1 override must not clobber pci0's cmfwcfg max_pcie_speed");
 }
 
 /**


### PR DESCRIPTION
##  [SYS-5132](https://tenstorrent.atlassian.net/browse/SYS-5132)
## https://github.com/tenstorrent/luwen/pull/173
## Overview
Add `PciPropertyTable.max_pcie_speed` for pci inst 0, 1 to fwtable override.

Set with `bh-mod set pci0_property_table.max_pcie_speed=n`
- n=0: Auto speed selection, Gen 5
- n=[1, 5]: Maps to PCIe gen

Change occurs on reset.

## Test
Added pytest (requires you use an updated bh-mod)
Change gen with bh-mod, then `tt-smi -r` and verify with `tt-smi --use_luwen`