### PR TITLE
boards: tt_blackhole: add galaxy_bin6 board revision

### DIFF
--- a/.github/boards.json
+++ b/.github/boards.json
@@ -9,5 +9,6 @@
   "galaxy",
   "galaxy_2",
   "galaxy_revc",
+  "galaxy_bin6",
   "orion_slt"
 ]

--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -115,7 +115,7 @@ jobs:
           else
             # verify that built images for smc and dmc fw are signed
             # imgtool returns a non-zero exit code if the image is not signed
-            if ! [[ "${{ matrix.board }}" =~ ^galaxy(_revc)?$ ]]; then
+            if ! [[ "${{ matrix.board }}" =~ ^galaxy(_revc|_bin6)?$ ]]; then
               imgtool verify --key "$SIGNATURE_KEY_FILE" build-${{ matrix.board }}/dmc/zephyr/zephyr.signed.bin
             fi
             imgtool verify --key "$SIGNATURE_KEY_FILE" build-${{ matrix.board }}/recovery/zephyr/zephyr.signed.bin

--- a/app/smc/sysbuild.cmake
+++ b/app/smc/sysbuild.cmake
@@ -18,9 +18,10 @@ if("${BUNDLE_VERSION_STRING}" STREQUAL "...")
 endif()
 
 # ======== Board validation ========
-# galaxy and galaxy_revc do not require a DMC image in bootfs
+# galaxy, galaxy_revc and galaxy_bin6 do not require a DMC image in bootfs
 set(IS_GALAXY_BOARD FALSE)
-if("${BOARD_REVISION}" STREQUAL "galaxy" OR "${BOARD_REVISION}" STREQUAL "galaxy_revc")
+if("${BOARD_REVISION}" STREQUAL "galaxy" OR "${BOARD_REVISION}" STREQUAL "galaxy_revc" OR
+   "${BOARD_REVISION}" STREQUAL "galaxy_bin6")
   set(IS_GALAXY_BOARD TRUE)
 endif()
 if("${SB_CONFIG_DMC_BOARD}" STREQUAL "" AND NOT IS_GALAXY_BOARD)
@@ -35,6 +36,8 @@ if(BOARD STREQUAL "tt_blackhole")
     set(PROD_NAME "GALAXY-1")
   elseif("${BOARD_REVISION}" STREQUAL "galaxy_revc")
     set(PROD_NAME "GALAXY-3")
+  elseif("${BOARD_REVISION}" STREQUAL "galaxy_bin6")
+    set(PROD_NAME "GALAXY_BIN6-1")
   else()
     string(TOUPPER ${BOARD_REVISION} BASE_NAME)
     set(PROD_NAME "${BASE_NAME}-1")

--- a/boards/tenstorrent/tt_blackhole/board.yml
+++ b/boards/tenstorrent/tt_blackhole/board.yml
@@ -15,6 +15,7 @@ boards:
     - name: "galaxy"
     - name: "galaxy_2"
     - name: "galaxy_revc"
+    - name: "galaxy_bin6"
     - name: "orion_slt"
   socs:
   - name: tt_blackhole

--- a/boards/tenstorrent/tt_blackhole/pre_dt_board.cmake
+++ b/boards/tenstorrent/tt_blackhole/pre_dt_board.cmake
@@ -4,6 +4,6 @@
 # The galaxy SMC devicetrees deliberately place several flash chip
 # candidates at the same SPI bus position; the flash mux selects among
 # them at boot.
-if("${BOARD_QUALIFIERS}" MATCHES "/smc" AND "${BOARD_REVISION}" MATCHES "^galaxy(_revc)?$")
+if("${BOARD_QUALIFIERS}" MATCHES "/smc" AND "${BOARD_REVISION}" MATCHES "^galaxy(_revc|_bin6)?$")
   list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")
 endif()

--- a/boards/tenstorrent/tt_blackhole/revision.cmake
+++ b/boards/tenstorrent/tt_blackhole/revision.cmake
@@ -1,5 +1,6 @@
 set(BOARD_REVISIONS
-    "p100a" "p150a" "p150b" "p150c" "p300a" "p300b" "p300c" "galaxy" "galaxy_2" "galaxy_revc" "orion_slt")
+    "p100a" "p150a" "p150b" "p150c" "p300a" "p300b" "p300c" "galaxy" "galaxy_2" "galaxy_revc"
+    "galaxy_bin6" "orion_slt")
 if(NOT BOARD_REVISION IN_LIST BOARD_REVISIONS)
 message(FATAL_ERROR "${BOARD_REVISION} is not a valid revision for tt_blackhole. Accepted revisions: ${BOARD_REVISIONS}")
 endif()

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY_BIN6/flash_info.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY_BIN6/flash_info.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+reprogrammed_count: 0
+date_programmed: 0
+vrm_checksum: 0
+tt_flash_version: 0

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY_BIN6/fw_table.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY_BIN6/fw_table.txt
@@ -1,0 +1,80 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+chip_limits {
+  asic_fmax: 1350
+  asic_fmin: 800
+  vdd_max: 900
+  vdd_min: 700
+  voltage_margin: 25
+  tdp_limit: 130
+  tdc_limit: 500
+  thm_limit: 90
+  tdc_fast_limit: 400
+  therm_trip_l1_limit: 0
+  bus_peak_limit: 0
+  frequency_margin: 0
+  gddr_thm_limit: 89
+  kernel_throttler_stop_nops_freq: 0
+  max_tdp_limit: 200
+}
+
+feature_enable {
+  cg_en: true
+  noc_translation_en: true
+  ddr_train_en: true
+  aiclk_ppm_en: true
+  watchdog_en: false
+  smbus_en: false
+  fan_ctrl_en: false
+  harvesting_en: true
+  doppler_en: false
+  kernel_throttler_at_floor_en: false
+}
+
+fan_table {
+  fan_table_point_x1: 0
+  fan_table_point_x2: 0
+  fan_table_point_y1: 0
+  fan_table_point_y2: 0
+}
+
+dram_table {
+  dram_mask: 0
+  dram_mask_en: false
+}
+
+chip_harvesting_table {
+  soft_harvesting_en: 0
+  soft_harvesting: 0
+}
+
+pci0_property_table {
+  max_pcie_speed: 0
+  pcie_bar0_size: 0
+  pcie_bar2_size: 0
+  pcie_bar4_size: 0
+  pcie_mode: DISABLED
+  num_serdes: 0
+}
+
+pci1_property_table {
+  max_pcie_speed: 5
+  pcie_bar0_size: 512
+  pcie_bar2_size: 1
+  pcie_bar4_size: 32768
+  pcie_mode: EP
+  num_serdes: 1
+}
+
+eth_property_table {
+  eth_disable_mask: 0
+  eth_disable_mask_en: false
+  eth_speed_override: 200
+}
+
+product_spec_harvesting {
+  dram_disable_count: 1
+  eth_disabled: false
+  tensix_col_disable_count: 1
+}

--- a/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY_BIN6/read_only.txt
+++ b/boards/tenstorrent/tt_blackhole/spirom_data_tables/GALAXY_BIN6/read_only.txt
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+funtest_table {
+  ft_stage: 0
+  ft1_exit_code: 0
+  ft2_exit_code: 0
+  ft_version: 0
+  ft_build_date: 0
+  ft_job_info: 0
+}
+
+reference_values_table {
+  reference_ro_08v: 0
+  aging_ro_08v: 0
+  reference_idd_08v_room_temp: 0
+  reference_temp_reading: 0
+  reference_voltage_reading: 0
+}
+vendor_id: 0x1e52
+asic_location: 0
+board_id: 0x202100000000

--- a/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_galaxy_bin6.overlay
+++ b/boards/tenstorrent/tt_blackhole/tt_blackhole_tt_blackhole_smc_galaxy_bin6.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Tenstorrent AI ULC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Galaxy boards fit second-source flash parts; include this before the
+ * partition adjustments below, as it recreates the partitions.
+ */
+#include "tt_blackhole_smc_flash_mux.dtsi"
+
+/delete-node/ &blupdate;
+/delete-node/ &dmfw;
+/delete-node/ &dmfwimg;
+
+/* No GDDR parameter blob is published for bin6; the revc parameters apply. */
+&memfwcfg {
+	binary-path = "$BLOBS_DIR/tt_blackhole_gddr_params_GALAXY_REVC.bin";
+};

--- a/drivers/misc/bh_fwtable/bh_fwtable.c
+++ b/drivers/misc/bh_fwtable/bh_fwtable.c
@@ -111,6 +111,7 @@ PcbType tt_bh_fwtable_get_pcb_type(const struct device *dev)
 		pcb_type = PcbTypeP300;
 		break;
 	case BOARDTYPE_UBB:
+	case BOARDTYPE_GALAXY_BIN6:
 		pcb_type = PcbTypeUBB;
 		break;
 	default:

--- a/include/zephyr/drivers/misc/bh_fwtable.h
+++ b/include/zephyr/drivers/misc/bh_fwtable.h
@@ -40,6 +40,7 @@ const struct _ReadOnly *tt_bh_fwtable_get_read_only_table(const struct device *d
 #define BOARDTYPE_P300A 0x45
 #define BOARDTYPE_P300C 0x46
 #define BOARDTYPE_UBB   0x47
+#define BOARDTYPE_GALAXY_BIN6 0x02 /* 00-00202-1-xxxxxxxx */
 
 typedef enum {
 	PcbTypeOrionSLT = 0,

--- a/lib/tenstorrent/bh_arc/chip_info_fwtable.c
+++ b/lib/tenstorrent/bh_arc/chip_info_fwtable.c
@@ -26,7 +26,9 @@ BUILD_ASSERT((int)BH_PCIE_MODE_RP == FwTable_PciPropertyTable_PcieMode_RP);
 
 bool bh_chip_info_is_ubb(void)
 {
-	return tt_bh_fwtable_get_board_type(fwtable_dev) == BOARDTYPE_UBB;
+	uint8_t board_type = tt_bh_fwtable_get_board_type(fwtable_dev);
+
+	return board_type == BOARDTYPE_UBB || board_type == BOARDTYPE_GALAXY_BIN6;
 }
 
 uint32_t bh_chip_info_additional_board_power(void)

--- a/lib/tenstorrent/bh_arc/chip_info_static.c
+++ b/lib/tenstorrent/bh_arc/chip_info_static.c
@@ -19,7 +19,7 @@
 /* Serdes count by board: P300 variants and UBB (Galaxy) use 1, P100/P150 use 2. */
 #if defined(CONFIG_BOARD_REVISION_P300A) || defined(CONFIG_BOARD_REVISION_P300B) ||                \
 	defined(CONFIG_BOARD_REVISION_P300C) || defined(CONFIG_BOARD_REVISION_GALAXY) ||           \
-	defined(CONFIG_BOARD_REVISION_GALAXY_REVC)
+	defined(CONFIG_BOARD_REVISION_GALAXY_REVC) || defined(CONFIG_BOARD_REVISION_GALAXY_BIN6)
 #define RECOVERY_NUM_SERDES 1
 #else
 #define RECOVERY_NUM_SERDES 2
@@ -27,7 +27,8 @@
 
 bool bh_chip_info_is_ubb(void)
 {
-#if defined(CONFIG_BOARD_REVISION_GALAXY) || defined(CONFIG_BOARD_REVISION_GALAXY_REVC)
+#if defined(CONFIG_BOARD_REVISION_GALAXY) || defined(CONFIG_BOARD_REVISION_GALAXY_REVC) ||         \
+	defined(CONFIG_BOARD_REVISION_GALAXY_BIN6)
 	return true;
 #else
 	return false;

--- a/scripts/rev2board.sh
+++ b/scripts/rev2board.sh
@@ -24,7 +24,7 @@ case "$1" in
   else
     BOARD="tt_blackhole@$1/tt_blackhole/$CLUSTER"
   fi;;
-  p100a|p150a|p150b|p150c|p300a|p300b|p300c|galaxy|galaxy_revc|orion_slt)
+  p100a|p150a|p150b|p150c|p300a|p300b|p300c|galaxy|galaxy_revc|galaxy_bin6|orion_slt)
   BOARD="tt_blackhole@$1/tt_blackhole/$CLUSTER";;
   bh-galaxy-revc)
   BOARD="tt_blackhole@galaxy_revc/tt_blackhole/$CLUSTER";;

--- a/scripts/tt_boot_fs.py
+++ b/scripts/tt_boot_fs.py
@@ -1006,8 +1006,11 @@ def _generate_bootfs_yaml(
     _logger.debug(partitions_yml)
 
     for partition in partitions_node.children.values():
-        # Galaxy and galaxy_revc do not have BM firmware
-        if args.board in {"galaxy", "galaxy_revc"} and partition.label == "bmfw":
+        # Galaxy, galaxy_revc and galaxy_bin6 do not have BM firmware
+        if (
+            args.board in {"galaxy", "galaxy_revc", "galaxy_bin6"}
+            and partition.label == "bmfw"
+        ):
             continue
         # P300 right chip does not have BM firmware
         if name[-5:] == "right" and partition.label == "bmfw":


### PR DESCRIPTION
Continuation of #1399.

Add the galaxy_bin6 revision for bin6 UBB parts, which permit one harvested DRAM instance. The SPI config tables are copied from galaxy_revc with dram_disable_count set to 1.

Registers the revision with the board, the CI board list, rev2board.sh, the sysbuild galaxy check, the tt_boot_fs bmfw exclusion and the CI DMC signature check, and extends the recovery chip-info UBB and serdes-count cases. SMC overlay reuses revc blobs.