### PR TITLE
app: bl0p5: Give logs to BL0p5

### DIFF
--- a/app/bl0p5/prj.conf
+++ b/app/bl0p5/prj.conf
@@ -18,3 +18,15 @@ CONFIG_IDLE_STACK_SIZE=256
 
 # BL1 runs on a single CPU; eliminates 3 extra ISR stacks and idle stacks (~7.7 KB)
 CONFIG_MP_MAX_NUM_CPUS=1
+
+# Deferred logging is flushed by a thread that never gets to run before the jump to BL1,
+# so messages are emitted synchronously instead.
+CONFIG_LOG=y
+CONFIG_LOG_MODE_IMMEDIATE=y
+
+# Disable PMP to save padding space...
+CONFIG_RISCV_PMP=n
+
+# Tag logs with BL0.5
+CONFIG_LOG_TAG_MAX_LEN=5
+CONFIG_LOG_TAG_DEFAULT="BL0.5"


### PR DESCRIPTION
### Overview

Emit logs from BL0p5. Get space back by disabling PMP, which saves padding between sections.

### Tests:

This builds and executes with logs in ttsim