### PR TITLE
drivers: fwtable: update board type to be uint32_t

### DIFF
--- a/drivers/misc/bh_fwtable/bh_fwtable.c
+++ b/drivers/misc/bh_fwtable/bh_fwtable.c
@@ -90,7 +90,7 @@ PcbType tt_bh_fwtable_get_pcb_type(const struct device *dev)
 	}
 
 	/* Extract board type from board_id */
-	uint8_t board_type = (uint8_t)((data->read_only_table.board_id >> 36) & 0xFF);
+	uint32_t board_type = BOARDTYPE_FROM_BOARD_ID(data->read_only_table.board_id);
 
 	/* Figure out PCB type from board type */
 	switch (board_type) {
@@ -122,8 +122,8 @@ PcbType tt_bh_fwtable_get_pcb_type(const struct device *dev)
 	return pcb_type;
 }
 
-/* Returns the board type extracted from board_id (bits 36-43) */
-uint8_t tt_bh_fwtable_get_board_type(const struct device *dev)
+/* Returns the board type extracted from board_id (bits 36-55) */
+uint32_t tt_bh_fwtable_get_board_type(const struct device *dev)
 {
 	struct bh_fwtable_data *data = dev->data;
 
@@ -132,7 +132,7 @@ uint8_t tt_bh_fwtable_get_board_type(const struct device *dev)
 	}
 
 	/* Extract board type from board_id */
-	return (uint8_t)((data->read_only_table.board_id >> 36) & 0xFF);
+	return BOARDTYPE_FROM_BOARD_ID(data->read_only_table.board_id);
 }
 
 /* Reads GPIO6 to determine whether it is p300 left chip. GPIO6 is only set on p300 left chip. */

--- a/include/zephyr/drivers/misc/bh_fwtable.h
+++ b/include/zephyr/drivers/misc/bh_fwtable.h
@@ -30,17 +30,18 @@ const struct _FwTable *tt_bh_fwtable_get_fw_table(const struct device *dev);
 const struct _FlashInfoTable *tt_bh_fwtable_get_flash_info_table(const struct device *dev);
 const struct _ReadOnly *tt_bh_fwtable_get_read_only_table(const struct device *dev);
 
-/* Board type values extracted from board_id */
-#define BOARDTYPE_ORION_SLT 0x37
-#define BOARDTYPE_P100A 0x43
-#define BOARDTYPE_P150A 0x40
-#define BOARDTYPE_P150  0x41
-#define BOARDTYPE_P150C 0x42
-#define BOARDTYPE_P300  0x44
-#define BOARDTYPE_P300A 0x45
-#define BOARDTYPE_P300C 0x46
-#define BOARDTYPE_UBB   0x47
-#define BOARDTYPE_GALAXY_BIN6 0x02 /* 00-00202-1-xxxxxxxx */
+/* Board type values extracted from board_id (bits 36-55, up to 5 hex digits) */
+#define BOARDTYPE_FROM_BOARD_ID(board_id) ((uint32_t)(((board_id) >> 36) & 0xFFFFF))
+#define BOARDTYPE_ORION_SLT               0x37
+#define BOARDTYPE_P100A                   0x43
+#define BOARDTYPE_P150A                   0x40
+#define BOARDTYPE_P150                    0x41
+#define BOARDTYPE_P150C                   0x42
+#define BOARDTYPE_P300                    0x44
+#define BOARDTYPE_P300A                   0x45
+#define BOARDTYPE_P300C                   0x46
+#define BOARDTYPE_UBB                     0x47
+#define BOARDTYPE_GALAXY_BIN6             0x202
 
 typedef enum {
 	PcbTypeOrionSLT = 0,
@@ -52,7 +53,7 @@ typedef enum {
 } PcbType;
 
 PcbType tt_bh_fwtable_get_pcb_type(const struct device *dev);
-uint8_t tt_bh_fwtable_get_board_type(const struct device *dev);
+uint32_t tt_bh_fwtable_get_board_type(const struct device *dev);
 bool tt_bh_fwtable_is_p300_left_chip(void);
 uint32_t tt_bh_fwtable_get_asic_location(const struct device *dev);
 void tt_bh_fwtable_apply_ccfgovr(const struct device *dev);

--- a/lib/tenstorrent/bh_arc/chip_info_fwtable.c
+++ b/lib/tenstorrent/bh_arc/chip_info_fwtable.c
@@ -26,7 +26,7 @@ BUILD_ASSERT((int)BH_PCIE_MODE_RP == FwTable_PciPropertyTable_PcieMode_RP);
 
 bool bh_chip_info_is_ubb(void)
 {
-	uint8_t board_type = tt_bh_fwtable_get_board_type(fwtable_dev);
+	uint32_t board_type = tt_bh_fwtable_get_board_type(fwtable_dev);
 
 	return board_type == BOARDTYPE_UBB || board_type == BOARDTYPE_GALAXY_BIN6;
 }

--- a/tests/lib/tenstorrent/bh_fwtable/src/main.c
+++ b/tests/lib/tenstorrent/bh_fwtable/src/main.c
@@ -20,7 +20,7 @@
  */
 struct board_expected {
 	const char *name;
-	uint8_t board_type; /* the top byte (bits 36-43) of board_id */
+	uint32_t board_type; /* bits 36-55 of board_id (up to 5 hex digits) */
 	uint32_t vendor_id;
 	uint32_t asic_fmax;
 	uint32_t asic_fmin;
@@ -115,7 +115,7 @@ static const struct board_expected *const known_boards[] = {
  * extracted from the loaded read_only table. Returns NULL for boards we
  * haven't characterized yet.
  */
-static const struct board_expected *expected_for_board_type(uint8_t board_type)
+static const struct board_expected *expected_for_board_type(uint32_t board_type)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(known_boards); i++) {
 		if (known_boards[i]->board_type == board_type) {
@@ -135,7 +135,7 @@ static void *suite_setup(void)
 {
 	const struct device *dev = FWTABLE_DEV;
 	const struct _ReadOnly *ro = tt_bh_fwtable_get_read_only_table(dev);
-	uint8_t board_type = (uint8_t)((ro->board_id >> 36) & 0xFF);
+	uint32_t board_type = BOARDTYPE_FROM_BOARD_ID(ro->board_id);
 
 	expected = expected_for_board_type(board_type);
 	return (void *)expected;


### PR DESCRIPTION
Follow up to: #1463

Update board type to uint32_t to properly reflect 5 hex digit board types.
Also updates Galaxy bin6 board type to accurately reflect board type.

Tests:
- bh_fwtable test on native sim run in CI and passed locally