### PR TITLE
tensix_init: fix cg_en logic

### DIFF
--- a/lib/tenstorrent/bh_arc/tensix_init.c
+++ b/lib/tenstorrent/bh_arc/tensix_init.c
@@ -87,7 +87,7 @@ static const struct device *const flash = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(spi
 
 void EnableTensixCG(bool broadcast, uint8_t noc_x, uint8_t noc_y)
 {
-	if (tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.cg_en) {
+	if (!tt_bh_fwtable_get_fw_table(fwtable_dev)->feature_enable.cg_en) {
 		return;
 	}
 


### PR DESCRIPTION
Fix the accidentally inverted Tensix clock gate enable logic.

This was accidentally broken in https://github.com/tenstorrent/tt-system-firmware/commit/2e1ca14d77b8ee62e9c241be938299d2f162c7e0#diff-66e7f25bb92f0d84a0d4d92329d9147178f89a8f4cc19140c304f3142a0166deR103 

and propagated in https://github.com/tenstorrent/tt-system-firmware/commit/513fc6247724fafd138e9e5f58f89013ade346f4#diff-66e7f25bb92f0d84a0d4d92329d9147178f89a8f4cc19140c304f3142a0166deR89