### PR TITLE
soc: print scratch regs on panic

### DIFF
--- a/soc/tenstorrent/tt_grendel/tt_grendel_smc/soc.c
+++ b/soc/tenstorrent/tt_grendel/tt_grendel_smc/soc.c
@@ -6,8 +6,33 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/devicetree.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/sys/sys_io.h>
 
 #include "platform.h"
+#include "soc.h"
+
+LOG_MODULE_REGISTER(soc, CONFIG_LOG_DEFAULT_LEVEL);
+
+#define GR_SCRATCH_REG_COUNT  16U
+#define GR_SCRATCH_REG_STRIDE 8U
+
+void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf)
+{
+	ARG_UNUSED(esf);
+
+	LOG_ERR("Fatal error: reason %u", reason);
+	for (unsigned int index = 0; index < GR_SCRATCH_REG_COUNT; index++) {
+		LOG_ERR("SCRATCH[%u] = 0x%08x", index,
+			sys_read32(SCRATCH_REG_BASE + (index * GR_SCRATCH_REG_STRIDE)));
+	}
+
+	LOG_PANIC();
+	LOG_ERR("Halting system");
+	k_fatal_halt(reason);
+	CODE_UNREACHABLE;
+}
 
 /*
  * TODO: Temporary shim to resolve header names for Keraunos


### PR DESCRIPTION
### Overview

Print scratch regs on k_panic for grendel

### Tests:

Forced `k_panic` in mission with this output:

```
[00:00:22.492,336] <err> os: 
[00:00:22.498,928] <err> os:  mcause: 11, Environment call from M-mode
[00:00:22.509,136] <err> os:   mtval: 0
[00:00:22.516,981] <err> os:      a0: 0000000000000004    t0: 0000000000000000
[00:00:22.528,297] <err> os:      a1: 00000000c0083020    t1: 00000000c007ab12
[00:00:22.539,759] <err> os:      a2: 0000000000000000    t2: 000000000000004c
[00:00:22.551,087] <err> os:      a3: 00000000c007f038    t3: 0000000002000000
[00:00:22.562,528] <err> os:      a4: 0000000000000000    t4: 0000000000000025
[00:00:22.573,854] <err> os:      a5: 00000000c0083110    t5: 00000000c0080e58
[00:00:22.585,314] <err> os:      a6: 0000000000002000    t6: 000000000000002a
[00:00:22.596,351] <err> os:      a7: 0000000000000000
[00:00:22.605,151] <err> os:      sp: 00000000c00888c0
[00:00:22.614,023] <err> os:      ra: 00000000c00674ba
[00:00:22.622,890] <err> os:    mepc: 00000000c00674c2
[00:00:22.631,762] <err> os: mstatus: 0000000000003880
[00:00:22.640,262] <err> os: 
[00:00:22.647,097] <err> os:      s0: 00000000c007a190    s6: 0000000000000000
[00:00:22.658,480] <err> os:      s1: 00000000c007a190    s7: 0000000000000000
[00:00:22.669,870] <err> os:      s2: ffffffffffffffff    s8: 0000000000000000
[00:00:22.681,365] <err> os:      s3: 0000000000000000    s9: 0000000000000000
[00:00:22.692,683] <err> os:      s4: 0000000000000000   s10: 0000000000000000
[00:00:22.704,001] <err> os:      s5: 0000000000000000   s11: 0000000000000000
[00:00:22.714,655] <err> os: 
[00:00:22.720,962] <err> os: call trace:
[00:00:22.728,963] <err> os:       0: sp: 00000000c00888c0 ra: 00000000c00674c2
[00:00:22.740,874] <err> os:       1: sp: 00000000c00888d0 ra: 00000000c0075dbc
[00:00:22.752,749] <err> os:       2: sp: 00000000c00888d8 ra: 00000000c0075d72
[00:00:22.764,694] <err> os:       3: sp: 00000000c00888f0 ra: 00000000c0075d72
[00:00:22.776,603] <err> os:       4: sp: 00000000c0088900 ra: 00000000c006d9a8
[00:00:22.787,966] <err> os: 
[00:00:22.794,865] <err> os: >>> ZEPHYR FATAL ERROR 4: Kernel panic on CPU 0
[00:00:22.806,079] <err> os: Current thread: 0xc0084110 (main)
[00:00:22.815,707] <err> soc: Fatal error: reason 4
[00:00:22.824,351] <err> soc: SCRATCH[0] = 0x00000000
[00:00:22.833,300] <err> soc: SCRATCH[1] = 0x00000000
[00:00:22.842,247] <err> soc: SCRATCH[2] = 0xc0158000
[00:00:22.851,261] <err> soc: SCRATCH[3] = 0x00000000
[00:00:22.860,208] <err> soc: SCRATCH[4] = 0x00000000
[00:00:22.869,155] <err> soc: SCRATCH[5] = 0x00000000
[00:00:22.878,102] <err> soc: SCRATCH[6] = 0x00000000
[00:00:22.887,049] <err> soc: SCRATCH[7] = 0x00000000
[00:00:22.895,989] <err> soc: SCRATCH[8] = 0x00000000
[00:00:22.904,936] <err> soc: SCRATCH[9] = 0x00000000
[00:00:22.913,883] <err> soc: SCRATCH[10] = 0x00000003
[00:00:22.922,919] <err> soc: SCRATCH[11] = 0x00000000
[00:00:22.931,957] <err> soc: SCRATCH[12] = 0x00000002
[00:00:22.940,993] <err> soc: SCRATCH[13] = 0x00000000
[00:00:22.950,031] <err> soc: SCRATCH[14] = 0x00000000
[00:00:22.959,062] <err> soc: SCRATCH[15] = 0x600dcafe
[00:00:22.967,996] <err> soc: Halting system

```

One downside is that it does use a fair amount of characters. With UART, or a large enough VUART buffer this might not be an issue.