### PR TITLE
boards: tenstorrent: mmk: explicit sival_shim kconfig

### DIFF
--- a/boards/tenstorrent/tt_mmk/Kconfig.defconfig
+++ b/boards/tenstorrent/tt_mmk/Kconfig.defconfig
@@ -9,6 +9,10 @@ config SYS_CLOCK_TICKS_PER_SEC
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 1000000
 
+config SIVAL_SHIM
+	bool
+	default y
+
 if LOG
 
 # Do not enable Tenstorrent virtual logging backend by default on MMK.

--- a/drivers/gpio/gpio_tt_grendel.c
+++ b/drivers/gpio/gpio_tt_grendel.c
@@ -17,7 +17,7 @@
  * (prefixed types, absolute _REG_ADDR). Remove when proper SiVal drop
  * is received with shared header naming scheme.
  */
-#ifdef PLATFORM_KER_SMC
+#ifdef CONFIG_SIVAL_SHIM
 typedef SMC_CPU_GPIO_WRAP_GPIO_0_CONTROL_reg_u GPIO_CTRL_CONTROL_reg_u;
 #endif
 

--- a/soc/tenstorrent/tt_grendel/tt_grendel_smc/soc.c
+++ b/soc/tenstorrent/tt_grendel/tt_grendel_smc/soc.c
@@ -39,7 +39,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf)
  * (prefixed types, absolute _REG_ADDR). Remove when proper SiVal drop
  * is received with shared header naming scheme.
  */
-#ifdef PLATFORM_KER_SMC
+#ifdef CONFIG_SIVAL_SHIM
 typedef SMC_CPU_UART_WRAP0_UART_CTRL_reg_u UART_CTRL_reg_u;
 typedef SMC_CPU_I3C_WRAP_0_I3C_CTRL_I3C_RESET_CTRL_STATUS_reg_u
 	I3C_CTRL_I3C_RESET_CTRL_STATUS_reg_u;


### PR DESCRIPTION
### Overview:

Select the SIVAL_SHIM explicitly with a KCONFIG that is (for now) default true at the board level.

This allows tt_mmk/tt_mimir to run with the sival shim also.

### Tests:

This builds my sysbuild with the shim. 