### PR TITLE
Stub out objtool in Metal CI to prevent glibc mismatch error

### DIFF
--- a/scripts/ci/build-and-load-kmd.sh
+++ b/scripts/ci/build-and-load-kmd.sh
@@ -127,8 +127,13 @@ fi
 # kernel ships a prebuilt objtool linked against GLIBC 2.38+, which
 # cannot run in a 22.04 container (GLIBC 2.35). Skip objtool in that
 # case; it is only used for stack validation and is not required to produce a
-# loadable module. SKIP_STACK_VALIDATION was removed from kbuild, so use the
-# documented OBJECT_FILES_NON_STANDARD switch instead.
+# loadable module.
+#
+# OBJECT_FILES_NON_STANDARD=y only skips per-TU objtool. With IBT/LTO, kbuild
+# still runs objtool on the linked module (tenstorrent.o), which is where the
+# glibc mismatch fails. SKIP_STACK_VALIDATION was removed from kbuild. Point
+# kbuild's `objtool` (scripts/Makefile.lib) at a no-op stub instead;
+# /usr/src is bind-mounted read-only.
 OBJTOOL_BIN="/lib/modules/${KVER}/build/tools/objtool/objtool"
 objtool_can_run() {
 	local err
@@ -144,7 +149,10 @@ objtool_can_run() {
 if ! objtool_can_run "$OBJTOOL_BIN"; then
 	echo "Kernel objtool cannot run in this environment (likely a glibc" \
 		"mismatch with bind-mounted host headers); skipping stack validation"
-	MAKE_ARGS+=("OBJECT_FILES_NON_STANDARD=y")
+	OBJTOOL_STUB="$BUILD_DIR/objtool-stub"
+	printf '#!/bin/sh\nexit 0\n' > "$OBJTOOL_STUB"
+	chmod +x "$OBJTOOL_STUB"
+	MAKE_ARGS+=("objtool=$OBJTOOL_STUB")
 fi
 
 make -C "$BUILD_DIR/tt-kmd" "${MAKE_ARGS[@]+"${MAKE_ARGS[@]}"}"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -9,6 +9,10 @@ set -e
 
 echo "## Running formatting check on commits. To skip this check, run git commit --no-verify ##"
 
+# Git worktrees set GIT_DIR to .git/worktrees/<name>. West then treats this
+# checkout as a new workspace and fails importing zephyr/west.yml.
+unset GIT_DIR GIT_WORK_TREE
+
 if [ -z "${ZEPHYR_BASE}" ]; then
 	zep_base=$(west list -f "{abspath}" zephyr)
 	echo "ZEPHYR_BASE not set, using $zep_base"

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -15,6 +15,10 @@ done
 
 echo "## Running compliance checks on commits. To skip these checks, run git push --no-verify ##"
 
+# Git worktrees set GIT_DIR to .git/worktrees/<name>. West then treats this
+# checkout as a new workspace and fails importing zephyr/west.yml.
+unset GIT_DIR GIT_WORK_TREE
+
 if [ -z "${ZEPHYR_BASE}" ]; then
 	zep_base=$(west list -f "{abspath}" zephyr)
 	echo "ZEPHYR_BASE not set, using $zep_base"


### PR DESCRIPTION
## Overview
Metal container Ubuntu version mismatch with host (22.04 vs 24.04) causes Metal CI failure due to glibc version mismatch during tt-kmd build.

This is because during tt-kmd build, we run **host** objtool against the container's glibc.

Objtool invocation (Kernel configured with CONFIG_OBJTOOL) is typical for Ubuntu 24.04 and is used for stack/unwind metadata for kernel traces through kernel modules, and LTO. It is not necessary for getting a working kernel module, so can be skipped.

> (Learn more about objtool: https://github.com/torvalds/linux/blob/master/tools/objtool/Documentation/objtool.txt)
> Relevant for us: "OBJECT_FILES_NON_STANDARD doesn't work for link time validation of vmlinux.o or a linked module.  So it should only be used for files which aren't linked into vmlinux or a module."

This PR stubs out the objtool bin as a no-op if there's a glibc version mismatch.

Also adds functionality for using git work trees in commit/push verification - improve your development workflow for working on multiple branches simultaneously!

## Tests
Metal CI on this PR with `syseng-gh-02` (Ubuntu 24.04 machine) tt-kmd build passes (was previously failing)!
https://github.com/tenstorrent/tt-system-firmware/actions/runs/33907858448/job/101136999512?pr=1475#logs