### PR TITLE
treewide: fix typos in code comments and doxygen markers

### DIFF
--- a/include/tenstorrent/bh_chip.h
+++ b/include/tenstorrent/bh_chip.h
@@ -40,11 +40,11 @@ struct bh_chip_config {
 };
 
 struct bh_chip_data {
-	/* Flag set when bootrom has been loaded and the arc_soft_reset sequence can be appled. */
+	/* Flag set when bootrom has been loaded and the arc_soft_reset sequence can be applied. */
 	bool workaround_applied;
 
 	/*
-	 * Flag set when need to send or receive 1 time info to chip.
+	 * Flag set when we need to send or receive 1 time info to chip.
 	 * Could be used for static data or config of peripherals.
 	 */
 	bool arc_needs_init_msg;

--- a/include/tenstorrent/uart_tt_virt.h
+++ b/include/tenstorrent/uart_tt_virt.h
@@ -69,14 +69,14 @@ enum tt_vuart_role {
 struct tt_vuart {
 	uint32_t magic;    /**< Magic number used to identify the virtual uart in memory */
 	uint32_t rx_cap;   /**< Receive buffer capacity, in bytes */
-	uint32_t rx_head;  /** Receive head counter */
-	uint32_t rx_tail;  /** Receive tail counter */
+	uint32_t rx_head;  /**< Receive head counter */
+	uint32_t rx_tail;  /**< Receive tail counter */
 	uint32_t tx_cap;   /**< Transmit buffer capacity, in bytes */
-	uint32_t tx_head;  /** Transmit head counter */
-	uint32_t tx_oflow; /** Number of transmit overflows (device to host) */
-	uint32_t tx_tail;  /** Transmit tail counter */
+	uint32_t tx_head;  /**< Transmit head counter */
+	uint32_t tx_oflow; /**< Number of transmit overflows (device to host) */
+	uint32_t tx_tail;  /**< Transmit tail counter */
 	uint32_t version;  /**< Version info MS-Byte to LS-Byte [INST.MAJOR.MINOR.PATCH] */
-	uint8_t buf[];     /** Buffer area of `tx_cap` bytes followed by `rx_cap` bytes */
+	uint8_t buf[];     /**< Buffer area of `tx_cap` bytes followed by `rx_cap` bytes */
 };
 
 /**
@@ -196,7 +196,7 @@ static inline int tt_vuart_poll_in(volatile struct tt_vuart *vuart, unsigned cha
 /**
  * @brief Poll the virtual UART buffer with outgoing data.
  *
- * This method transmits one byte of data from the virtual UART buffer, if possible.
+ * This method transmits one byte of data to the virtual UART buffer, if possible.
  * If the buffer is empty, this method simply returns.
  *
  * If writing to the virtual UART results in buffer overflow, the overflow counter is incremented

--- a/scripts/tooling/tracing.c
+++ b/scripts/tooling/tracing.c
@@ -211,7 +211,7 @@ static int parse_args(struct tracing *tracing, int argc, char **argv)
 			errno = 0;
 			addr = strtol(optarg, NULL, 0);
 			if (errno != 0) {
-				E("invalid operand to -i %s: %s", optarg, strerror(errno));
+				E("invalid operand to -a %s: %s", optarg, strerror(errno));
 				usage(basename(argv[0]));
 				return -errno;
 			}


### PR DESCRIPTION
## Summary

Comment-only fixes for 10 defects. No functional change to firmware behaviour.

- **include/tenstorrent/uart_tt_virt.h**: six `struct tt_vuart` members (`rx_head`, `rx_tail`, `tx_head`, `tx_oflow`, `tx_tail`, `buf[]`) use `/**` rather than `/**<` for their trailing member comments. Doxygen treats `/**` as a *preceding* comment, so each of these docs is currently attached to the following member. The other four members of the same struct (`magic`, `rx_cap`, `tx_cap`, `version`) already use `/**<`.
- **include/tenstorrent/uart_tt_virt.h**: `tt_vuart_poll_out()` writes `out_char` *into* the buffer, but its `@brief` body said it "transmits one byte of data **from** the virtual UART buffer" — copy-pasted from `tt_vuart_poll_in()` directly above. Changed `from` -> `to`.
- **scripts/tooling/tracing.c** (line 214): the `case 'a':` handler prints `invalid operand to -i` — every other handler in the same `switch` names its own option (`-b`, `-c`, `-i`, `-m`). Changed to `-a`. **This changes a user-facing error string**, so please review; no test or script in the repo asserts on it (grepped the tree).
- **include/tenstorrent/bh_chip.h**: `appled` -> `applied` in the `workaround_applied` comment.
- **include/tenstorrent/bh_chip.h**: `Flag set when need to send...` -> `Flag set when we need to send...`.

Not changed, but worth a look: `scripts/tooling/console.c` has the same option-letter copy-paste in three more places — the `case 'a'` (line 246), `case 'm'` (line 297) and `case 'w'` (line 323) handlers all print `invalid operand to -i`. Left alone to keep this PR to the set actually reviewed; happy to fold them in if you'd like.

Commit is signed off per CONTRIBUTING.md.