### PR TITLE
github: workflows: skip expired artifacts in ci-stats

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,12 +71,27 @@ jobs:
             console.log(`Total artifacts found: ${artifacts.data.artifacts.length}`);
 
             for (const artifact of artifacts.data.artifacts) {
-              const download = await github.rest.actions.downloadArtifact({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                artifact_id: artifact.id,
-                archive_format: 'zip'
-              });
+              if (artifact.expired) {
+                console.log(`Skipping artifact ${artifact.id}, expired`);
+                continue;
+              }
+
+              let download;
+              try {
+                download = await github.rest.actions.downloadArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: artifact.id,
+                  archive_format: 'zip'
+                });
+              } catch (error) {
+                if (error.status === 410) {
+                  // Handles race where artifact expires after artifacts cache but before download
+                  console.log(`Skipping artifact ${artifact.id}, expired`);
+                  continue;
+                }
+                throw error;
+              }
 
               const fname = `${artifact.name}-${artifact.id}-${artifact.workflow_run.head_sha}.zip`;
               fs.writeFileSync(fname, Buffer.from(download.data));

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,12 @@ name: Documentation
 on:
   push:
     branches: [main]
-  pull_request: {}
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -20,6 +25,8 @@ env:
 
 jobs:
   gen-config:
+    # Avoid a full docs rebuild when some other PR label is added.
+    if: github.event.action != 'labeled' || github.event.label.name == 'ci-docs'
     runs-on: ubuntu-24.04
     outputs:
       ci-boards: ${{ steps.gen-config.outputs.ci-boards }}
@@ -31,7 +38,8 @@ jobs:
           echo "ci-boards=$(jq -c "[ .[][] | .board ]" .github/ci_boards.json)" | tee -a $GITHUB_OUTPUT
 
   ci-stats:
-    if: github.event_name == 'push'
+    # Label: ci-docs ("Request Documentation CI to be run on this PR")
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci-docs')
     needs: [gen-config]
     strategy:
       matrix:
@@ -245,7 +253,7 @@ jobs:
   build-ci-stats:
     runs-on: ubuntu-22.04
     needs: [build, ci-stats, gen-config]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci-docs')
     steps:
       - name: Download docs
         uses: actions/download-artifact@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,6 +76,11 @@ jobs:
                 continue;
               }
 
+              if (artifact.workflow_run.head_branch != 'main') {
+                console.log(`Skipping artifact ${artifact.id}, branch ${artifact.workflow_run.head_branch}`);
+                continue;
+              }
+
               let download;
               try {
                 download = await github.rest.actions.downloadArtifact({
@@ -117,11 +122,6 @@ jobs:
 
                     if (!testResults[testName]) {
                       testResults[testName] = {};
-                    }
-
-                    if (artifact.workflow_run.head_branch != 'main') {
-                      console.log(`Skipping artifact ${artifact.id}, branch ${artifact.workflow_run.head_branch}`);
-                      return;
                     }
 
                     if (!testResults[testName][workflowRunId]) {


### PR DESCRIPTION
## Overview
Loudbox ci-stats has been failing due to expired artifacts. Eg.
https://github.com/tenstorrent/tt-system-firmware/actions/runs/34231674677/job/102079158083
So skip expired and just output a shorter stats csv.

Not unexpected since we haven't run loudbox stress in a while. Perhaps we should remove ci-stats for loudbox entirely? Unless we wish to resume testing loudbox - We may well end up with this job just generating empty CSVs.

Additional changes:
- Skip downloading non-main artifacts (we previously skipped after downloading)
- Add `ci-docs` label to run docs.yml workflow manually

## Tests
Run on this PR with `ci-docs`
Loudbox pass!
https://github.com/tenstorrent/tt-system-firmware/actions/runs/34239450084/job/102105599977?pr=1486
