### PR TITLE
doc: release: fill in the v19.15.0 change list backport

### DIFF
--- a/doc/release/migration-guide-19.15.md
+++ b/doc/release/migration-guide-19.15.md
@@ -3,3 +3,79 @@
 ## Migration Guide
 
 This document lists recommended and required changes for those migrating from the previous v19.14.0 firmware release to the new 19.15.0 firmware release.
+
+## Required: second-source SPI flash interlock
+
+Blackhole Galaxy may now ship a second-source SPI EEPROM. Firmware older than 19.15 only speaks the Micron MT25QU512ABB command set. Writing that image onto a second-source board leaves firmware that cannot read itself back, including recovery.
+
+19.15 adds an interlock so tt-flash will not write an image that cannot support the board in front of it. There are three participants:
+
+1. **Firmware bundle** — each image declares the board variables it knows and the values it supports, in `compat-variables.json`.
+2. **tt-flash** — checks those values against the running firmware (today: SPI EEPROM JEDEC ID from telemetry tag 80) and refuses an incompatible image.
+3. **Running firmware** — `FLASH_UNLOCK` carries a bitmap of the variables tt-flash checked. Firmware refuses to unlock if a required variable is missing, so an older tt-flash that does not know about board variables cannot flash a second-source board.
+
+The first board variable is SPI EEPROM JEDEC ID (`BOARD_VAR_SPI_JEDEC_ID` = 0).
+
+### What you must do
+
+- **Original Micron MT25QU512ABB boards** (`JEDEC ID 0x20bb20`): no tool change is required. Firmware exempts this part from the JEDEC-ID unlock check, so existing tt-flash continues to work.
+- **Second-source SPI boards** (any other JEDEC ID): you need both
+  - a 19.15.0 (or later) firmware bundle, which includes `compat-variables.json`, and
+  - a tt-flash that implements the board-variable interlock ([tt-flash#112](https://github.com/tenstorrent/tt-flash/pull/112)).
+- **Galaxy bin6** (board type `0x202`): tt-flash 3.11.0 or later, in addition to the interlock above if the board is second-source.
+
+Until tt-flash#112 is in a numbered release, flashing a second-source board requires a tt-flash build that includes that change.
+
+### Compatibility matrix
+
+`x` means the version of that participant does not matter. "new" means 19.15 firmware / a bundle that carries `compat-variables.json` / a tt-flash that implements the interlock. Observed messages are from qualification.
+
+| fwbundle | tt-flash | running FW | Result | Observed |
+| -------- | -------- | ---------- | ------ | -------- |
+| x | x | old | Not applicable / don't care | (old firmware does not implement the interlock) |
+| x | old | new | No app support; firmware must not unlock | `Error: Failed to unlock spi` |
+| old | new | new | Bundle does not declare hardware support; firmware must not unlock | `Error: The firmware on this board will not allow a flash until these are verified against the image: board variable 0. This firmware bundle does not say which hardware it supports; use a newer bundle.` |
+| new but incompatible | new | new | tt-flash rejects before write | `Error: This firmware is not compatible with this board: SPI EEPROM is 0x20bb20; this firmware supports 0x20bb21` |
+| new | new | new | Flash unlocks; new image is written | successfully flashed |
+
+The incompatible-bundle example above is the error shape (actual JEDEC IDs depend on the fitted part and the image).
+
+### Supported SPI EEPROM JEDEC IDs
+
+19.15 images that include the Galaxy flash mux accept:
+
+| JEDEC ID   | Part |
+| ---------- | ---- |
+| `0x20bb20` | Micron MT25QU512ABB |
+| `0xc2253a` | Macronix MX25U51245G |
+| `0xc8631a` | GigaDevice GD25LF512MF |
+| `0xef6020` | Winbond W25Q51RW-Q/-N, W25Q512NW-IQ/IN |
+
+An unrecognized chip still enumerates on a single-I/O fallback so the card stays readable. Flashing it still requires a bundle that lists that JEDEC ID. `tt-flash --force` does not override this check.
+
+### Downgrade
+
+On a **second-source** board that is already running 19.15:
+
+- Old tt-flash cannot unlock the flash (`Failed to unlock spi`).
+- A new tt-flash will not write a pre-19.15 bundle, because that bundle has no `compat-variables.json`.
+
+You cannot return those boards to pre-19.15 firmware with the old tools. Stay on 19.15+ bundles and an interlock-aware tt-flash.
+
+On an **MT25** board, existing tools and older bundles continue to work.
+
+See [board variables](https://github.com/tenstorrent/tt-system-firmware/tree/main/doc/services/board_variables/index.rst) for the protocol.
+
+## Recommended: Tensix clock gating now honors `cg_en`
+
+`feature_enable.cg_en` was inverted: firmware skipped Tensix clock gating when the flag was set, and applied it when the flag was clear. 19.15 corrects this.
+
+Every production firmware table ships `cg_en: true`, so after upgrade Tensix clock gating is on. Idle and light-load Tensix power should drop; full-load power is largely unchanged. If you had cleared `cg_en` to *enable* gating under the old inverted logic, that board will now run with gating off — set `cg_en` to the intended polarity.
+
+## Optional: PCIe max generation override
+
+`pci0_property_table.max_pcie_speed` and `pci1_property_table.max_pcie_speed` can be overridden with `bh-mod` and persist across firmware upgrades. Valid values are `{0, 1, 2, 3, 4, 5}`; `0` is unconstrained (Gen 5 default). `bh-mod res` restores the cmfwcfg value. Set the instance whose `pcie_mode` is EP. This requires tt-flash 3.8.0 or later to preserve `ccfgovr` across flashes.
+
+## Galaxy bin6
+
+Galaxy bin6 is a new UBB board type (`0x202`, `tt_blackhole@galaxy_bin6`). Host tools that switch on board type need to treat `0x202` as a Galaxy/UBB variant (one harvested DRAM instance; SPI tables based on Galaxy Rev C). tt-flash 3.11.0 adds this type.

--- a/doc/release/release-notes-19.15.md
+++ b/doc/release/release-notes-19.15.md
@@ -1,21 +1,93 @@
 # v19.15.0
 
-> This is a working draft for the up-coming 19.15.0 release.
-
 We are pleased to announce the release of TT System Firmware version 19.15.0 🥳🎉.
 
 Major enhancements with this release include:
+
+- Second-source SPI flash support on Blackhole Galaxy, with a flash-tool interlock so an image that cannot drive the fitted EEPROM cannot be written.
+- Galaxy bin6 board revision (`0x202`), for UBB parts that permit one harvested DRAM instance.
+- Persistent `bh-mod` override of per-instance PCIe max generation.
+- Fix of inverted Tensix clock-gate enable: `feature_enable.cg_en` now actually enables clock gating (lower idle / light-load Tensix power on production tables).
 
 ## What's Changed
 
 ## Blackhole
 
+### Second-source SPI Flash
+
+Blackhole Galaxy boards may now ship a second-source SPI EEPROM instead of the original Micron MT25QU512ABB. Firmware selects the matching flash configuration at boot from a mux of known parts, and reports the fitted JEDEC ID in telemetry.
+
+Supported parts (JEDEC ID as `0x00MMTTCC`):
+
+| JEDEC ID   | Part |
+| ---------- | ---- |
+| `0x20bb20` | Micron MT25QU512ABB |
+| `0xc2253a` | Macronix MX25U51245G |
+| `0xc8631a` | GigaDevice GD25LF512MF |
+| `0xef6020` | Winbond W25Q51RW-Q/-N, W25Q512NW-IQ/IN |
+
+An unrecognized chip still comes up on a single-I/O fallback so the board remains readable and reflashable.
+
+Writing an MT25-only image onto a second-source board would leave firmware that cannot read itself back, including recovery. This release therefore adds a three-way interlock between the firmware bundle, tt-flash, and the running firmware:
+
+1. Each image in the bundle carries a `compat-variables.json` listing the board variables it constrains and the values it supports. The first variable is SPI EEPROM JEDEC ID (`BOARD_VAR_SPI_JEDEC_ID`, telemetry tag 80).
+2. tt-flash compares those constraints to the value reported by the running firmware and refuses an incompatible image.
+3. `TT_SMC_MSG_FLASH_UNLOCK` carries a bitmap of the variables tt-flash verified. Firmware refuses to unlock if a required variable was not checked, so an older tt-flash that does not know about board variables cannot write a second-source board.
+
+Original Micron MT25 boards are exempt from the JEDEC-ID requirement, so existing tt-flash continues to work on those boards. Second-source boards require a tt-flash that implements the interlock and a 19.15 (or later) bundle. See the [19.15 Migration Guide](https://github.com/tenstorrent/tt-system-firmware/tree/main/doc/release/migration-guide-19.15.md) and the [board variables documentation](https://github.com/tenstorrent/tt-system-firmware/tree/main/doc/services/board_variables/index.rst).
+
+### Boards
+
+- New board revision: Galaxy bin6 (`tt_blackhole@galaxy_bin6`, board type `0x202`). SPI config is based on Galaxy Rev C with `product_spec_harvesting.dram_disable_count` set to 1 (one harvested DRAM instance). The SMC overlay reuses Rev C GDDR parameters.
+
 ### Persistent SPI Flash Parameters
+
 - Expose `pci0_property_table.max_pcie_speed` and
   `pci1_property_table.max_pcie_speed` to `bh-mod`, valid values
   `{0, 1, 2, 3, 4, 5}`. `0` is unconstrained (Gen 5 default).
   `bh-mod res` restores the cmfwcfg value. Set the instance
   whose `pcie_mode` is EP.
+
+### Power
+
+- Fix accidentally inverted Tensix clock-gate enable. `EnableTensixCG()` now applies clock gating when `feature_enable.cg_en` is set, and skips it when the flag is clear. Every production firmware table ships `cg_en: true`, so Tensix clock gating takes effect on upgrade. Expect lower idle and light-load Tensix power; full-load draw is largely unchanged.
+
+### Telemetry
+
+- Publish the SPI flash JEDEC ID as `TAG_FLASH_JEDEC_ID` (tag 80), packed as `0x00MMTTCC` (`MM` manufacturer, `TT` memory type, `CC` capacity). `0` if the ID could not be read.
+- Add characterization submessage `TT_SUB_MSG_SET_TELEMETRY_UPDATE_INTERVAL` to set the periodic telemetry interval (10–1000 ms; `0` restores the 100 ms default).
+
+### Logging
+
+- Publish error-level logs to the host (KMD) immediately rather than waiting for the next periodic flush.
+- Drain queued logs when a GDDR thermal trip is processed, so the trip context is visible on the host.
+
+### Host Interface
+
+- `TT_SMC_MSG_FLASH_UNLOCK` now accepts a verified-board-variable bitmap. The reply always reports the variables this board requires in `data[1]`. See `flash_unlock_rqst` in `msgqueue.h`.
+- Board type extracted from `board_id` is a `uint32_t` (was narrower), covering up to 5-hex-digit types such as Galaxy bin6.
+
+### Drivers
+
+- Add a flash mux that probes JEDEC-ID-matched candidate configurations at boot and selects the first that accepts the fitted chip.
+- Drive Tensix and Ethernet tile/RISC resets through the Zephyr reset API, with complete Blackhole reset DT coverage.
+- DMC: initial MCTP/PLDM support.
+
+### Tooling
+
+- Blackhole recovery flashloader probe table adds Macronix MX25U51245G, GigaDevice GD25LF512MF, and Winbond W25Q51RW.
+- Remove the unused `tt-console` binary from tooling.
+- SMC pytest waits 0.7 s after a power-state toggle and polls the power delta after the low-power settle, so the power-state tests are less timing-sensitive.
+
+### Documentation
+
+- Document board variables and the flash interlock under `doc/services/board_variables/`.
+
+## Grendel
+
+- New SoC/board bring-up: `tt_keraunos`, `tt_mmk`, Mimir remote boot, and K-SMC-bl0p5 (with BL0p5 logging).
+- Msgqueue gains a mailbox IRQ doorbell backend, used by MMK.
+- Register-name shim for Keraunos.
 
 ## Migration guide
 


### PR DESCRIPTION
## Summary
- Fill in the v19.15.0 release notes and migration guide on the release branch.
- Cover the second-source SPI flash interlock, Tensix clock-gate enable fix, PCIe max-speed `bh-mod` override, and Galaxy bin6.
- Include the qualification compatibility matrix and the tt-flash / bundle / running-FW constraints.

## Test plan
- [x] Review notes against `v19.14.0...v19.15.0-rc1` and the four called-out changes
- [x] Confirm the interlock matrix and error strings match qualification
- [x] After merge, copy the notes into the GitHub release when tagging `v19.15.0`


Made with [Cursor](https://cursor.com)