### PR TITLE
drivers: misc: remoteproc: split load from execute

### DIFF
--- a/drivers/misc/tt_mimir_remote_boot/tt_mimir_remote_boot.c
+++ b/drivers/misc/tt_mimir_remote_boot/tt_mimir_remote_boot.c
@@ -59,16 +59,24 @@ static int tt_mimir_remote_boot_init(const struct device *dev)
 			LOG_ERR("remoteproc[%zu] is not ready", i);
 			return -ENODEV;
 		}
-
 		/* TODO - D2D FW copy via OCCP */
 
-		/* Remote execute the M-SMC_BL1 */
-		ret = tt_smc_remoteproc_boot(cfg->remoteprocs[i], entry->load_addr,
+		/* OCCP load firmware bin */
+		ret = tt_smc_remoteproc_load(cfg->remoteprocs[i], entry->load_addr,
 					     (uint8_t *)(TT_BUN2_STAGING_AREA_ADDR +
 							 manifest->payload_offset + entry->offset),
 					     (size_t)entry->length);
 		if (ret != 0) {
 			LOG_ERR("Failed to OCCP-load Mimir FW on remoteproc[%zu]: %d", i, ret);
+			return ret;
+		}
+	}
+
+	for (size_t i = 0; i < cfg->num_remoteprocs; i++) {
+		/* Remote execute the M-SMC_BL1 */
+		ret = tt_smc_remoteproc_boot(cfg->remoteprocs[i], entry->load_addr);
+		if (ret != 0) {
+			LOG_ERR("Failed to OCCP-boot Mimir FW on remoteproc[%zu]: %d", i, ret);
 			return ret;
 		}
 	}

--- a/drivers/misc/tt_smc_remoteproc/tt_smc_remoteproc.c
+++ b/drivers/misc/tt_smc_remoteproc/tt_smc_remoteproc.c
@@ -29,18 +29,26 @@ struct tt_smc_remoteproc_data {
 	struct occp_backend_i3c occp_backend; /* OCCP I3C backend */
 };
 
-int tt_smc_remoteproc_boot(const struct device *dev, uint64_t addr, uint8_t *img_data,
-			   size_t img_size)
+int tt_smc_remoteproc_load(const struct device *dev, uint64_t addr, const uint8_t *bin_data,
+			   size_t bin_size)
 {
 	struct tt_smc_remoteproc_data *data = dev->data;
 	int ret;
 
 	/* Write image to target */
-	ret = occp_write_data(&data->occp_backend.base, addr, img_data, img_size);
+	ret = occp_write_data(&data->occp_backend.base, addr, bin_data, bin_size);
 	if (ret != 0) {
 		LOG_ERR("Failed to write image to remote SMC: %d", ret);
 		return ret;
 	}
+
+	return 0;
+}
+
+int tt_smc_remoteproc_boot(const struct device *dev, uint64_t addr)
+{
+	struct tt_smc_remoteproc_data *data = dev->data;
+	int ret;
 
 	/* Execute image on CPU 0 */
 	ret = occp_execute_image(&data->occp_backend.base, addr, 0);

--- a/include/zephyr/drivers/misc/tt_smc_remoteproc.h
+++ b/include/zephyr/drivers/misc/tt_smc_remoteproc.h
@@ -7,21 +7,41 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_MISC_TT_SMC_REMOTEPROC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_MISC_TT_SMC_REMOTEPROC_H_
 
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/device.h>
+
 /**
  * @file
  * @brief Tenstorrent SMC Remote Processor APIs
  */
 
 /**
- * @brief Boot SMC remote processor
+ * @brief Write binary data into remote SMC memory.
  *
- * Load an image to SMC remote processor SRAM, and boot it
- * @param dev Pointer to the tt_smc_remoteproc device
- * @param addr Address to load the image to
- * @param img_data Pointer to image data
- * @param img_size Size of image data
+ * Copy an arbitrary block of binary data into the remote SMC address space at @p addr.
+ *
+ * @param dev Pointer to the tt_smc_remoteproc device.
+ * @param addr Target address in the remote SMC memory map.
+ * @param bin_data Pointer to the binary data to write.
+ * @param bin_size Number of bytes in @p bin_data.
+ *
+ * @return 0 on success, or a negative errno code on failure.
  */
-int tt_smc_remoteproc_boot(const struct device *dev, uint64_t addr, uint8_t *img_data,
-			   size_t img_size);
+int tt_smc_remoteproc_load(const struct device *dev, uint64_t addr, const uint8_t *bin_data,
+			   size_t bin_size);
+
+/**
+ * @brief Boot a previously loaded SMC image.
+ *
+ * Start execution of the image already placed at @p addr on the remote SMC CPU.
+ *
+ * @param dev Pointer to the tt_smc_remoteproc device.
+ * @param addr Address of the loaded image entry point in the remote SMC memory map.
+ *
+ * @return 0 on success, or a negative errno code on failure.
+ */
+int tt_smc_remoteproc_boot(const struct device *dev, uint64_t addr);
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_MISC_TT_SMC_REMOTEPROC_H_ */

--- a/tests/drivers/tt_smc_remoteproc/src/main.c
+++ b/tests/drivers/tt_smc_remoteproc/src/main.c
@@ -31,8 +31,11 @@ ZTEST(tt_smc_remoteproc, test_boot)
 
 	zassert_true(device_is_ready(smc_dev), "Remote SMC device not ready");
 
-	ret = tt_smc_remoteproc_boot(smc_dev, SMC_SRAM_OCCP_BASE, remote_smc_bin,
+	ret = tt_smc_remoteproc_load(smc_dev, SMC_SRAM_OCCP_BASE, remote_smc_bin,
 				     remote_smc_bin_len);
+	zassert_equal(ret, 0, "Failed to load remote SMC image: %d", ret);
+
+	ret = tt_smc_remoteproc_boot(smc_dev, SMC_SRAM_OCCP_BASE);
 	zassert_equal(ret, 0, "Failed to boot remote SMC: %d", ret);
 
 	/*


### PR DESCRIPTION
### Overview
Split remoteproc load from remoteproc execute.

This allows

A) Quicker back to back executes on two remote cores since we can perform load A -> load B -> exec A -> Exec B 
B) Placement of arbitrary bins via I3C; needed for eventual D2D work.

### Tests

Full mission boot in ttsim