### PR TITLE
scripts: ci: skip tt-kmd rebuild when the host module matches

### DIFF
--- a/scripts/ci/build-and-load-kmd.sh
+++ b/scripts/ci/build-and-load-kmd.sh
@@ -9,13 +9,20 @@
 
 set -euo pipefail
 
-if [ $# -ne 1 ] || [ -z "$1" ]; then
-	echo "Usage: $(basename "$0") <kmd-version>" >&2
+if [ $# -lt 1 ] || [ $# -gt 2 ] || [ -z "$1" ]; then
+	echo "Usage: $(basename "$0") <kmd-version> [--force]" >&2
 	echo "Example: $(basename "$0") 2.10.0" >&2
 	exit 1
 fi
 
 KMD_VERSION="$1"
+FORCE=0
+if [ "${2:-}" = "--force" ]; then
+	FORCE=1
+elif [ -n "${2:-}" ]; then
+	echo "Usage: $(basename "$0") <kmd-version> [--force]" >&2
+	exit 1
+fi
 KMD_TAG="ttkmd-${KMD_VERSION}"
 KVER="$(uname -r)"
 KMD_REPO="${KMD_REPO:-https://github.com/tenstorrent/tt-kmd.git}"
@@ -29,6 +36,13 @@ fi
 export DEBIAN_FRONTEND=noninteractive
 
 echo "Running kernel: ${KVER}"
+if [ "$FORCE" -eq 0 ] && [ -d /sys/module/tenstorrent ]; then
+	LOADED="$(cat /sys/module/tenstorrent/version)"
+	if [ "$LOADED" = "$KMD_VERSION" ]; then
+		echo "tt-kmd loaded: ${LOADED} (already present, skip rebuild)"
+		exit 0
+	fi
+fi
 echo "Building ${KMD_TAG} from ${KMD_REPO}"
 
 "${SUDO[@]}" apt-get update


### PR DESCRIPTION
## Overview
https://github.com/tenstorrent/tt-system-firmware/pull/1475 fixed objtool GLIBC version error on 24.04 containers, but now we're tripping on modpost (when building in 22.04 metal container). My bad that slipped through - saw the pass in our hardware smoke container and thought it was good. Eg. https://github.com/tenstorrent/tt-system-firmware/actions/runs/34016466804/job/101442161371

So skip the rebuild if the loaded kmd version matches what is requested. This means that when tt-kmd updates, we'll trip over this again on `syseng-gh-02` metal tests. But for now, I just want to turn CI green

Add `--force` flag to `build-and-load-kmd.sh` to force build.

## Tests
Disabled `syseng-gh-03` and ran metal tests on this PR
Will post `syseng-gh-02` metal:
https://github.com/tenstorrent/tt-system-firmware/actions/runs/34277190416/job/102236610661