### PR TITLE
scripts: Add timeout to reset_dmc

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -1047,6 +1047,7 @@ def dirty_reset_test():
     """
     Helper to execute dirty reset test. Returns True if test passes, False otherwise
     """
+    openocd_timeout = 30  # seconds to wait for OpenOCD to reset the DMC
     timeout = 60  # seconds to wait for SMC boot
 
     # Use dmc-reset script as a library to reset the DMC
@@ -1054,15 +1055,16 @@ def dirty_reset_test():
         return None
 
     args.config = dmc_reset.DEFAULT_DMC_CFG
-    args.debug = 0
+    args.debug = 1
     args.openocd = dmc_reset.DEFAULT_OPENOCD
     args.scripts = dmc_reset.DEFAULT_SCRIPTS_DIR
     args.jtag_id = None
     args.hexfile = None
+    args.timeout = openocd_timeout
 
     ret = dmc_reset.reset_dmc(args)
     if ret != os.EX_OK:
-        logger.warning("DMC reset failed on iteration")
+        logger.warning("DMC reset failed")
         return False
     ret = dmc_reset.wait_for_smc_boot(timeout)
     if ret != os.EX_OK:

--- a/scripts/dmc_reset.py
+++ b/scripts/dmc_reset.py
@@ -228,8 +228,12 @@ def wait_for_smc_boot(timeout):
     Waits for SMC to complete boot after DMC is reset
     @param timeout: time to wait for boot in seconds
     """
-    remaining = timeout
+    start = time.monotonic()
     delay = 1
+
+    def timed_out():
+        return time.monotonic() - start >= timeout
+
     # First stage- rescan pcie
     while True:
         try:
@@ -239,9 +243,10 @@ def wait_for_smc_boot(timeout):
         if Path("/dev/tenstorrent/0").exists():
             break
         time.sleep(delay)
-        remaining -= delay
-        if remaining <= 0:
-            logger.error(f"Card did not enumerate after {timeout} seconds")
+        if timed_out():
+            logger.error(
+                f"Card did not enumerate after {time.monotonic() - start:.0f} seconds"
+            )
             return os.EX_UNAVAILABLE
     # Second stage- is the card firmware working?
     if not pyluwen_found:
@@ -263,23 +268,23 @@ def wait_for_smc_boot(timeout):
         except BaseException:
             # Rescan PCIe again, in case the card disappeared
             pcie_utils.rescan_pcie()
-        remaining -= delay
         time.sleep(delay)
-        if remaining <= 0:
-            logger.error(f"SMC failed to initialize after {timeout} seconds")
+        if timed_out():
+            logger.error(
+                f"SMC failed to initialize after {time.monotonic() - start:.0f} seconds"
+            )
             return os.EX_UNAVAILABLE
     # TAG_DM_APP_FW_VERSION stays 0 until SMC sends Dm2CmReadyRequest and DMC
     # responds with send_init_data (bh_chip_set_static_info). Telemetry becomes
     # readable before that handshake, so wait for the version to appear.
     m3_ver = telemetry.m3_app_fw_version
     while m3_ver == 0:
-        if remaining <= 0:
+        if timed_out():
             logger.error(
-                f"SMC is not up: DMC app FW version still 0 after {timeout} seconds"
+                f"SMC is not up: DMC app FW version still 0 after {time.monotonic() - start:.0f} seconds"
             )
             return os.EX_UNAVAILABLE
         time.sleep(delay)
-        remaining -= delay
         try:
             m3_ver = chip.get_telemetry().m3_app_fw_version
         except Exception:
@@ -296,12 +301,12 @@ def wait_for_smc_boot(timeout):
             if rsp[0] == 1:
                 break
         except Exception:
-            # Just decrement timeout, which we do below
             pass
-        remaining -= delay
         time.sleep(delay)
-        if remaining <= 0:
-            logger.error(f"SMC unable to communicate with DMC after {timeout} seconds")
+        if timed_out():
+            logger.error(
+                f"SMC unable to communicate with DMC after {time.monotonic() - start:.0f} seconds"
+            )
             return os.EX_UNAVAILABLE
     return os.EX_OK
 

--- a/scripts/dmc_reset.py
+++ b/scripts/dmc_reset.py
@@ -50,6 +50,8 @@ DEFAULT_OPENOCD = DEFAULT_SDK_INSTALL_DIR / "usr" / "bin" / "openocd"
 DEFAULT_SCRIPTS_DIR = DEFAULT_SDK_INSTALL_DIR / "usr" / "share" / "openocd" / "scripts"
 DEFAULT_HW_MAP = OPT_DIR / "twister" / "hw-map.yml"
 
+DEFAULT_OPENOCD_TIMEOUT = 60
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Reset DMC", allow_abbrev=False)
@@ -111,6 +113,14 @@ def parse_args():
         action="store_true",
         help="Wait for SMC to boot after resetting DMC",
     )
+    parser.add_argument(
+        "-t",
+        "--timeout",
+        default=DEFAULT_OPENOCD_TIMEOUT,
+        help="Timeout in seconds for the openocd command",
+        metavar="TIMEOUT",
+        type=int,
+    )
 
     args = parser.parse_args()
 
@@ -130,6 +140,19 @@ def parse_args():
 
 
 def reset_dmc(args):
+    """
+    Reset the DMC
+    All args must be provided if calling reset_dmc directly.
+    @param args: arguments
+        args.openocd: path to openocd executable
+        args.scripts: path to openocd scripts directory
+        args.config: path to openocd config file
+        args.jtag_id: JTAG ID of the DMC
+        args.hexfile: path to hex file to program to the DMC
+        args.timeout: timeout in seconds for the openocd command
+        args.debug: debug level
+    @return: exit code EX_OK if successful, otherwise an error code
+    """
     openocd_cmd = [
         str(args.openocd),
         "-s",
@@ -173,10 +196,28 @@ def reset_dmc(args):
             "stderr": subprocess.DEVNULL,
         }
 
-    proc = subprocess.run(openocd_cmd, **openocd_kwargs)
+    if args.timeout:
+        openocd_timeout = args.timeout
+    else:
+        openocd_timeout = DEFAULT_OPENOCD_TIMEOUT
+
+    try:
+        proc = subprocess.run(openocd_cmd, timeout=openocd_timeout, **openocd_kwargs)
+    except subprocess.TimeoutExpired as e:
+        logger.error(
+            f"OpenOCD timed out after {openocd_timeout}s: {' '.join(openocd_cmd)}"
+        )
+        if e.stdout:
+            logger.error(f"OpenOCD stdout:\n{e.stdout.decode(errors='replace')}")
+        if e.stderr:
+            logger.error(f"OpenOCD stderr:\n{e.stderr.decode(errors='replace')}")
+        return os.EX_SOFTWARE
     if proc.returncode != 0:
         logger.error("command failed: " + " ".join(openocd_cmd))
-        logger.error(f"Failed to reset DMC: {proc.stderr}")
+        if proc.stdout:
+            logger.error(f"OpenOCD stdout:\n{proc.stdout.decode(errors='replace')}")
+        if proc.stderr:
+            logger.error(f"OpenOCD stderr:\n{proc.stderr.decode(errors='replace')}")
         return os.EX_SOFTWARE
 
     return os.EX_OK

--- a/scripts/smc_test_recovery.py
+++ b/scripts/smc_test_recovery.py
@@ -50,6 +50,7 @@ def reset_dmc():
     args.scripts = dmc_reset.DEFAULT_SCRIPTS_DIR
     args.jtag_id = None
     args.hexfile = None
+    args.timeout = 30
 
     dmc_reset.reset_dmc(args)
 


### PR DESCRIPTION
## Overview
We sometimes see smoke test timeout failures (12 mins):
https://github.com/tenstorrent/tt-system-firmware/actions/runs/34267692435/job/102201401358?pr=1488
This happens when dirty reset hangs (7 mins below)
```
2026-09-08T19:20:08.9819659Z DEBUG   - PYTEST: INFO: dirty reset passed on iteration 1
2026-09-08T19:20:08.9820039Z DEBUG   - PYTEST: INFO: Iteration 2:
2026-09-08T19:27:20.8984405Z DEBUG   - PYTEST: ERROR: SMC failed to initialize after 60 seconds
2026-09-08T19:27:20.8984848Z DEBUG   - PYTEST: WARNING: SMC did not boot after dirty reset
2026-09-08T19:27:20.8985257Z DEBUG   - PYTEST: WARNING: dirty reset failed on iteration 2
2026-09-08T19:27:20.8985578Z DEBUG   - PYTEST: INFO: Iteration 3:
2026-09-08T19:27:23.4128571Z DEBUG   - PYTEST: INFO: dirty reset passed on iteration 3
```
Not sure if this happens in `reset_dmc` openocd command or in `wait_for_smc_boot`. This PR hopes to add some visibility.

Add timeout parameter to reset_dmc openocd subprocess (default 60s default), smoke test calls with 30s timeout (since we're not doing programming).

Add openocd logs on `reset_dmc` timeout or failure.

Update `wait_for_smc_boot` timeout check to be more deterministic. `rescan_pcie()` takes 1s (guaranteed), `pyluwen.detect_chips()` is capped to 5s. `get_telemetry` expected to be instant. Output the actual time spent at the failed stage so that we can see if we're hanging in one of the above.

## Test
Ran smoke dirty reset (passed 10/10)

<details>
<summary> Added "badargs" to openocd command to force failure and collected the logs:</summary>

```
INFO     e2e_smoke:e2e_smoke.py:1058 Iteration 9:
ERROR    dmc_reset:dmc_reset.py:216 command failed: /home/projkov/zephyr-sdk-1.0.1/hosttools/sysroots/x86_64-pokysdk-linux/usr/bin/openocd -s /home/projkov/zephyr-sdk-1.0.1/hosttools/sysroots/x86_64-pokysdk-linux/usr/share/openocd/scripts -f /home/projkov/tt-system-firmware-work/tt-system-firmware/boards/tenstorrent/tt_blackhole/support/tt_blackhole_dmc.cfg -c init -c targets -c reset run badargs; exit
ERROR    dmc_reset:dmc_reset.py:220 OpenOCD stderr:
Open On-Chip Debugger 0.12.0-01050-g91bd278a5 (2026-03-25-02:24)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
force hard breakpoints
Info : clock speed 2000 kHz
Info : STLINK V3J8M3B5S1 (API v3) VID:PID 0483:374F
Info : Target voltage: 1.776603
Info : [stm32g0x.cpu] Cortex-M0+ r0p1 processor detected
Info : [stm32g0x.cpu] target has 4 breakpoints, 2 watchpoints
Info : starting gdb server for stm32g0x.cpu on 3333
Info : Listening on port 3333 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32g0x.cpu       hla_target little stm32g0x.cpu       running

power_restore
program <filename> [address] [pre-verify] [verify] [reset] [exit]
reset [run|halt|init]
reset_config [none|trst_only|srst_only|trst_and_srst]
          [srst_pulls_trst|trst_pulls_srst|combined|separate]
          [srst_gates_jtag|srst_nogate] [trst_push_pull|trst_open_drain]
          [srst_push_pull|srst_open_drain]
          [connect_deassert_srst|connect_assert_srst]
reset_nag ['enable'|'disable']
soft_reset_halt
srst_deasserted
  stm32g0x.cpu arp_examine ['allow-defer']
  stm32g0x.cpu arp_halt
  stm32g0x.cpu arp_halt_gdb
  stm32g0x.cpu arp_poll
  stm32g0x.cpu arp_reset
  stm32g0x.cpu arp_waitstate
  stm32g0x.cpu examine_deferred
  stm32g0x.cpu was_examined
  stm32l4x option_load bank_id


WARNING  e2e_smoke:e2e_smoke.py:1034 DMC reset failed
WARNING  e2e_smoke:e2e_smoke.py:1061 dirty reset failed on iteration 9
```

</details>