### PR TITLE
app: smc: pytest: validate all ASICS on DUT launch and mcuboot test

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -234,6 +234,22 @@ def _verify_running_versions(board_name=None, asic_id=0):
     del arc_chip
 
 
+def _expected_chip_count(board_name):
+    """Number of BH chips that must enumerate before tt-flash, or None if unknown."""
+    if board_name is None:
+        return None
+    board_name = board_name.lower()
+    if "galaxy" in board_name:
+        return 32
+    if "loudbox" in board_name:
+        return 8
+    if "quietbox2" in board_name:
+        return 4
+    if "p300" in board_name:
+        return 2
+    return 1
+
+
 def _prepare_and_launch_dut(
     unlaunched_dut: DeviceAdapter,
     flash_mcuboot_bl2=False,
@@ -248,6 +264,7 @@ def _prepare_and_launch_dut(
     should_flash_mcuboot_bl2 = flash_mcuboot_bl2 and (
         board_name is None or not _skip_boards(board_name)
     )
+    min_chips = _expected_chip_count(board_name)
 
     if flash_mcuboot_bl2 and board_name is not None and _skip_boards(board_name):
         logger.info("Skipping mcuboot-bl2 flash on board '%s'", board_name)
@@ -269,7 +286,7 @@ def _prepare_and_launch_dut(
         except subprocess.CalledProcessError as e:
             pytest.exit(f"Failed to flash mcuboot-bl2 with west flash: {e}")
         # Wait for the ARC chip to boot after bootloader flash.
-        wait_arc_boot(asic_id, timeout=timeout)
+        wait_arc_boot(asic_id, timeout=timeout, min_chips=min_chips)
 
     try:
         unlaunched_dut.launch()
@@ -279,23 +296,43 @@ def _prepare_and_launch_dut(
         pytest.exit("DUT flash timed out")
 
     # Wait for the ARC chip to boot after bootloader flash.
-    wait_arc_boot(asic_id, timeout=timeout)
+    wait_arc_boot(asic_id, timeout=timeout, min_chips=min_chips)
 
     _verify_running_versions(board_name=board_name, asic_id=asic_id)
 
 
-def wait_arc_boot(asic_id, timeout=15):
+def _chips_reachable():
+    """
+    Count chips the driver can talk to, whether or not their ARC has booted.
+
+    detect_chips() raises while a chip is still initializing, which does not
+    mean the card fell off the bus.
+    """
+    try:
+        chips = pyluwen.detect_chips_fallible(
+            local_only=True, continue_on_failure=True, noc_safe=True
+        )
+    except BaseException:
+        return 0
+    return sum(1 for chip in chips if chip.have_comms())
+
+
+def wait_arc_boot(asic_id, timeout=15, min_chips=None):
     start = time.time()
+    needed = asic_id + 1 if min_chips is None else min_chips
     # Attempt to detect the ARC chip for 15 seconds
     timeout = timeout
     while True:
         try:
             chips = pyluwen.detect_chips()
-            if len(chips) > asic_id:
-                logger.info("Detected ARC chip")
+            if len(chips) >= needed:
+                logger.info("Detected %d ARC chip(s)", len(chips))
                 break
-        except Exception:
-            logger.warning("SMC firmware requires a reset. Rescanning PCIe bus")
+            logger.warning(
+                "Detected %d/%d ARC chip(s); rescanning PCIe bus", len(chips), needed
+            )
+        except Exception as e:
+            logger.warning("SMC firmware requires a reset. Rescanning PCIe bus: %s", e)
         except BaseException as e:
             # We will continue through these exceptions, since pyluwen
             # sometimes throws rust exceptions when the chip is resetting.
@@ -307,7 +344,9 @@ def wait_arc_boot(asic_id, timeout=15):
             smc_test_recovery.recover_smc(asic_id)
             logger.error(f"Did not detect ARC chip within timeout period {timeout}")
             pytest.exit(f"Did not detect ARC chip within timeout period {timeout}")
-        rescan_pcie()
+        # Removing a chip that is merely mid-boot drops the one function we
+        # already have, and it may not come back.
+        rescan_pcie(remove=_chips_reachable() == 0)
     chip = chips[asic_id]
     try:
         status = chip.axi_read32(ARC_STATUS)
@@ -341,16 +380,10 @@ def arc_chip_dut(launched_arc_dut, asic_id):
 
 def check_chip_count(board_name):
     chips = pyluwen.detect_chips()
-    if "galaxy" in board_name:
-        assert len(chips) == 32, f"Expected 32 BH chips on Galaxy, found {len(chips)}"
-    elif "loudbox" in board_name:
-        assert len(chips) == 8, f"Expected 8 BH chips on Loudbox, found {len(chips)}"
-    elif "quietbox2" in board_name:
-        assert len(chips) == 4, f"Expected 4 BH chips on Quietbox2, found {len(chips)}"
-    elif "p300" in board_name:
-        assert len(chips) == 2, f"Expected 2 BH chips on P300, found {len(chips)}"
-    else:
-        assert len(chips) == 1, f"Expected 1 BH chip, found {len(chips)}"
+    expected = _expected_chip_count(board_name)
+    assert len(chips) == expected, (
+        f"expected {expected} BH chips on {board_name}, found {len(chips)}"
+    )
     del chips
 
 

--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -1271,76 +1271,114 @@ def test_aiclk(arc_chip_dut, asic_id):
         logger.info(f"AICLK set to {aiclk} MHz successfully")
 
 
-def test_mcuboot(unlaunched_dut, asic_id):
+def _read_spi(chip, addr, size):
+    buf = bytearray(size)
+    chip.as_bh().spi_read(addr, buf)
+    return bytes(buf)
+
+
+def _reset_smc():
+    # tt-smi will fail here since it checks for valid telemetry after reset,
+    # we still need to run it to trigger the SMC reboot
+    subprocess.run(["tt-smi", "-r"], capture_output=False, check=False)
+
+
+def test_mcuboot(unlaunched_dut, asic_id, board_name):
     """
     Validates that the SMC falls back to the recovery image
     when the main image is not valid.
+
+    Every ASIC on the card is staged. Both p300 ASICs boot from their own SPI,
+    and tt-flash skips a card whose ASICs are not in the same state.
     """
-    arc_chip = wait_arc_boot(asic_id, timeout=15)
+    min_chips = _expected_chip_count(board_name)
     MCUBOOT_HEADER_ADDR = 0x29E000
     MCUBOOT_MAGIC = 0x96F3B83D
+    ROM_HEADER_ADDR = 0x0
+    # One SPI sector. The boot fs descriptor table runs to 0x3FC0, but erasing
+    # its first sector is enough to make the bootrom fall over to the failover
+    # descriptor at 0x4000.
+    SPI_SECTOR_SIZE = 0x1000
+    ERASED_BLOCK = bytes([0xFF] * SPI_SECTOR_SIZE)
+    wait_arc_boot(asic_id, timeout=15, min_chips=min_chips)
+    targets = pyluwen.detect_chips()
     # First, validate we are running the base image. A good way to check this is
     # to see that telemetry data is available
-    try:
-        arc_chip.get_telemetry()
-    except Exception as e:
-        assert False, f"Failed to get telemetry data: {e}"
-    # Check that the MCUBOOT header magic is present
-    buf = bytes(4)
-    arc_chip.as_bh().spi_read(MCUBOOT_HEADER_ADDR, buf)
-    magic = int.from_bytes(buf, "little")
-    assert magic == MCUBOOT_MAGIC, (
-        f"MCUBOOT magic not found at {MCUBOOT_HEADER_ADDR:#010x}"
-    )
-    logger.info(f"MCUBOOT magic found in main image header: 0x{magic:#010x}")
+    for i, chip in enumerate(targets):
+        try:
+            chip.get_telemetry()
+        except Exception as e:
+            assert False, f"Failed to get telemetry data on chip {i}: {e}"
+        # Check that the MCUBOOT header magic is present
+        magic = int.from_bytes(_read_spi(chip, MCUBOOT_HEADER_ADDR, 4), "little")
+        assert magic == MCUBOOT_MAGIC, (
+            f"MCUBOOT magic not found at {MCUBOOT_HEADER_ADDR:#010x} on chip {i}"
+        )
+        logger.info("MCUBOOT magic found in main image header on chip %d", i)
     # Now, erase the header of the main image, so that the SMC will fall
     # back to the recovery image
     logger.info("Erasing main image header to trigger recovery fallback")
-    buf = bytes([0xFF] * 0x1000)
-    arc_chip.as_bh().spi_write(MCUBOOT_HEADER_ADDR, buf)
+    for chip in targets:
+        chip.as_bh().spi_write(MCUBOOT_HEADER_ADDR, ERASED_BLOCK)
     # Reset the SMC to trigger the fallback
-    del arc_chip  # Force re-detection of the chip
-    smi_reset_cmd = "tt-smi -r"
-    # tt-smi will fail here since it checks for valid telemetry after reset,
-    # we still need to run it to trigger the SMC reboot
-    subprocess.run(smi_reset_cmd.split(), capture_output=False, check=False)
-    arc_chip = wait_arc_boot(asic_id, timeout=15)
+    del targets  # Force re-detection of the chip
+    _reset_smc()
+
+    wait_arc_boot(asic_id, timeout=15, min_chips=min_chips)
+    targets = pyluwen.detect_chips()
     # Validate that the SMC has booted into the recovery image
-    with pytest.raises(Exception):
-        arc_chip.get_telemetry()
+    for chip in targets:
+        with pytest.raises(Exception):
+            chip.get_telemetry()
     logger.info("SMC telemetry data not available, as expected in recovery mode")
-    # Readback the ROM header. We will need it present to use tt-flash
-    header = bytes(0x1000)
-    arc_chip.as_bh().spi_read(0x0, header)
+    # Readback the ROM header. We will need it present to use tt-flash. The
+    # two p300 ASICs describe different images, so each header has to go back
+    # to the chip it came from.
+    headers = {
+        chip.get_pci_interface_id(): _read_spi(chip, ROM_HEADER_ADDR, SPI_SECTOR_SIZE)
+        for chip in targets
+    }
     # Erase the ROM header to make sure we can boot recovery from the failover
     # descriptor
-    arc_chip.as_bh().spi_write(0x0, buf)
+    for chip in targets:
+        chip.as_bh().spi_write(ROM_HEADER_ADDR, ERASED_BLOCK)
     logger.info("Erased ROM header to force failover boot from recovery image")
     # Reset the SMC to trigger the fallback. Note that we cannot check
     # the return code here since tt-smi will fail due to missing telemetry.
-    subprocess.run(smi_reset_cmd.split(), capture_output=False, check=False)
-    arc_chip = wait_arc_boot(asic_id, timeout=15)
-    with pytest.raises(Exception):
-        arc_chip.get_telemetry()
+    del targets
+    _reset_smc()
+
+    wait_arc_boot(asic_id, timeout=15, min_chips=min_chips)
+    targets = pyluwen.detect_chips()
+    for chip in targets:
+        with pytest.raises(Exception):
+            chip.get_telemetry()
     logger.info(
         "SMC telemetry data not available, as expected in "
         "recovery mode booted from failover"
     )
     # Now, restore the ROM header so we can flash a good image
-    arc_chip.as_bh().spi_write(0x0, header)
+    for chip in targets:
+        chip.as_bh().spi_write(ROM_HEADER_ADDR, headers[chip.get_pci_interface_id()])
     # Now, make sure we can flash a good image from recovery mode
+    del targets
     unlaunched_dut.launch()
-    del arc_chip  # Force re-detection of the chip
-    arc_chip = wait_arc_boot(asic_id, timeout=60)
+
+    wait_arc_boot(asic_id, timeout=60, min_chips=min_chips)
+    targets = pyluwen.detect_chips()
     # Make sure we can get telemetry data again
-    try:
-        arc_chip.get_telemetry()
-    except Exception as e:
-        assert False, f"Failed to get telemetry data after recovery: {e}"
-    # Check that the MCUBOOT header magic is present again
-    buf = bytes(4)
-    arc_chip.as_bh().spi_read(MCUBOOT_HEADER_ADDR, buf)
-    magic = int.from_bytes(buf, "little")
+    for i, chip in enumerate(targets):
+        try:
+            chip.get_telemetry()
+        except Exception as e:
+            assert False, (
+                f"Failed to get telemetry data after recovery on chip {i}: {e}"
+            )
+        # Check that the MCUBOOT header magic is present again
+        magic = int.from_bytes(_read_spi(chip, MCUBOOT_HEADER_ADDR, 4), "little")
+        assert magic == MCUBOOT_MAGIC, (
+            f"MCUBOOT magic not restored at {MCUBOOT_HEADER_ADDR:#010x} on chip {i}"
+        )
 
 
 def test_temperature_sensors(arc_chip_dut, asic_id):

--- a/scripts/pcie_utils.py
+++ b/scripts/pcie_utils.py
@@ -42,12 +42,13 @@ def find_tt_devs():
     return devs
 
 
-def rescan_pcie():
+def rescan_pcie(remove=True):
     """
     Helper to rescan PCIe bus
+    @param remove: unbind the cards first, so the rescan re-enumerates them
     """
     # First, we must find the PCIe card to power it off
-    devs = find_tt_devs()
+    devs = find_tt_devs() if remove else []
     for dev in devs:
         remove_path = Path(dev) / "remove"
         try:


### PR DESCRIPTION
## Overview
After mcuboot-bl2 reset, wait_arc_boot returned as soon as ASIC 0 enumerated. On p300 that is often before the second chip is up, and tt-flash then skips the incomplete card even with --force.

"1 chip(s) detected, expected 2. Skipping flash for this board. " (see below)

Eg.
```
==== Test  started at 2026-09-09 13:50:04.087051 ====
-- west flash: using runner tt_flash
[92mStage:[0m SETUP
[92mStage:[0m DETECT
	Detected Chips: 1
[91m 	Error: P300 board (board_id: 0x45100000000) has 1 chip(s) detected, expected 2. Skipping flash for this board. [0m
FLASH [91mFAILED[0m: No devices available to flash.
FATAL ERROR: command exited with status 1: /opt/python/venv/bin/tt-flash flash /__w/tt-system-firmware/tt-system-firmware/zephyr/twister-e2e-flash/tt_blackhole@p300a_tt_blackhole_smc/zephyr_gnu/tt-system-firmware/app/smc/app.e2e-smoke-flash/update.fwbundle --force --allow-major-downgrades
```

In general (eg. on dut launch), wait for correct number of chips in /dev/tenstorrent before running tt-flash.

Fix up `test_mcuboot` to validate both ASICS on p300a. Saves the ROM header since they are L/R ASIC unique, and indexes by pci ID to make sure that they don't get swapped around.

Add `remove` param to `rescan_pcie` to make the remove part of remove-rescan optional. When theres one chip already up, stop removing and only rescan. Fixes https://github.com/tenstorrent/tt-system-firmware/actions/runs/34375498412/job/102547201448

## Test
Smoke p150a local pass
Smoke p300a local pass
CI smoke p150a/p300a passes