### PR TITLE
app: smc: wait for SMC after bh-mod restore in ccfgovr test

### DIFF
--- a/app/smc/pytest/e2e_smoke.py
+++ b/app/smc/pytest/e2e_smoke.py
@@ -2039,6 +2039,7 @@ def test_ccfgovr_bh_mod(unlaunched_dut: DeviceAdapter, asic_id: int):
     restore = subprocess.run(
         [
             bh_mod,
+            "--reset-timeout=60s",
             "set",
             f"chip_limits.tdp_limit={tdp_baseline}",
             f"feature_enable.kernel_throttler_at_floor_en={'true' if kt_baseline & 1 else 'false'}",
@@ -2052,6 +2053,8 @@ def test_ccfgovr_bh_mod(unlaunched_dut: DeviceAdapter, asic_id: int):
             f"Failed to restore baseline config (rc={restore.returncode}); "
             f"SPI flash may be left modified: {restore.stderr.decode(errors='replace')}"
         )
+    del chip
+    wait_arc_boot(asic_id, timeout=60)
 
 
 def test_ccfgovr_eth_speed_override(arc_chip_dut, asic_id, board_name):


### PR DESCRIPTION
## Overview
bh-mod set resets the ASIC. The restore path omitted --reset-timeout and did not wait for CMFW init, so the next test's 15s fixture could race a chip that was still coming up.

Other bh-mod tests have this check, just this one was missing

Eg. 
https://github.com/tenstorrent/tt-system-firmware/actions/runs/34269407241/job/102206935244
https://github.com/tenstorrent/tt-system-firmware/actions/runs/34277190159/job/102233460361?pr=1491
`test_ccfgovr_eth_speed_override` fails with ARC FW has not yet booted. When exiting the prior test `test_ccfgovr_bh_mod` make sure that the ARC is up.

## Tests
p150a smoke