### PR TITLE
app: bl1: change K_mbox SPA to be remapped.

### DIFF
--- a/app/bl1/boards/tt_mmk_tt_mimir_smc.overlay
+++ b/app/bl1/boards/tt_mmk_tt_mimir_smc.overlay
@@ -22,9 +22,9 @@
 	 * interrupt line exists for this remote view, so interrupts are
 	 * omitted.
 	 */
-	k_mbox: mbox@1208018000 {
+	k_mbox: mbox@1202018000 {
 		compatible = "tenstorrent,grendel-mbox";
-		reg = <0x12 0x08018000 0x0 0x20000>;
+		reg = <0x12 0x02018000 0x0 0x20000>;
 		channel-pairs = <32>;
 		#mbox-cells = <1>;
 	};


### PR DESCRIPTION
### Overview

The former value assumed no remapping of SPA happened between the D2d link between K and M. However, I believe D2D ATT tables are programmed in the sival drop to make the mem region appear just like PCIE sees these SPA addrs.

### Tests:

Full boot in ttsim (with addr-remap hardcoded in the simulator.)